### PR TITLE
Add Codex fast-mode, auto-review pricing, and UTC billing

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ command to use. It does not edit shell startup files.
   resource diagnostics.
 - Deterministic recommended actions with evidence, confidence, and caveats.
 - An editable, database-backed provider and model pricing catalog.
+- Codex fast-mode credit-equivalent pricing when a session records its service
+  tier.
 - Codex rate-limit consumption summaries when snapshots are present.
 
 Cost estimates are analytical aids, not billing statements. Subscription usage,
-negotiated rates, batch pricing, and unrecognized models can differ from the
-standard API-equivalent catalog.
+negotiated rates, batch pricing, missing service-tier markers, and unrecognized
+models can differ from the standard API-equivalent catalog.
 
 ## Common Commands
 
@@ -220,6 +222,11 @@ changed files or archive entries replace their previous normalized data. Codex
 fork metadata and replay traces are used to avoid counting inherited parent
 history again in subagent sessions.
 
+All calendar buckets and range boundaries use UTC: day, ISO week, month, year,
+and the existing 15-minute timeline. A version upgrade that changes a derived
+field such as UTC calendar keys or service tier causes one full source reimport;
+later syncs return to normal fingerprint-based incrementality.
+
 ClickHouse source versions are immutable. A sync stages changed sources and a
 complete source manifest, then publishes one global generation marker last.
 Reports pin that generation, so a failed multi-source sync leaves the previous
@@ -333,6 +340,22 @@ treated as total input with cached input as a read subset. Explicit
 `cache_creation_input_tokens` plus `cache_read_input_tokens` records preserve
 cache writes separately. Tokenomics does not invent cache-write volume for
 legacy records that cannot prove it.
+
+For standard pricing, Codex `thread_settings_applied.service_tier=priority`
+applies the documented ChatGPT fast-mode credit multipliers: `2.5x` for
+GPT-5.6 and GPT-5.5, and `2x` for GPT-5.4
+([official fast-mode documentation](https://developers.openai.com/codex/speed)).
+This is deliberately separate from API Priority processing. Missing or unknown
+tiers remain standard-priced instead of silently assuming fast mode. In
+particular, a forked child rollout that omits its own service tier does not
+inherit the parent's tier, so such local logs can understate workspace billing.
+Custom pricing is used as entered and does not receive these packaged
+multipliers.
+
+`codex-auto-review` is included at effective rates of `$2.50` input, `$0.25`
+cached input, and `$15.00` output per million tokens. Those rates are derived
+from an observed OpenAI workspace billing export; OpenAI does not currently
+publish a separate public model-rate page for this internal model id.
 
 omp (oh-my-pi) cost is estimated from the packaged omp pricing catalog using
 official Z.AI (Zhipu AI) GLM rates in USD per million tokens

--- a/lib/core/aggregate.js
+++ b/lib/core/aggregate.js
@@ -18,7 +18,7 @@ const {
   yearKey,
 } = require("./report-model");
 const { normalizeUsage } = require("./usage");
-const { calculateCost } = require("./pricing");
+const { calculateCost, normalizeServiceTier } = require("./pricing");
 
 function addUsage(report, record, options) {
   const timestamp = isValidDate(record.timestamp) ? record.timestamp : new Date(NaN);
@@ -26,8 +26,9 @@ function addUsage(report, record, options) {
   const model = record.model || UNKNOWN_MODEL;
   const provider = record.provider || inferProvider(model);
   const effort = normalizeEffort(record.effort);
+  const serviceTier = normalizeServiceTier(record.serviceTier);
   const usage = normalizeUsage(record.usage);
-  const cost = calculateCost(provider, model, usage, timestamp, options);
+  const cost = calculateCost(provider, model, usage, timestamp, { ...options, serviceTier });
   const visibleChars = normalizeVisibleChars(record.visibleChars, usage);
 
   addToStats(report.total, usage, cost, visibleChars);
@@ -48,6 +49,7 @@ function addUsage(report, record, options) {
   addToStats(bucket(report.providers, provider), usage, cost, visibleChars);
   addToStats(bucket(report.models, model), usage, cost, visibleChars);
   addToStats(bucket(report.providerModels, `${provider}/${model}`), usage, cost, visibleChars);
+  addToStats(bucket(report.serviceTiers, serviceTier), usage, cost, visibleChars);
   addToStats(bucket(report.projects, project), usage, cost, visibleChars);
   addToStats(nestedBucket(report.projectDaily, project, dateKey(timestamp)), usage, cost, visibleChars);
   addToStats(nestedBucket(report.projectModels, project, model), usage, cost, visibleChars);
@@ -71,6 +73,7 @@ function addUsage(report, record, options) {
     model,
     project,
     effort,
+    serviceTier,
     usage,
     cost: {
       known: cost.known,
@@ -86,7 +89,7 @@ function addUsage(report, record, options) {
     report._usageEvents.push(event);
   }
 
-  return { timestamp, project, model, provider, effort, usage, cost, visibleChars };
+  return { timestamp, project, model, provider, effort, serviceTier, usage, cost, visibleChars };
 }
 
 module.exports = {

--- a/lib/core/configuration.js
+++ b/lib/core/configuration.js
@@ -1,8 +1,9 @@
 "use strict";
 
+const { createHash } = require("node:crypto");
 const { PRICING, PRICING_SOURCES } = require("./pricing");
 
-const PACKAGED_CONFIGURATION_REVISION = "packaged-1";
+const PACKAGED_CONFIGURATION_REVISION = "packaged-2";
 const ALLOWED_SETTINGS = new Set(["openaiContext", "pricingBasis", "pricingRevision", "regionalMultiplier", "monthlyCostLimitUsd", "usageProfile"]);
 const ALLOWED_MATCH_MODES = new Set(["snapshot", "prefix", "exact"]);
 const ALLOWED_VARIANTS = new Set(["standard", "short", "long"]);
@@ -33,7 +34,8 @@ function rowFromPrices(provider, model, variant, prices, extra = {}) {
     cacheCreate1h: prices.cacheCreate1h ?? null,
     cacheRead: provider === "openai" ? (prices.cachedInput ?? null) : (prices.cacheRead ?? null),
     output: prices.output,
-    sourceUrl: provider === "openai" ? PRICING_SOURCES.openai
+    sourceUrl: provider === "openai" && model === "codex-auto-review" ? ""
+             : provider === "openai" ? PRICING_SOURCES.openai
              : provider === "omp" ? PRICING_SOURCES.omp
              : PRICING_SOURCES.anthropic,
   };
@@ -110,6 +112,15 @@ function normalizeUsageProfile(source) {
   return { id, name, mode };
 }
 
+function normalizedPricingRevision(requestedRevision, pricingBasis) {
+  if (pricingBasis === "custom") return requestedRevision;
+  if (/^packaged-\d+$/.test(requestedRevision)) return PACKAGED_CONFIGURATION_REVISION;
+  const derivedPattern = new RegExp(`^${PACKAGED_CONFIGURATION_REVISION}:[0-9a-f]{32}$`);
+  if (derivedPattern.test(requestedRevision)) return requestedRevision;
+  const digest = createHash("sha256").update(requestedRevision).digest("hex").slice(0, 32);
+  return `${PACKAGED_CONFIGURATION_REVISION}:${digest}`;
+}
+
 function normalizedDate(value, field, rowId) {
   if (value === null || value === undefined || value === "") return null;
   const text = String(value);
@@ -179,7 +190,10 @@ function normalizeConfiguration(source = {}) {
   if (!["standard", "custom"].includes(pricingBasis)) {
     throw new Error("pricingBasis must be standard or custom");
   }
-  const pricingRevision = String(rawSettings.pricingRevision || revision).trim();
+  const requestedPricingRevision = String(rawSettings.pricingRevision || revision).trim();
+  const packagedManagedPricing = pricingBasis === "standard" &&
+    (!requestedPricingRevision || /^packaged-\d+$/.test(requestedPricingRevision));
+  const pricingRevision = normalizedPricingRevision(requestedPricingRevision, pricingBasis);
   if (!pricingRevision || pricingRevision.length > 160) {
     throw new Error("pricingRevision must be a non-empty string");
   }
@@ -201,7 +215,27 @@ function normalizeConfiguration(source = {}) {
   if (!Array.isArray(source.prices) || source.prices.length === 0 || source.prices.length > 1_000) {
     throw new Error("configuration prices must contain between 1 and 1000 rows");
   }
-  const prices = source.prices.map(normalizePricingRow)
+  const normalizedSourcePrices = source.prices.map(normalizePricingRow);
+  const sourceIds = new Set();
+  for (const row of normalizedSourcePrices) {
+    if (sourceIds.has(row.id)) throw new Error(`duplicate pricing row: ${row.id}`);
+    sourceIds.add(row.id);
+  }
+  if (packagedManagedPricing) {
+    const rowsById = new Map(normalizedSourcePrices.map((row) => [row.id, row]));
+    for (const [index, sourceRow] of packagedPricingRows().entries()) {
+      const row = normalizePricingRow(sourceRow, normalizedSourcePrices.length + index);
+      if (!rowsById.has(row.id)) rowsById.set(row.id, row);
+    }
+    normalizedSourcePrices.splice(0, normalizedSourcePrices.length, ...rowsById.values());
+  } else if (pricingBasis === "standard") {
+    const autoReviewSource = packagedPricingRows().find((row) => (
+      row.provider === "openai" && row.model === "codex-auto-review"
+    ));
+    const autoReview = normalizePricingRow(autoReviewSource, normalizedSourcePrices.length);
+    if (!sourceIds.has(autoReview.id)) normalizedSourcePrices.push(autoReview);
+  }
+  const prices = normalizedSourcePrices
     .sort((a, b) => a.provider.localeCompare(b.provider) || a.model.localeCompare(b.model) || a.variant.localeCompare(b.variant) || a.id.localeCompare(b.id));
   const ids = new Set();
   for (const row of prices) {

--- a/lib/core/derivation.js
+++ b/lib/core/derivation.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // Bump these independently when their derived values can change for the same source bytes.
-const ANALYTICS_DERIVATION_VERSION = 5;
+const ANALYTICS_DERIVATION_VERSION = 6;
 
 function sourceFingerprint(parts, {
   analyticsDerivationVersion = ANALYTICS_DERIVATION_VERSION,

--- a/lib/core/pricing.js
+++ b/lib/core/pricing.js
@@ -9,6 +9,17 @@ const {
 const { normalizeUsage } = require("./usage");
 
 const TOKENS_PER_PRICE_UNIT = 1_000_000;
+const UNKNOWN_SERVICE_TIER = "unknown";
+
+// ChatGPT Codex fast-mode credit multipliers. These are intentionally kept
+// separate from API Priority processing, which has different rates.
+const OPENAI_FAST_MULTIPLIERS = {
+  "gpt-5.5": 2.5,
+  "gpt-5.6-sol": 2.5,
+  "gpt-5.6-terra": 2.5,
+  "gpt-5.6-luna": 2.5,
+  "gpt-5.4": 2,
+};
 
 const PRICING_SOURCES = {
   openai: "https://developers.openai.com/api/docs/pricing",
@@ -16,6 +27,7 @@ const PRICING_SOURCES = {
   openaiGpt5: "https://developers.openai.com/api/docs/models/gpt-5",
   openaiGpt51: "https://developers.openai.com/api/docs/models/gpt-5.1",
   openaiCodex: "https://developers.openai.com/api/docs/models/gpt-5-codex",
+  openaiCodexFast: "https://developers.openai.com/codex/speed",
   openaiCodexMini: "https://developers.openai.com/api/docs/models/codex-mini-latest",
   anthropic: "https://docs.anthropic.com/en/docs/about-claude/pricing",
   omp: "https://docs.z.ai/guides/overview/pricing",
@@ -106,6 +118,13 @@ const PRICING = {
       },
       "chat-latest": {
         short: { input: 5.00, cachedInput: 0.50, output: 30.00 },
+      },
+      // Internal Codex auto-review traffic is exposed under this model id in
+      // workspace usage exports. These effective rates are derived from the
+      // exported credits and token buckets because no public model page lists
+      // codex-auto-review.
+      "codex-auto-review": {
+        short: { input: 2.50, cachedInput: 0.25, output: 15.00 },
       },
     },
   },
@@ -261,6 +280,33 @@ function applyCostMultiplier(breakdown, multiplier) {
   return Object.fromEntries(Object.entries(breakdown).map(([key, value]) => [key, number(value) * factor]));
 }
 
+function normalizeServiceTier(value) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (normalized === "priority" || normalized === "fast") return "priority";
+  if (normalized === "default" || normalized === "standard") return "default";
+  return UNKNOWN_SERVICE_TIER;
+}
+
+function openAIFastMultiplier(model, serviceTier, options = {}) {
+  if (normalizeServiceTier(serviceTier) !== "priority") return 1;
+  if (options.pricingBasis === "custom") return 1;
+  const normalized = normalizeModel(model);
+  for (const [priceKey, multiplier] of Object.entries(OPENAI_FAST_MULTIPLIERS)) {
+    if (isOpenAIModelPriceMatch(normalized, priceKey)) return multiplier;
+  }
+  return 1;
+}
+
+function pricingMultiplier(provider, model, options = {}) {
+  const regionalMultiplier = Number.isFinite(Number(options.regionalMultiplier))
+    ? Number(options.regionalMultiplier)
+    : 1;
+  const serviceTierMultiplier = provider === "openai"
+    ? openAIFastMultiplier(model, options.serviceTier, options)
+    : 1;
+  return regionalMultiplier * serviceTierMultiplier;
+}
+
 function openAIInputTokensForLongPricing(usage) {
   return number(usage.input) + number(usage.cacheCreate5m) + number(usage.cacheCreate30m) + number(usage.cacheCreate1h) + number(usage.cacheRead);
 }
@@ -276,6 +322,7 @@ function isOpenAIModelPriceMatch(normalized, priceKey) {
 function calculateCost(provider, model, usage, timestamp, options = {}) {
   const normalizedUsage = normalizeUsage(usage);
   const reasoningOutput = Math.min(number(normalizedUsage.reasoningOutput), number(normalizedUsage.output));
+  const multiplier = pricingMultiplier(provider, model, options);
   const catalogPrices = pricesFromCatalog(provider, model, normalizedUsage, timestamp, options);
   if (catalogPrices) {
     const cachedInputPrice = catalogPrices.cachedInput ?? catalogPrices.cacheRead ?? catalogPrices.input;
@@ -286,12 +333,12 @@ function calculateCost(provider, model, usage, timestamp, options = {}) {
       cacheCreate1h: (normalizedUsage.cacheCreate1h * number(catalogPrices.cacheCreate1h)) / TOKENS_PER_PRICE_UNIT,
       cacheRead: (normalizedUsage.cacheRead * cachedInputPrice) / TOKENS_PER_PRICE_UNIT,
       output: (normalizedUsage.output * catalogPrices.output) / TOKENS_PER_PRICE_UNIT,
-    }, options.regionalMultiplier);
+    }, multiplier);
     return {
       known: true,
       amount: sumCostBreakdown(breakdown),
       breakdown,
-      reasoningAmount: ((reasoningOutput * catalogPrices.output) / TOKENS_PER_PRICE_UNIT) * number(options.regionalMultiplier || 1),
+      reasoningAmount: ((reasoningOutput * catalogPrices.output) / TOKENS_PER_PRICE_UNIT) * multiplier,
     };
   }
   if (provider === "anthropic") {
@@ -304,17 +351,20 @@ function calculateCost(provider, model, usage, timestamp, options = {}) {
       cacheCreate1h: (normalizedUsage.cacheCreate1h * prices.cacheCreate1h) / TOKENS_PER_PRICE_UNIT,
       cacheRead: (normalizedUsage.cacheRead * prices.cacheRead) / TOKENS_PER_PRICE_UNIT,
       output: (normalizedUsage.output * prices.output) / TOKENS_PER_PRICE_UNIT,
-    }, options.regionalMultiplier);
+    }, multiplier);
     return {
       known: true,
       amount: sumCostBreakdown(breakdown),
       breakdown,
-      reasoningAmount: ((reasoningOutput * prices.output) / TOKENS_PER_PRICE_UNIT) * number(options.regionalMultiplier || 1),
+      reasoningAmount: ((reasoningOutput * prices.output) / TOKENS_PER_PRICE_UNIT) * multiplier,
     };
   }
 
   if (provider === "openai") {
-    const prices = Array.isArray(options.pricingCatalog) ? null : lookupOpenAIPrices(model, normalizedUsage, options);
+    const packagedAutoReviewFallback = options.pricingBasis !== "custom" &&
+      isOpenAIModelPriceMatch(normalizeModel(model), "codex-auto-review");
+    const allowPackagedFallback = !Array.isArray(options.pricingCatalog) || packagedAutoReviewFallback;
+    const prices = allowPackagedFallback ? lookupOpenAIPrices(model, normalizedUsage, options) : null;
     if (!prices) return { known: false, amount: 0, breakdown: newCostBreakdown(), reasoningAmount: 0 };
     const cachedInputPrice = prices.cachedInput ?? prices.input;
     const breakdown = applyCostMultiplier({
@@ -324,12 +374,12 @@ function calculateCost(provider, model, usage, timestamp, options = {}) {
       cacheCreate1h: 0,
       cacheRead: (normalizedUsage.cacheRead * cachedInputPrice) / TOKENS_PER_PRICE_UNIT,
       output: (normalizedUsage.output * prices.output) / TOKENS_PER_PRICE_UNIT,
-    }, options.regionalMultiplier);
+    }, multiplier);
     return {
       known: true,
       amount: sumCostBreakdown(breakdown),
       breakdown,
-      reasoningAmount: ((reasoningOutput * prices.output) / TOKENS_PER_PRICE_UNIT) * number(options.regionalMultiplier || 1),
+      reasoningAmount: ((reasoningOutput * prices.output) / TOKENS_PER_PRICE_UNIT) * multiplier,
     };
   }
 
@@ -343,12 +393,12 @@ function calculateCost(provider, model, usage, timestamp, options = {}) {
       cacheCreate1h: (normalizedUsage.cacheCreate1h * prices.cacheCreate1h) / TOKENS_PER_PRICE_UNIT,
       cacheRead: (normalizedUsage.cacheRead * prices.cacheRead) / TOKENS_PER_PRICE_UNIT,
       output: (normalizedUsage.output * prices.output) / TOKENS_PER_PRICE_UNIT,
-    }, options.regionalMultiplier);
+    }, multiplier);
     return {
       known: true,
       amount: sumCostBreakdown(breakdown),
       breakdown,
-      reasoningAmount: ((reasoningOutput * prices.output) / TOKENS_PER_PRICE_UNIT) * number(options.regionalMultiplier || 1),
+      reasoningAmount: ((reasoningOutput * prices.output) / TOKENS_PER_PRICE_UNIT) * multiplier,
     };
   }
 
@@ -367,14 +417,18 @@ function sumCostBreakdown(breakdown) {
 }
 
 module.exports = {
+  OPENAI_FAST_MULTIPLIERS,
   PRICING,
   PRICING_SOURCES,
   TOKENS_PER_PRICE_UNIT,
+  UNKNOWN_SERVICE_TIER,
   calculateCost,
   isOpenAIModelPriceMatch,
   lookupAnthropicPrices,
   lookupOmpPrices,
   lookupOpenAIPrices,
+  normalizeServiceTier,
+  openAIFastMultiplier,
   openAIInputTokensForLongPricing,
   pricesFromCatalog,
   sumCostBreakdown,

--- a/lib/core/report-model.js
+++ b/lib/core/report-model.js
@@ -81,6 +81,7 @@ function newReport() {
     providers: {},
     models: {},
     providerModels: {},
+    serviceTiers: {},
     projects: {},
     projectQuarterHourly: {},
     projectQuarterHourlyProviderModels: {},
@@ -337,7 +338,7 @@ function pad2(value) {
 
 function dateKey(date) {
   if (!isValidDate(date)) return "unknown-date";
-  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+  return `${date.getUTCFullYear()}-${pad2(date.getUTCMonth() + 1)}-${pad2(date.getUTCDate())}`;
 }
 
 function quarterHourKey(date) {
@@ -348,17 +349,17 @@ function quarterHourKey(date) {
 
 function monthKey(date) {
   if (!isValidDate(date)) return "unknown-month";
-  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}`;
+  return `${date.getUTCFullYear()}-${pad2(date.getUTCMonth() + 1)}`;
 }
 
 function yearKey(date) {
   if (!isValidDate(date)) return "unknown-year";
-  return String(date.getFullYear());
+  return String(date.getUTCFullYear());
 }
 
 function weekKey(date) {
   if (!isValidDate(date)) return "unknown-week";
-  const utc = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const utc = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
   const day = utc.getUTCDay() || 7;
   utc.setUTCDate(utc.getUTCDate() + 4 - day);
   const yearStart = new Date(Date.UTC(utc.getUTCFullYear(), 0, 1));
@@ -369,7 +370,7 @@ function weekKey(date) {
 function inferProvider(model, fallback) {
   const value = (model || "").toLowerCase();
   if (value.startsWith("claude-")) return "anthropic";
-  if (value.startsWith("gpt-") || value.startsWith("o") || value === "chat-latest") return "openai";
+  if (value.startsWith("gpt-") || value.startsWith("codex-") || value.startsWith("o") || value === "chat-latest") return "openai";
   return fallback || "unknown";
 }
 

--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -328,8 +328,8 @@ function webSummary(report, options = {}) {
     : new Date();
   const currentMonthName = monthKey(now);
   const usageProfile = normalizedUsageProfile(report);
-  const currentMonthStart = new Date(now.getFullYear(), now.getMonth(), 1);
-  const currentMonthEnd = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+  const currentMonthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  const currentMonthEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1));
   const currentMonthStats = serializableStats(report.monthly?.[currentMonthName] || { costUsd: 0 });
   const monthlyCostLimitUsd = usageProfile.mode === "api" && Number.isFinite(report.monthlyCostLimitUsd) && report.monthlyCostLimitUsd > 0
     ? report.monthlyCostLimitUsd
@@ -341,6 +341,7 @@ function webSummary(report, options = {}) {
     : [];
   return {
     generatedAt: now.toISOString(),
+    calendarTimeZone: "UTC",
     usageProfile,
     costSemantics: usageProfile.mode === "subscription" ? "api-equivalent" : "estimated-billed",
     apiEquivalentCostUsd: report.total.costUsd || 0,
@@ -364,6 +365,7 @@ function webSummary(report, options = {}) {
     models: topStats(report.models, Number.MAX_SAFE_INTEGER),
     topProjects: topStats(report.projects, top),
     topEfforts: topStats(report.efforts, top),
+    serviceTiers: topStats(report.serviceTiers, Number.MAX_SAFE_INTEGER),
     daily: chronologicalEntries(report.daily).map(([name, stats]) => ({ name, ...serializableStats(stats) })),
     weekly: chronologicalEntries(report.weekly).map(([name, stats]) => ({ name, ...serializableStats(stats) })),
     monthly: chronologicalEntries(report.monthly).map(([name, stats]) => ({ name, ...serializableStats(stats) })),

--- a/lib/ingest/parser.js
+++ b/lib/ingest/parser.js
@@ -28,6 +28,10 @@ const {
   usageFromCodexInfo,
 } = require("../core/usage");
 const { addUsage } = require("../core/aggregate");
+const {
+  UNKNOWN_SERVICE_TIER,
+  normalizeServiceTier,
+} = require("../core/pricing");
 const { addRateLimitSnapshot } = require("../core/rate-limits");
 const { addTelemetrySnapshot } = require("../core/telemetry");
 
@@ -48,6 +52,7 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
     model: UNKNOWN_MODEL,
     provider: "openai",
     effort: UNKNOWN_EFFORT,
+    serviceTier: UNKNOWN_SERVICE_TIER,
     assistantOutputChars: newAssistantOutputChars(),
     output: 0,
     reasoningOutput: 0,
@@ -66,6 +71,7 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
     model: UNKNOWN_MODEL,
     provider: "openai",
     effort: UNKNOWN_EFFORT,
+    serviceTier: UNKNOWN_SERVICE_TIER,
     totalUsage: null,
     visibleChars: newVisibleChars(),
     assistantOutputChars: newAssistantOutputChars(),
@@ -87,6 +93,7 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
     codexState.turn.model = codexState.model;
     codexState.turn.provider = codexState.provider || "openai";
     codexState.turn.effort = codexState.effort;
+    codexState.turn.serviceTier = codexState.serviceTier;
   };
 
   const flushTurn = () => {
@@ -128,6 +135,10 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
     codexState.skippingForkReplay = false;
     codexState.totalUsage = null;
     codexState.preferLastTokenUsageAfterForkReplay = true;
+    // A replay can contain the parent's thread_settings_applied record before
+    // its first traced turn. Do not leak that tier into child-only usage.
+    codexState.serviceTier = UNKNOWN_SERVICE_TIER;
+    updateTurnMeta();
   };
 
   const ensureTurn = (turnId, timestamp) => {
@@ -286,6 +297,15 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
       if (codexState.skippingForkReplay) return;
     }
 
+    if (json.type === "event_msg" && json.payload?.type === "thread_settings_applied") {
+      const serviceTier = normalizeServiceTier(json.payload.thread_settings?.service_tier);
+      if (serviceTier !== UNKNOWN_SERVICE_TIER) {
+        codexState.serviceTier = serviceTier;
+        updateTurnMeta();
+      }
+      return;
+    }
+
     if (json.type === "event_msg" && json.payload?.type === "task_started") {
       ensureTurn(json.payload.turn_id || null, new Date(json.timestamp));
     } else if (json.type === "turn_context" && json.payload?.turn_id) {
@@ -375,6 +395,7 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
         model,
         project: codexState.project,
         effort,
+        serviceTier: codexState.turn?.serviceTier || codexState.serviceTier,
         timestamp,
         usage: codexUsage.usage,
         visibleChars: codexState.visibleChars,

--- a/lib/recommendations.js
+++ b/lib/recommendations.js
@@ -137,10 +137,10 @@ function apiMonthlyBudgetForecast(report, context = {}) {
   const limit = number(report.monthlyCostLimitUsd);
   const now = context.now instanceof Date && Number.isFinite(context.now.getTime()) ? context.now : new Date();
   if (limit <= 0) return null;
-  const month = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+  const month = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
   const cost = number(report.monthly?.[month]?.costUsd);
-  const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
-  const elapsedDays = Math.max(0.25, now.getDate() - 1 + (now.getHours() + now.getMinutes() / 60) / 24);
+  const daysInMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 0)).getUTCDate();
+  const elapsedDays = Math.max(0.25, now.getUTCDate() - 1 + (now.getUTCHours() + now.getUTCMinutes() / 60) / 24);
   const projected = cost * daysInMonth / elapsedDays;
   const overage = projected - limit;
   if (cost < 10 || overage < Math.max(10, limit * 0.1)) return null;
@@ -152,7 +152,7 @@ function apiMonthlyBudgetForecast(report, context = {}) {
     action: "Review the highest-cost projects and compare complete Luna-plus-Sol-review workflows with Sol-direct work before changing routing defaults.",
     impactUsd: roundedMoney(overage),
     confidence: "medium",
-    evidence: `${`$${cost.toFixed(2)}`} month to date · day ${now.getDate()} of ${daysInMonth}`,
+    evidence: `${`$${cost.toFixed(2)}`} month to date · UTC day ${now.getUTCDate()} of ${daysInMonth}`,
     caveat: "The forecast assumes the current run rate continues and may move with workload or incomplete pricing coverage.",
   };
 }

--- a/lib/report/text.js
+++ b/lib/report/text.js
@@ -249,11 +249,12 @@ function renderTextReport(report, options) {
   const lines = [];
   lines.push("Tokenomics Viewer");
   lines.push(`Sources: files=${formatInt(report.sources.files)}, zip_files=${formatInt(report.sources.zipFiles)}, zip_entries=${formatInt(report.sources.zipEntries)}, skipped=${formatInt(report.sources.skippedFiles)}, token_count_snapshots=${formatInt(report.sources.tokenCountSnapshots)}, skipped_token_count_snapshots=${formatInt(report.sources.skippedTokenCountSnapshots)}, parse_errors=${formatInt(report.sources.parseErrors)}`);
-  lines.push(`Pricing sources: OpenAI=${PRICING_SOURCES.openai}; OpenAI GPT-5.6=${PRICING_SOURCES.openaiGpt56}; OpenAI models=${PRICING_SOURCES.openaiGpt5}; OpenAI Codex=${PRICING_SOURCES.openaiCodex}; Anthropic=${PRICING_SOURCES.anthropic}`);
+  lines.push(`Pricing sources: OpenAI=${PRICING_SOURCES.openai}; OpenAI GPT-5.6=${PRICING_SOURCES.openaiGpt56}; OpenAI models=${PRICING_SOURCES.openaiGpt5}; OpenAI Codex=${PRICING_SOURCES.openaiCodex}; Codex fast mode=${PRICING_SOURCES.openaiCodexFast}; Anthropic=${PRICING_SOURCES.anthropic}`);
   lines.push(`OpenAI context pricing mode: ${options.openaiContext}`);
   lines.push(formatStatsLine("Total", report.total));
   lines.push(printSection("By provider", report.providers, options.top));
   lines.push(printSection("By model", report.models, options.top));
+  lines.push(printSection("By service tier", report.serviceTiers, options.top));
   lines.push(printEffortSection("By effort", report.efforts, options.top));
   lines.push(printSection("By model/effort", flattenNestedStats(report.modelEfforts), options.top));
   lines.push(printRateLimitSection(report, options.top));

--- a/lib/storage/clickhouse-pricing.js
+++ b/lib/storage/clickhouse-pricing.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { normalizeConfiguration } = require("../core/configuration");
+const { OPENAI_FAST_MULTIPLIERS } = require("../core/pricing");
 
 const CLICKHOUSE_COST_COLUMNS = [
   "priced",
@@ -52,12 +53,38 @@ function rowMatchExpression(row, expressions) {
   return `(${[providerMatches, modelMatches, ...dates].join(" AND ")})`;
 }
 
+function openAIModelSnapshotMatchExpression(modelExpression, model) {
+  const encodedModel = encodedString(model);
+  const suffix = `substringUTF8(${modelExpression}, lengthUTF8(${encodedModel}) + 2)`;
+  return `(${modelExpression} = ${encodedModel} OR (startsWith(${modelExpression}, concat(${encodedModel}, '-')) AND match(${suffix}, '^\\d{4}-\\d{2}-\\d{2}$')))`;
+}
+
+function openAIFastMultiplierExpression(configuration, expressions) {
+  if (configuration.settings.pricingBasis === "custom") return "1";
+  const modelsByMultiplier = new Map();
+  for (const [model, multiplier] of Object.entries(OPENAI_FAST_MULTIPLIERS)) {
+    const models = modelsByMultiplier.get(multiplier) || [];
+    models.push(model);
+    modelsByMultiplier.set(multiplier, models);
+  }
+  const priorityTier = `(${expressions.serviceTier} = 'priority' OR ${expressions.serviceTier} = 'fast')`;
+  const pairs = [];
+  for (const [multiplier, models] of modelsByMultiplier) {
+    const modelMatches = models
+      .map((model) => openAIModelSnapshotMatchExpression(expressions.model, model))
+      .join(" OR ");
+    pairs.push(`(${expressions.provider} = 'openai' AND ${priorityTier} AND (${modelMatches}))`, String(multiplier));
+  }
+  return `multiIf(${[...pairs, "1"].join(", ")})`;
+}
+
 function buildClickHouseCostProjection(sourceConfiguration, sourceExpressions = {}) {
   const configuration = normalizeConfiguration(sourceConfiguration);
   const alias = sourceExpressions.alias || "raw";
   const expressions = {
     provider: sourceExpressions.provider || `lowerUTF8(trimBoth(toString(${alias}.provider)))`,
     model: sourceExpressions.model || `lowerUTF8(trimBoth(toString(${alias}.model)))`,
+    serviceTier: sourceExpressions.serviceTier || `lowerUTF8(trimBoth(toString(${alias}.service_tier)))`,
     timestamp: sourceExpressions.timestamp
       ? sourceExpressions.timestampIsDateTime
         ? sourceExpressions.timestamp
@@ -109,8 +136,9 @@ function buildClickHouseCostProjection(sourceConfiguration, sourceExpressions = 
 
   const price = (index) => `tupleElement(matched_prices, ${index})`;
   const known = `isNotNull(${price(1)})`;
-  const multiplier = Number(configuration.settings.regionalMultiplier);
-  const amount = (tokens, unitPrice) => `if(${known}, toFloat64(${tokens}) * ifNull(${unitPrice}, 0) * ${multiplier} / 1000000, 0)`;
+  const regionalMultiplier = Number(configuration.settings.regionalMultiplier);
+  const serviceTierMultiplier = openAIFastMultiplierExpression(configuration, expressions);
+  const amount = (tokens, unitPrice) => `if(${known}, toFloat64(${tokens}) * ifNull(${unitPrice}, 0) * ${regionalMultiplier} * (${serviceTierMultiplier}) / 1000000, 0)`;
   const costs = {
     input: amount(expressions.input, price(1)),
     cacheCreate5m: amount(expressions.cacheCreate5m, price(2)),

--- a/lib/storage/clickhouse.js
+++ b/lib/storage/clickhouse.js
@@ -26,6 +26,7 @@ const {
   pricingOptionsFromConfiguration,
 } = require("../core/configuration");
 const { normalizeCodexUuid } = require("../core/usage");
+const { normalizeServiceTier } = require("../core/pricing");
 const { emitSyncProgress } = require("../core/sync-progress");
 const { newRateLimitAttribution, newRateLimitStats } = require("../core/rate-limits");
 const { CLICKHOUSE_COST_COLUMNS, buildClickHouseCostProjection } = require("./clickhouse-pricing");
@@ -244,6 +245,7 @@ function createClickHouseBackend(dependencies = {}) {
         model String CODEC(ZSTD(3)),
         project String CODEC(ZSTD(3)),
         effort LowCardinality(String) CODEC(ZSTD(1)),
+        service_tier LowCardinality(String) DEFAULT 'unknown' CODEC(ZSTD(1)),
         input UInt64 CODEC(Delta, ZSTD(1)),
         cache_create_5m UInt64 CODEC(Delta, ZSTD(1)),
         cache_create_30m UInt64 CODEC(Delta, ZSTD(1)),
@@ -271,6 +273,7 @@ function createClickHouseBackend(dependencies = {}) {
     await clickHouseRequest(client, `
       ALTER TABLE usage_events
         ADD COLUMN IF NOT EXISTS import_id String DEFAULT '' CODEC(ZSTD(3)),
+        ADD COLUMN IF NOT EXISTS service_tier LowCardinality(String) DEFAULT 'unknown' CODEC(ZSTD(1)),
         ADD COLUMN IF NOT EXISTS cache_create_30m UInt64 DEFAULT 0 CODEC(Delta, ZSTD(1)),
         ADD COLUMN IF NOT EXISTS cost_cache_create_30m_usd Float64 DEFAULT 0 CODEC(Gorilla, ZSTD(1)),
         ADD COLUMN IF NOT EXISTS visible_input_chars UInt64 DEFAULT 0 CODEC(Delta, ZSTD(1)),
@@ -788,6 +791,7 @@ function createClickHouseBackend(dependencies = {}) {
       model: event.model,
       project: event.project,
       effort: event.effort,
+      service_tier: normalizeServiceTier(event.serviceTier),
       input: number(event.usage.input),
       cache_create_5m: number(event.usage.cacheCreate5m),
       cache_create_30m: number(event.usage.cacheCreate30m),
@@ -1165,6 +1169,7 @@ function createClickHouseBackend(dependencies = {}) {
     const provider = `multiIf(startsWith(${model}, 'claude-'), 'anthropic', startsWith(${model}, 'gpt-') OR startsWith(${model}, 'o') OR ${model} = 'chat-latest', 'openai', 'unknown')`;
     const rateDefinitions = clickHouseRepricedDefinitions("rate_limit_samples", "repriced_rate_limit_samples", configuration, {
       provider,
+      serviceTier: "'unknown'",
       timestamp: "fromUnixTimestamp64Milli(toInt64(raw.timestamp_ms))",
       timestampIsDateTime: true,
       cacheCreate5m: "0",
@@ -1228,6 +1233,7 @@ function createClickHouseBackend(dependencies = {}) {
     "model",
     "project",
     "effort",
+    "service_tier",
   ];
 
   const CLICKHOUSE_USAGE_GROUPS = [
@@ -1248,6 +1254,7 @@ function createClickHouseBackend(dependencies = {}) {
     { bucket: "projectModels", grouped: ["project", "model"], keys: ["project", "model"] },
     { bucket: "projectProviderModels", grouped: ["project", "provider", "model"], keys: ["project", "provider", "model"] },
     { bucket: "efforts", grouped: ["effort"], keys: ["effort"] },
+    { bucket: "serviceTiers", grouped: ["service_tier"], keys: ["service_tier"] },
     { bucket: "modelEfforts", grouped: ["model", "effort"], keys: ["model", "effort"] },
     { bucket: "providerModelEffortDaily", grouped: ["provider", "model", "effort", "date_key"], keys: ["provider", "model", "effort", "date_key"] },
   ];
@@ -1365,6 +1372,7 @@ function createClickHouseBackend(dependencies = {}) {
       else if (row.bucket === "providers") report.providers[row.key1] = stats;
       else if (row.bucket === "models") report.models[row.key1] = stats;
       else if (row.bucket === "providerModels") report.providerModels[row.key1] = stats;
+      else if (row.bucket === "serviceTiers") report.serviceTiers[row.key1] = stats;
       else if (row.bucket === "projects") report.projects[row.key1] = stats;
       else if (row.bucket === "projectDaily") {
         report.projectDaily[row.key1] ??= {};

--- a/lib/storage/sqlite.js
+++ b/lib/storage/sqlite.js
@@ -28,7 +28,7 @@ const {
   weekKey,
   yearKey,
 } = require("../core/report-model");
-const { calculateCost } = require("../core/pricing");
+const { calculateCost, normalizeServiceTier } = require("../core/pricing");
 const { sameSourceFingerprint, sourceFingerprint } = require("../core/derivation");
 const {
   defaultConfiguration,
@@ -164,6 +164,7 @@ function createSqliteBackend(dependencies = {}) {
         model TEXT NOT NULL,
         project TEXT NOT NULL,
         effort TEXT NOT NULL,
+        service_tier TEXT NOT NULL DEFAULT 'unknown',
         input INTEGER NOT NULL,
         cache_create_5m INTEGER NOT NULL,
         cache_create_30m INTEGER NOT NULL DEFAULT 0,
@@ -256,6 +257,7 @@ function createSqliteBackend(dependencies = {}) {
       CREATE INDEX IF NOT EXISTS idx_codex_sessions_parent ON codex_sessions(parent_session_id);
     `);
     ensureSqliteColumn(db, "usage_events", "visible_input_chars", "INTEGER NOT NULL DEFAULT 0");
+    ensureSqliteColumn(db, "usage_events", "service_tier", "TEXT NOT NULL DEFAULT 'unknown'");
     ensureSqliteColumn(db, "usage_events", "cache_create_30m", "INTEGER NOT NULL DEFAULT 0");
     ensureSqliteColumn(db, "usage_events", "cost_cache_create_30m_usd", "REAL NOT NULL DEFAULT 0");
     ensureSqliteColumn(db, "usage_events", "visible_output_chars", "INTEGER NOT NULL DEFAULT 0");
@@ -516,13 +518,13 @@ function createSqliteBackend(dependencies = {}) {
       insertUsage: db.prepare(`
         INSERT INTO usage_events(
           source_path, line_no, timestamp, date_key, week_key, month_key, year_key,
-          provider, model, project, effort,
+          provider, model, project, effort, service_tier,
           input, cache_create_5m, cache_create_30m, cache_create_1h, cache_read, output, reasoning_output,
           context_window, priced, cost_usd, reasoning_cost_usd,
           cost_input_usd, cost_cache_create_5m_usd, cost_cache_create_30m_usd, cost_cache_create_1h_usd,
           cost_cache_read_usd, cost_output_usd,
           visible_input_chars, visible_output_chars, visible_total_chars, visible_chars_per_token
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `),
       insertOutputCharMetric: db.prepare(`
         INSERT INTO output_char_metrics(
@@ -595,6 +597,7 @@ function createSqliteBackend(dependencies = {}) {
       event.model,
       event.project,
       event.effort,
+      normalizeServiceTier(event.serviceTier),
       event.usage.input,
       event.usage.cacheCreate5m,
       event.usage.cacheCreate30m,
@@ -856,7 +859,11 @@ function createSqliteBackend(dependencies = {}) {
       contextWindow: number(row.context_window),
       inputIncludesCacheRead: false,
     };
-    const cost = calculateCost(row.provider || "unknown", row.model || UNKNOWN_MODEL, usage, timestamp, options);
+    const serviceTier = normalizeServiceTier(row.service_tier);
+    const cost = calculateCost(row.provider || "unknown", row.model || UNKNOWN_MODEL, usage, timestamp, {
+      ...options,
+      serviceTier,
+    });
     const visibleChars = normalizeVisibleChars({
       input: row.visible_input_chars,
       output: row.visible_output_chars,
@@ -886,6 +893,7 @@ function createSqliteBackend(dependencies = {}) {
     addToStats(bucket(report.providers, provider), usage, cost, visibleChars);
     addToStats(bucket(report.models, model), usage, cost, visibleChars);
     addToStats(bucket(report.providerModels, provider + "/" + model), usage, cost, visibleChars);
+    addToStats(bucket(report.serviceTiers, serviceTier), usage, cost, visibleChars);
     addToStats(bucket(report.projects, project), usage, cost, visibleChars);
     addToStats(nestedBucket(report.projectDaily, project, dateKey(timestamp)), usage, cost, visibleChars);
     addToStats(nestedBucket(report.projectModels, project, model), usage, cost, visibleChars);

--- a/public/index.html
+++ b/public/index.html
@@ -1449,7 +1449,7 @@
       const date = new Date(TokenomicsTimeline.periodStart(name));
       if (Number.isNaN(date.getTime())) return name;
       if (/^\d{4}-\d{2}$/.test(name)) return date.toLocaleDateString([], { month: 'short', year: 'numeric', timeZone: 'UTC' });
-      return date.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+      return date.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', timeZone: 'UTC', timeZoneName: 'short' });
     }
 
     function emptyPeriodStats() {

--- a/test/clickhouse-pricing.test.js
+++ b/test/clickhouse-pricing.test.js
@@ -28,3 +28,19 @@ test("ClickHouse pricing projection encodes editable model ids as data", () => {
   assert.doesNotMatch(sql.matchExpression, /model-'quoted/);
   assert.match(sql.matchExpression, /base64Decode\('/);
 });
+
+test("ClickHouse pricing projection applies packaged fast multipliers from service_tier", () => {
+  const sql = buildClickHouseCostProjection(defaultConfiguration(), { alias: "raw" });
+
+  assert.match(sql.projection, /raw\.service_tier/);
+  assert.match(sql.projection, /= 'priority'/);
+  assert.match(sql.projection, /= 'fast'/);
+  assert.match(sql.projection, /2\.5/);
+  assert.match(sql.projection, /, 2,/);
+
+  const custom = defaultConfiguration();
+  custom.settings.pricingBasis = "custom";
+  custom.settings.pricingRevision = "custom-fast-test";
+  const customSql = buildClickHouseCostProjection(custom, { alias: "raw" });
+  assert.doesNotMatch(customSql.projection, /raw\.service_tier/);
+});

--- a/test/clickhouse.test.js
+++ b/test/clickhouse.test.js
@@ -427,6 +427,7 @@ test("ClickHouse sync streams usage rows in bounded insert chunks", async () => 
     )));
     assert.ok(queries.some((query) => (
       query.includes("CREATE TABLE IF NOT EXISTS usage_events")
+      && query.includes("service_tier LowCardinality(String)")
       && query.includes("CODEC(ZSTD(3))")
       && query.includes("CODEC(Delta, ZSTD(1))")
       && query.includes("CODEC(Gorilla, ZSTD(1))")
@@ -437,14 +438,17 @@ test("ClickHouse sync streams usage rows in bounded insert chunks", async () => 
     )));
     const alter = queries.find((query) => query.trim().startsWith("ALTER TABLE usage_events"));
     assert.ok(alter, "long ALTER TABLE SQL should be observed from the request body");
+    assert.match(alter, /ADD COLUMN IF NOT EXISTS service_tier/);
     assert.match(alter, /ADD COLUMN IF NOT EXISTS visible_chars_per_token/);
     const usageStatsQuery = queries.find((query) => query.includes("FROM usage_events") && query.includes("GROUP BY GROUPING SETS"));
     assert.ok(usageStatsQuery);
     assert.match(usageStatsQuery, /'providerModelEffortDaily'/);
+    assert.match(usageStatsQuery, /'serviceTiers'/);
     assert.match(usageStatsQuery, /\(provider, model, effort, date_key\)/);
     assert.equal((usageStatsQuery.match(/FROM usage_events AS raw/g) || []).length, 1);
     assert.doesNotMatch(usageStatsQuery, /UNION ALL/);
     assert.equal(mock.inserts.usage_events.reduce((sum, insert) => sum + insert.rows, 0), rows);
+    assert.equal(JSON.parse(mock.inserts.usage_events[0].body.trim().split("\n")[0]).service_tier, "unknown");
     assert.equal(mock.inserts.telemetry_events.reduce((sum, insert) => sum + insert.rows, 0), rows);
     assert.match(mock.inserts.telemetry_events[0].body, /token_count/);
     assert.ok(mock.inserts.usage_events.length > 1);

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -20,15 +20,50 @@ test("default configuration exposes a validated editable pricing catalog", () =>
   assert.equal(configuration.settings.pricingBasis, "standard");
   assert.equal(configuration.settings.regionalMultiplier, 1);
   assert.equal(configuration.settings.monthlyCostLimitUsd, null);
-  assert.equal(configuration.settings.pricingRevision, "packaged-1");
+  assert.equal(configuration.settings.pricingRevision, "packaged-2");
   assert.deepEqual(configuration.settings.usageProfile, {
     id: "default",
     name: "Work API",
     mode: "api",
   });
   assert.ok(configuration.prices.some((row) => row.provider === "openai" && row.model === "gpt-5.6-luna" && row.variant === "short"));
+  assert.ok(configuration.prices.some((row) => row.provider === "openai" && row.model === "codex-auto-review" && row.variant === "short"));
   assert.ok(configuration.prices.some((row) => row.provider === "anthropic" && row.model === "claude-opus-4-8"));
   assert.deepEqual(normalizeConfiguration(configuration), configuration);
+});
+
+test("packaged-1 pricing is upgraded with codex-auto-review without replacing persisted rows", () => {
+  const configuration = defaultConfiguration();
+  configuration.revision = "packaged-1";
+  configuration.settings.pricingRevision = "packaged-1";
+  configuration.prices = configuration.prices.filter((row) => row.model !== "codex-auto-review");
+  const luna = configuration.prices.find((row) => (
+    row.provider === "openai" && row.model === "gpt-5.6-luna" && row.variant === "short"
+  ));
+  luna.input = 2;
+
+  const normalized = normalizeConfiguration(configuration);
+
+  assert.equal(normalized.settings.pricingRevision, "packaged-2");
+  assert.equal(normalized.prices.find((row) => row.id === luna.id).input, 2);
+  assert.ok(normalized.prices.some((row) => row.provider === "openai" && row.model === "codex-auto-review"));
+});
+
+test("standard edited catalogs get a stable pricing-engine revision and auto-review row", () => {
+  const configuration = defaultConfiguration();
+  configuration.settings.pricingRevision = "edited-catalog-1";
+  configuration.prices = configuration.prices.filter((row) => row.model !== "codex-auto-review");
+
+  const normalized = normalizeConfiguration(configuration);
+
+  assert.match(normalized.settings.pricingRevision, /^packaged-2:[0-9a-f]{32}$/);
+  assert.equal(normalizeConfiguration(normalized).settings.pricingRevision, normalized.settings.pricingRevision);
+  assert.ok(normalized.prices.some((row) => row.provider === "openai" && row.model === "codex-auto-review"));
+
+  configuration.settings.pricingBasis = "custom";
+  const custom = normalizeConfiguration(configuration);
+  assert.equal(custom.settings.pricingRevision, "edited-catalog-1");
+  assert.equal(custom.prices.some((row) => row.model === "codex-auto-review"), false);
 });
 
 test("database pricing rows override packaged prices and apply the regional multiplier", () => {

--- a/test/dashboard-report.test.js
+++ b/test/dashboard-report.test.js
@@ -17,7 +17,7 @@ test("dashboard summary keeps daily buckets chronological for time-series charts
   assert.deepEqual(summary.daily.map((row) => row.name), ["2026-01-01", "2026-01-02", "2026-01-03"]);
 });
 
-test("dashboard summary exposes the current local calendar month", () => {
+test("dashboard summary exposes the current UTC calendar month", () => {
   const report = newReport();
   report.monthlyCostLimitUsd = 100;
   report.monthly["2026-06"] = statsFixture({ costUsd: 12 });
@@ -29,19 +29,32 @@ test("dashboard summary exposes the current local calendar month", () => {
     costUsd: 34.5,
   });
 
-  const summary = webSummary(report, defaultOptions({ now: new Date(2026, 6, 17, 12, 0, 0) }));
+  const summary = webSummary(report, defaultOptions({ now: new Date("2026-07-17T12:00:00.000Z") }));
 
-  assert.equal(summary.generatedAt, new Date(2026, 6, 17, 12, 0, 0).toISOString());
+  assert.equal(summary.generatedAt, "2026-07-17T12:00:00.000Z");
+  assert.equal(summary.calendarTimeZone, "UTC");
   assert.equal(summary.currentMonth.name, "2026-07");
   assert.equal(summary.currentMonth.through, "2026-07-17");
-  assert.equal(summary.currentMonth.startAt, new Date(2026, 6, 1).toISOString());
-  assert.equal(summary.currentMonth.endAt, new Date(2026, 6, 18).toISOString());
+  assert.equal(summary.currentMonth.startAt, "2026-07-01T00:00:00.000Z");
+  assert.equal(summary.currentMonth.endAt, "2026-07-18T00:00:00.000Z");
   assert.equal(summary.currentMonth.costUsd, 34.5);
   assert.equal(summary.currentMonth.requests, 9);
   assert.equal(summary.currentMonth.limitUsd, 100);
   assert.equal(summary.currentMonth.remainingUsd, 65.5);
   assert.equal(summary.currentMonth.overageUsd, 0);
   assert.equal(summary.currentMonth.usedRatio, 0.345);
+});
+
+test("dashboard summary chooses the billing month from UTC rather than local time", () => {
+  const report = newReport();
+  report.monthly["2026-08"] = statsFixture({ requests: 1, costUsd: 5 });
+
+  const summary = webSummary(report, defaultOptions({ now: new Date("2026-08-01T01:00:00.000Z") }));
+
+  assert.equal(summary.currentMonth.name, "2026-08");
+  assert.equal(summary.currentMonth.through, "2026-08-01");
+  assert.equal(summary.currentMonth.startAt, "2026-08-01T00:00:00.000Z");
+  assert.equal(summary.currentMonth.costUsd, 5);
 });
 
 test("dashboard summary returns a zero current month when it has no usage", () => {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -197,6 +197,129 @@ test("skips exact duplicate last_token_usage snapshots within one turn", () => {
   assert.equal(report.total.output, 20);
 });
 
+test("tracks thread_settings_applied service-tier transitions per Codex thread", () => {
+  const report = newReport();
+  const processLine = createLineProcessor(
+    report,
+    defaultOptions({ openaiContext: "short" }),
+    "codex-service-tier-transition-fixture",
+  );
+  const tokenCount = (timestamp, input) => ({
+    type: "event_msg",
+    timestamp,
+    payload: {
+      type: "token_count",
+      info: { last_token_usage: { input_tokens: input, output_tokens: input } },
+    },
+  });
+  const settings = (timestamp, service_tier) => ({
+    type: "event_msg",
+    timestamp,
+    payload: {
+      type: "thread_settings_applied",
+      thread_settings: {
+        model: "gpt-5.6-sol",
+        service_tier,
+      },
+    },
+  });
+
+  processLine(JSON.stringify({
+    type: "session_meta",
+    timestamp: "2026-07-10T00:42:27.000Z",
+    payload: { cwd: "/tmp/service-tier", model_provider: "openai", model: "gpt-5.6-sol" },
+  }), 1);
+  processLine(JSON.stringify(settings("2026-07-10T00:42:28.000Z", "priority")), 2);
+  processLine(JSON.stringify({
+    type: "turn_context",
+    timestamp: "2026-07-10T00:42:29.000Z",
+    payload: { turn_id: "turn-priority", cwd: "/tmp/service-tier", model: "gpt-5.6-sol" },
+  }), 3);
+  processLine(JSON.stringify(tokenCount("2026-07-10T00:42:30.000Z", 100_000)), 4);
+
+  processLine(JSON.stringify(settings("2026-07-10T00:43:00.000Z", "default")), 5);
+  processLine(JSON.stringify({
+    type: "turn_context",
+    timestamp: "2026-07-10T00:43:01.000Z",
+    payload: { turn_id: "turn-default", cwd: "/tmp/service-tier", model: "gpt-5.6-sol" },
+  }), 6);
+  processLine(JSON.stringify(tokenCount("2026-07-10T00:43:02.000Z", 100_000)), 7);
+
+  assert.equal(report._usageEvents.length, 2);
+  assert.equal(report._usageEvents[0].serviceTier, "priority");
+  assert.equal(report._usageEvents[1].serviceTier, "default");
+  assert.equal(report._usageEvents[0].cost.amount, 8.75, "priority Sol uses 2.5x standard short pricing");
+  assert.equal(report._usageEvents[1].cost.amount, 3.5, "default Sol uses standard short pricing");
+  assert.equal(report.total.costUsd, 12.25);
+});
+
+test("forked child without an explicit tier does not inherit parent priority pricing", () => {
+  const report = newReport();
+  const parentSessionId = "019f0000-0000-7000-8000-000000000101";
+  const childSessionId = "019f0000-0000-7000-8000-000000000102";
+  const parentTurnId = "019f0000-0000-7000-8000-000000000103";
+  const childTurnId = "019f0000-0000-7000-8000-000000000104";
+  const processLine = createLineProcessor(
+    report,
+    defaultOptions({
+      openaiContext: "short",
+      codexForkRegistry: {
+        tracesBySession: new Map([[parentSessionId, new Set([`turn:${parentTurnId}`])]]),
+      },
+    }),
+    "codex-service-tier-fork-fixture",
+  );
+
+  const tokenCount = {
+    type: "event_msg",
+    timestamp: "2026-07-10T01:00:03.000Z",
+    payload: {
+      type: "token_count",
+      info: { last_token_usage: { input_tokens: 100_000, output_tokens: 100_000 } },
+    },
+  };
+  processLine(JSON.stringify({
+    type: "session_meta",
+    timestamp: "2026-07-10T01:00:00.000Z",
+    payload: {
+      id: childSessionId,
+      forked_from_id: parentSessionId,
+      cwd: "/tmp/service-tier-child",
+      model_provider: "openai",
+      model: "gpt-5.6-sol",
+    },
+  }), 1);
+  processLine(JSON.stringify({
+    type: "event_msg",
+    timestamp: "2026-07-10T01:00:00.500Z",
+    payload: {
+      type: "thread_settings_applied",
+      thread_settings: { model: "gpt-5.6-sol", service_tier: "priority" },
+    },
+  }), 2);
+  processLine(JSON.stringify({
+    type: "event_msg",
+    timestamp: "2026-07-10T01:00:01.000Z",
+    payload: { type: "task_started", turn_id: parentTurnId },
+  }), 3);
+  processLine(JSON.stringify(tokenCount), 4);
+  processLine(JSON.stringify({
+    type: "event_msg",
+    timestamp: "2026-07-10T01:00:02.000Z",
+    payload: { type: "task_started", turn_id: childTurnId },
+  }), 5);
+  processLine(JSON.stringify({
+    type: "turn_context",
+    timestamp: "2026-07-10T01:00:02.500Z",
+    payload: { turn_id: childTurnId, cwd: "/tmp/service-tier-child", model: "gpt-5.6-sol" },
+  }), 6);
+  processLine(JSON.stringify({ ...tokenCount, timestamp: "2026-07-10T01:00:03.000Z" }), 7);
+
+  assert.equal(report.total.requests, 1);
+  assert.equal(report._usageEvents[0].cost.amount, 3.5, "missing child tier must remain standard");
+  assert.notEqual(report._usageEvents[0].serviceTier, "priority");
+});
+
 test("omp malformed JSON is counted in lenient mode and rejected in strict mode", async () => {
   const tmp = fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-omp-parse-test-"));
   const ompHome = Path.join(tmp, "omp-home");

--- a/test/pricing-usage.test.js
+++ b/test/pricing-usage.test.js
@@ -919,6 +919,104 @@ test("unknown providers and models remain unpriced", () => {
   assert.equal(reportModel.inferProvider("mystery-model"), "unknown");
 });
 
+test("OpenAI priority service tier applies the model-specific fast multiplier", () => {
+  const usageValue = simpleUsage(100_000, 100_000);
+  const date = new Date("2026-07-10T00:00:00.000Z");
+  const expectedMultipliers = {
+    "gpt-5.5": 2.5,
+    "gpt-5.6-sol": 2.5,
+    "gpt-5.6-luna": 2.5,
+    "gpt-5.4": 2,
+  };
+
+  for (const [model, multiplier] of Object.entries(expectedMultipliers)) {
+    const standard = pricing.calculateCost(
+      "openai",
+      model,
+      usageValue,
+      date,
+      { ...pricingOptions, serviceTier: "default" },
+    );
+    const priority = pricing.calculateCost(
+      "openai",
+      model,
+      usageValue,
+      date,
+      { ...pricingOptions, serviceTier: "priority" },
+    );
+
+    assert.equal(standard.known, true, `${model} standard tier must be priced`);
+    assert.equal(priority.known, true, `${model} priority tier must be priced`);
+    assert.equal(priority.amount, standard.amount * multiplier, `${model} fast multiplier`);
+  }
+});
+
+test("missing or unknown OpenAI service tiers stay at standard pricing", () => {
+  const usageValue = simpleUsage(100_000, 100_000);
+  const date = new Date("2026-07-10T00:00:00.000Z");
+  const standard = pricing.calculateCost("openai", "gpt-5.6-sol", usageValue, date, pricingOptions);
+  const legacy = pricing.calculateCost("openai", "gpt-5.6-sol", usageValue, date, {
+    ...pricingOptions,
+    serviceTier: null,
+  });
+  const unknown = pricing.calculateCost("openai", "gpt-5.6-sol", usageValue, date, {
+    ...pricingOptions,
+    serviceTier: "future-tier",
+  });
+
+  assert.equal(legacy.amount, standard.amount, "old logs without a tier remain standard-priced");
+  assert.equal(unknown.amount, standard.amount, "unknown tiers must not silently become fast");
+});
+
+test("codex-auto-review is priced at the standard OpenAI rate even with priority context", () => {
+  const cost = pricing.calculateCost(
+    "openai",
+    "codex-auto-review",
+    {
+      ...simpleUsage(1_000_000, 1_000_000),
+      cacheRead: 1_000_000,
+      inputIncludesCacheRead: false,
+    },
+    new Date("2026-07-15T00:00:00.000Z"),
+    { ...pricingOptions, serviceTier: "priority" },
+  );
+
+  assert.equal(cost.known, true);
+  assert.deepEqual(roundCosts(cost.breakdown), {
+    input: 2.5,
+    cacheCreate5m: 0,
+    cacheCreate30m: 0,
+    cacheCreate1h: 0,
+    cacheRead: 0.25,
+    output: 15,
+  });
+  assert.equal(cost.amount, 17.75);
+});
+
+test("standard catalog fallback is limited to packaged codex-auto-review pricing", () => {
+  const configuration = require("../lib/core/configuration").defaultConfiguration();
+  const withoutAutoReview = configuration.prices.filter((row) => row.model !== "codex-auto-review");
+  const withoutGpt54 = configuration.prices.filter((row) => row.model !== "gpt-5.4");
+  const usageValue = simpleUsage(1_000_000, 1_000_000);
+  const timestamp = new Date("2026-07-15T00:00:00.000Z");
+
+  assert.equal(pricing.calculateCost("openai", "codex-auto-review", usageValue, timestamp, {
+    ...pricingOptions,
+    pricingBasis: "standard",
+    pricingCatalog: withoutAutoReview,
+  }).known, true);
+  assert.equal(pricing.calculateCost("openai", "codex-auto-review", usageValue, timestamp, {
+    ...pricingOptions,
+    pricingBasis: "custom",
+    pricingCatalog: withoutAutoReview,
+  }).known, false);
+  assert.equal(pricing.calculateCost("openai", "gpt-5.4", usageValue, timestamp, {
+    ...pricingOptions,
+    pricingBasis: "standard",
+    pricingCatalog: withoutGpt54,
+  }).known, false);
+});
+
 test("reasoning output is clamped to visible output tokens", () => {
   const normalized = usage.normalizeUsage({ output: 10, reasoningOutput: 50, inputIncludesCacheRead: false });
   assert.equal(normalized.reasoningOutput, 10);
@@ -1003,12 +1101,15 @@ test("cumulative usage resets expose sequenceReset and establish a new baseline"
 });
 
 test("date and ISO week keys honor their calendar boundaries", () => {
-  const endOfDay = new Date(2026, 0, 4, 23, 59, 59, 999);
-  const nextDay = new Date(2026, 0, 5, 0, 0, 0, 0);
+  const endOfDay = new Date("2026-01-04T23:59:59.999Z");
+  const nextDay = new Date("2026-01-05T00:00:00.000Z");
   assert.equal(reportModel.dateKey(endOfDay), "2026-01-04");
   assert.equal(reportModel.dateKey(nextDay), "2026-01-05");
-  assert.equal(reportModel.weekKey(new Date(2021, 0, 1)), "2020-W53");
-  assert.equal(reportModel.weekKey(new Date(2021, 0, 4)), "2021-W01");
+  assert.equal(reportModel.weekKey(new Date("2021-01-01T00:00:00.000Z")), "2020-W53");
+  assert.equal(reportModel.weekKey(new Date("2021-01-04T00:00:00.000Z")), "2021-W01");
+  assert.equal(reportModel.dateKey(new Date("2026-01-01T01:30:00.000Z")), "2026-01-01");
+  assert.equal(reportModel.monthKey(new Date("2026-01-01T01:30:00.000Z")), "2026-01");
+  assert.equal(reportModel.yearKey(new Date("2026-01-01T01:30:00.000Z")), "2026");
   assert.equal(reportModel.quarterHourKey(new Date("2026-07-10T12:14:59.999Z")), "2026-07-10T12:00Z");
   assert.equal(reportModel.quarterHourKey(new Date("2026-07-10T12:15:00.000Z")), "2026-07-10T12:15Z");
   assert.equal(reportModel.quarterHourKey(new Date(NaN)), null);

--- a/test/sqlite.test.js
+++ b/test/sqlite.test.js
@@ -57,6 +57,26 @@ test("SQLite backend factory creates an empty database and report", () => {
   });
 });
 
+test("SQLite adds service_tier to an existing usage_events table", () => {
+  const tmp = fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-service-tier-migration-test-"));
+  const dbPath = Path.join(tmp, "tokenomics.sqlite");
+  const backend = createSqliteBackend();
+  backend.buildReportFromDatabase(dbPath, defaultOptions());
+
+  const legacy = new DatabaseSync(dbPath);
+  legacy.exec("ALTER TABLE usage_events DROP COLUMN service_tier");
+  legacy.close();
+
+  backend.buildReportFromDatabase(dbPath, defaultOptions());
+  const migrated = new DatabaseSync(dbPath);
+  try {
+    const column = migrated.prepare("SELECT name, dflt_value FROM pragma_table_info('usage_events') WHERE name = 'service_tier'").get();
+    assert.deepEqual({ ...column }, { name: "service_tier", dflt_value: "'unknown'" });
+  } finally {
+    migrated.close();
+  }
+});
+
 test("SQLite fork pre-scan excludes unchanged sources", async () => {
   const tmp = fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-sqlite-prescan-test-"));
   const jsonl = Path.join(tmp, "session.jsonl");


### PR DESCRIPTION
## Summary

- track Codex `service_tier` transitions and persist them in SQLite and ClickHouse
- apply documented fast-mode credit multipliers for GPT-5.6, GPT-5.5, and GPT-5.4 under standard pricing
- add effective `codex-auto-review` input, cached-input, and output rates
- move day, ISO week, month, year, dashboard range, and budget calculations to UTC
- version pricing projections and analytics derivations so old rows and ClickHouse overlays cannot mask the new calculation

## Why

The viewer previously ignored fast-mode service tiers, left auto-review traffic unpriced, and grouped billing periods in local time. These differences made local Codex estimates diverge materially from workspace billing.

## Verification

- `node --test` — 221 passed
- generated ClickHouse pricing SQL executed with `clickhouse local`; a priority Sol sample produced the expected 2.5x cost
- SQLite and ClickHouse legacy-column migrations verified
- full Codex rescan verified in an isolated temporary SQLite database

## Compatibility and residual risk

- analytics derivation version 6 triggers a one-time source reimport to backfill UTC keys and service tiers
- missing or unknown tiers remain standard-priced; forked child rollouts do not inherit parent priority state
- local child logs that omit their own tier can therefore still understate workspace billing
- custom pricing is used as entered and does not receive packaged fast multipliers

No billing export or session-log artifact is included in this change.