### PR TITLE
Add multi-harness ingestion and mode-aware pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Tokenomics Viewer
 
-Local-first cost and token analytics for Codex, Claude Code, and omp (oh-my-pi), powered by
+Local-first cost and token analytics for Codex, Claude Code, omp (oh-my-pi),
+Pi, Gemini CLI, Qwen Code, OpenCode, Cursor Agent, and Grok Build, powered by
 ClickHouse. Tokenomics reads local session logs, removes replayed parent traces
-from forked Codex sessions, normalizes usage, and estimates costs from an
-editable pricing catalog.
+from forked Codex sessions, normalizes exact usage where the source proves its
+semantics, and estimates costs from an editable pricing catalog.
 
 The dashboard and database run on your machine. Tokenomics does not upload
 session logs or reports.
@@ -28,7 +29,8 @@ The installer does not use `sudo` or install npm packages. On the first run it:
 3. Installs a private Node.js 26 runtime when the system Node.js is too old.
 4. Installs `clickhousectl`, selects stable ClickHouse, and starts the named
    `tokenomics` server.
-5. Imports local Codex, Claude Code, and omp sessions into ClickHouse.
+5. Imports supported exact-usage sessions and observed-only Cursor/Grok
+   metadata into ClickHouse.
 6. Starts the dashboard on a loopback address and opens it in your browser.
 
 Subsequent launches are one command:
@@ -60,9 +62,16 @@ command to use. It does not edit shell startup files.
   resource diagnostics.
 - Deterministic recommended actions with evidence, confidence, and caveats.
 - An editable, database-backed provider and model pricing catalog.
+- Usage events preserve the billing provider, harness agent, raw service tier,
+  and canonical `standard`/`fast`/`unknown` service mode as separate dimensions.
+- The dashboard exposes Service Mode totals so explicit fast telemetry is not
+  confused with a model name or a provider-specific tier.
 - Codex fast-mode credit-equivalent pricing when a session records its service
   tier.
 - Codex rate-limit consumption summaries when snapshots are present.
+- Observed Harness Coverage for Cursor Agent and Grok Build session metadata.
+  These sessions are explicitly `observed-only`: usage is unavailable and they
+  never change exact token, request, cost, agent, or service-mode totals.
 
 Cost estimates are analytical aids, not billing statements. Subscription usage,
 negotiated rates, batch pricing, missing service-tier markers, and unrecognized
@@ -89,9 +98,15 @@ Limit discovery to one source. Tokenomics options follow `--`:
 tokenomics-launch -- --source codex
 tokenomics-launch -- --source claude
 tokenomics-launch -- --source omp
+tokenomics-launch -- --source gemini
+tokenomics-launch -- --source opencode
+tokenomics-launch -- --source cursor
+tokenomics-launch -- --source grok
 ```
 
-The default `--source all` scans Claude Code, Codex, and omp together.
+The default `--source all` scans exact Claude Code, Codex, omp, Pi, Gemini,
+Qwen, and OpenCode sources together, plus observed-only Cursor Agent and Grok
+Build metadata.
 
 Serve the current ClickHouse database without scanning source files:
 
@@ -207,15 +222,38 @@ pricing changes, and incremental syncs do not require a reset.
 
 With no explicit paths, Tokenomics discovers:
 
-- `~/.claude/projects/**/*.jsonl`
+- `${CLAUDE_CONFIG_DIR:-~/.claude}/projects/**/*.jsonl`, or every root in the
+  path-delimited `CLAUDE_CONFIG_DIRS`
+- Claude Desktop/Cowork
+  `local-agent-mode-sessions/**/.claude/projects/**/*.jsonl`
 - `${CODEX_HOME:-~/.codex}/sessions/**/*.{jsonl,jsonl.zst}`
 - `${CODEX_HOME:-~/.codex}/archived_sessions/**/*.{jsonl,jsonl.zst,zip}`
 - `${OMP_HOME:-~/.omp/agent}/sessions/**/*.jsonl` (omp/oh-my-pi)
+- `~/.pi/agent/sessions/**/*.jsonl` (Pi)
+- `~/.gemini/tmp/*/chats/session-*.{json,jsonl}` (Gemini CLI)
+- `~/.qwen/projects/*/chats/*.jsonl` (Qwen Code)
+- `${XDG_DATA_HOME:-~/.local/share}/opencode/opencode*.db` (OpenCode,
+  read-only)
+- `~/.cursor/projects/*/agent-transcripts/**/*.jsonl` (Cursor Agent,
+  observed-only)
+- `~/.grok/sessions/<encoded-cwd>/<session-id>/updates.jsonl` (Grok Build,
+  observed-only; reads sibling `summary.json` and optional `signals.json`)
 
-Use `--source claude`, `--source codex`, `--source omp`, `--archives`, or `--no-archives` to
-control default discovery. ZIP and Zstandard-compressed rollouts are read
+Use `--source claude`, `--source codex`, `--source omp`, `--source pi`,
+`--source gemini`, `--source qwen`, `--source opencode`, `--source cursor`,
+`--source grok`, `--archives`, or `--no-archives` to control default discovery.
+ZIP and Zstandard-compressed rollouts are read
 directly without extracting them. If both `.jsonl` and `.jsonl.zst` versions
 exist during a compression transition, the plain file is read once.
+
+Cursor and Grok Build records are metadata coverage, not token telemetry. The
+ingester does not parse Cursor conversation content or Grok `updates.jsonl`
+events, and never turns file size, mtime, context snapshots, or running totals
+into usage or cost estimates. Cursor records use the transcript file mtime as
+explicit `fileModifiedAt` provenance and leave the model unknown unless a
+future source proves a session-level model. Grok records retain the model and
+project from `summary.json`, plus `contextTokensUsed` and
+`contextWindowTokens` snapshots from `signals.json` when present.
 
 Sync is incremental by source fingerprint. Unchanged sessions are skipped;
 changed files or archive entries replace their previous normalized data. Codex
@@ -235,6 +273,33 @@ complete report visible instead of exposing a partial import.
 Pricing revisions are deliberately excluded from source fingerprints. Editing
 a rate or adding a model updates normalized database costs without reopening
 JSONL, ZIP, or Zstandard source files.
+
+### Exact multi-harness adapters
+
+Pi records per-message `usage` buckets directly. Gemini CLI and Qwen Code
+record cached tokens as a subset of prompt/input tokens, so Tokenomics subtracts
+that subset exactly once before aggregation. Their visible candidate/output and
+thinking buckets are disjoint, so both contribute to output-billed tokens while
+thinking remains available as an attributed subset. OpenCode is opened read-only with
+Node's SQLite API; active top-level session messages use `data.tokens`, retain
+`providerID` as the billing provider and `opencode` as the harness agent, and
+ignore embedded cost in favor of the normal pricing catalog. Claude discovery
+honors its config-directory environment variables and includes nested Claude
+Desktop/Cowork project sessions. Missing or malformed explicit mode metadata
+always remains `unknown`.
+
+### Observed-only Cursor Agent and Grok Build
+
+Cursor Agent and Grok Build are metadata-coverage adapters, not exact usage
+adapters. Cursor discovery uses `~/.cursor/projects/*/agent-transcripts/**/*.jsonl`
+and records only the project path plus transcript file mtime (`fileModifiedAt`);
+conversation lines are not parsed and the model remains unknown. Grok Build
+discovery uses `~/.grok/sessions/<encoded-cwd>/<session-id>/updates.jsonl` and
+reads only sibling `summary.json` plus optional `signals.json` metadata. It
+retains summary model/project/timestamp fields and context-token snapshots when
+present. Neither adapter calls usage aggregation, creates service-mode rows,
+or contributes to exact token/cost totals. The dashboard labels this surface
+“Observed Harness Coverage” and states that usage is unavailable.
 
 ### omp (oh-my-pi)
 
@@ -351,6 +416,18 @@ particular, a forked child rollout that omits its own service tier does not
 inherit the parent's tier, so such local logs can understate workspace billing.
 Custom pricing is used as entered and does not receive these packaged
 multipliers.
+
+Claude Code `usage.speed` is mapped per request: `fast` is fast mode and
+`standard`/`normal` are standard mode; missing or invalid values remain
+`unknown`. Claude `usage.service_tier` is retained separately and never implies
+fast mode. The packaged fast tariff currently applies only to the catalog's
+Claude Opus 4.8 entry (2x); other models stay at their standard catalog rate
+until an explicit provider tariff is verified. Custom pricing is not multiplied
+by this packaged fast tariff
+([official Claude Code fast-mode documentation](https://code.claude.com/docs/en/fast-mode)).
+Claude's first transition into fast mode can invalidate the current prompt
+cache; Tokenomics prices the token buckets recorded by the harness and does not
+guess that transition from surrounding requests.
 
 `codex-auto-review` is included at effective rates of `$2.50` input, `$0.25`
 cached input, and `$15.00` output per million tokens. Those rates are derived

--- a/README.md
+++ b/README.md
@@ -420,10 +420,10 @@ multipliers.
 Claude Code `usage.speed` is mapped per request: `fast` is fast mode and
 `standard`/`normal` are standard mode; missing or invalid values remain
 `unknown`. Claude `usage.service_tier` is retained separately and never implies
-fast mode. The packaged fast tariff currently applies only to the catalog's
-Claude Opus 4.8 entry (2x); other models stay at their standard catalog rate
-until an explicit provider tariff is verified. Custom pricing is not multiplied
-by this packaged fast tariff
+fast mode. The packaged catalog prices Claude Opus 5 and Claude Opus 4.8 at the
+same standard rates and applies the same 2x fast tariff to both; other models
+stay at their standard catalog rate until an explicit provider tariff is
+verified. Custom pricing is not multiplied by this packaged fast tariff
 ([official Claude Code fast-mode documentation](https://code.claude.com/docs/en/fast-mode)).
 Claude's first transition into fast mode can invalidate the current prompt
 cache; Tokenomics prices the token buckets recorded by the harness and does not

--- a/docs/HARNESS_FORMAT_FRONTIER.md
+++ b/docs/HARNESS_FORMAT_FRONTIER.md
@@ -33,6 +33,9 @@ dashboard breakdowns
   `usage.service_tier`.
 - Claude transcript/API spelling `standard` and OpenTelemetry spelling `normal`
   both normalize to canonical `standard`; `fast` remains `fast`.
+- Packaged Anthropic pricing recognizes canonical `claude-opus-5` and
+  `claude-opus-4-8` at the same standard rates and applies the same verified
+  fast tariff to both.
 - Canonical service mode is `standard`, `fast`, or `unknown`. Unknown values
   remain unknown and never silently receive fast pricing.
 - Provider-specific tier and canonical service mode remain separate stored
@@ -88,6 +91,8 @@ dashboard breakdowns
   remain four distinguishable inputs and only the first receives fast pricing.
 - Claude `usage.service_tier=priority` with `usage.speed=standard` stays standard
   speed.
+- Standard and fast `claude-opus-5` requests price identically to their
+  corresponding `claude-opus-4-8` requests.
 - The first observed fast request is priced only from its recorded cache/input
   buckets; surrounding requests do not invent a cache invalidation.
 - Codex priority/default transitions remain attached to the correct turns.

--- a/docs/HARNESS_FORMAT_FRONTIER.md
+++ b/docs/HARNESS_FORMAT_FRONTIER.md
@@ -1,0 +1,111 @@
+# Harness Format and Service Mode Frontier
+
+Document status: design-sealed
+Current frontier: exact usage events from explicit local harness telemetry, with
+provider-specific tier metadata kept separate from canonical standard/fast mode
+Bounded context: local session discovery, parsing, normalized usage storage, and
+dashboard breakdowns
+
+## Context Bridge: Observed Session to Usage Evidence
+
+- Left context: harness-local session storage.
+- Left term and sense: `observed session` means a real local transcript or
+  session record with a stable source path and harness-native boundaries.
+- Right context: normalized token and cost analytics.
+- Right term and sense: `exact usage` means native token counters whose
+  input/cache/output semantics are known for the recorded request.
+- Relation: an observed session is evidence that work happened, but is not
+  evidence of exact usage.
+- Confidence: high for the distinction; per-harness confidence comes from
+  fixtures and live schema probes.
+- Allowed use: discover and count observed sessions; expose an explicit
+  measurement provenance; estimate only in a separately labelled surface.
+- Disallowed use: price message text, context snapshots, file size, or mtime as
+  exact request telemetry, or silently add those estimates to exact totals.
+- Decay trigger: a harness format/version change or the appearance of new native
+  usage fields requires a fresh probe and fixture.
+
+## Admitted Surface
+
+- Codex JSONL and archive ingestion keeps fork replay exclusion and reads
+  `thread_settings_applied.thread_settings.service_tier`.
+- Claude Code assistant usage may expose `usage.speed` independently from
+  `usage.service_tier`.
+- Claude transcript/API spelling `standard` and OpenTelemetry spelling `normal`
+  both normalize to canonical `standard`; `fast` remains `fast`.
+- Canonical service mode is `standard`, `fast`, or `unknown`. Unknown values
+  remain unknown and never silently receive fast pricing.
+- Provider-specific tier and canonical service mode remain separate stored
+  dimensions.
+- New harness adapters must preserve the billing provider separately from the
+  harness/agent identity.
+- Exact token counters may be normalized when their cache semantics are known
+  and covered by a fixture.
+- Cursor Agent transcripts and Grok Build sessions are admitted as
+  `observed-only` metadata coverage. They retain agent/provider/model/project
+  identity and source-timestamp provenance; Grok may retain context-token
+  snapshots from `signals.json`.
+
+## Rejected Surface
+
+- Treating a model name containing `fast` as proof of fast service mode.
+- Treating Anthropic Priority Tier and Anthropic Fast mode as the same feature.
+- Mapping Codex `priority` directly to an API Priority Tier price.
+- Inheriting a parent Codex service tier into a child rollout that does not
+  record its own tier.
+- Reporting character estimates, divided session totals, inferred costs, or
+  embedded provider costs as exact request telemetry.
+- Treating Cursor file mtime, transcript content, Grok context snapshots, or
+  running update totals as exact usage or cost telemetry.
+- Claiming parity with every upstream CodeBurn provider from a registry count.
+
+## Guard-Only Future
+
+- Any future estimate or provider-reported cost for Cursor Agent, Kiro, or Grok
+  requires a separate measurement contract before it can join exact usage
+  totals; observed-only metadata remains excluded from those totals.
+- Network and RPC sources require separate authority, privacy, retry, and
+  snapshot semantics.
+- Provider-reported costs may be retained as evidence only after a separate raw
+  versus recomputed cost contract is designed.
+
+## Design Laws
+
+1. `agent`, billing `provider`, raw `service_tier`, and canonical
+   `service_mode` are distinct dimensions.
+2. Price from normalized token buckets and the selected pricing catalog; do not
+   trust an embedded total merely because the source exposes one.
+3. Missing or unrecognized mode metadata fails open for ingestion but closed
+   for premium pricing: record `unknown`, price at the standard rate only when
+   the provider/model tariff permits that fallback.
+4. One corrupt provider or source must not erase usage from other providers.
+5. A derivation change that adds or changes a stored dimension invalidates
+   source fingerprints and forces one reimport.
+
+## Falsifier Roster
+
+- Claude events with `usage.speed=fast`, `standard`, missing, and invalid values
+  remain four distinguishable inputs and only the first receives fast pricing.
+- Claude `usage.service_tier=priority` with `usage.speed=standard` stays standard
+  speed.
+- The first observed fast request is priced only from its recorded cache/input
+  buckets; surrounding requests do not invent a cache invalidation.
+- Codex priority/default transitions remain attached to the correct turns.
+- A forked Codex child without a tier never inherits the parent's fast mode.
+- SQLite and ClickHouse round trips preserve agent, raw tier, and service mode.
+- A model id containing `fast` without explicit speed telemetry remains
+  `unknown`.
+- Every admitted exact-usage harness has a discovery fixture, a token-semantics
+  fixture, a malformed-input fixture, and an unpriced-model check. Every
+  observed-only harness instead has a zero-usage invariant and provenance
+  fixture.
+
+## Implementation Seals
+
+- Slice: service mode and representative multi-harness adapters
+- Source/spec: `lib/ingest`, `lib/core`, `lib/storage`, `lib/dashboard.js`,
+  `public/index.html`
+- Boundary: exact local telemetry plus explicitly labelled observed-only Cursor
+  Agent/Grok metadata; estimates, network, and RPC sources remain rejected
+- Required evidence: focused parser/pricing/storage/dashboard tests, full
+  `node --test`, intended diff review, and adversary verdict

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -130,8 +130,8 @@ function parseArgs(argv, env = process.env) {
     }
   }
 
-  if (!["all", "claude", "codex", "omp"].includes(options.source)) {
-    throw new Error("--source must be all, claude, codex, or omp");
+  if (!["all", "claude", "codex", "omp", "pi", "gemini", "qwen", "opencode", "cursor", "grok"].includes(options.source)) {
+    throw new Error("--source must be all, claude, codex, omp, pi, gemini, qwen, opencode, cursor, or grok");
   }
   if (!["auto", "short", "long"].includes(options.openaiContext)) {
     throw new Error("--openai-context must be auto, short, or long");
@@ -179,10 +179,12 @@ function parseArgs(argv, env = process.env) {
 function helpText() {
   return `Usage: node app.js [options] [paths...]
 
-Scans Claude Code, Codex, and omp (oh-my-pi) JSONL sessions and estimates token costs.
+Scans exact local sessions from Claude Code, Codex, omp (oh-my-pi), Pi, Gemini CLI,
+Qwen Code, and OpenCode; Cursor Agent and Grok Build contribute observed-only
+metadata coverage and never token or cost usage.
 
 Options:
-  --source all|claude|codex|omp   Source roots to scan when paths are omitted (default: all)
+  --source all|claude|codex|omp|pi|gemini|qwen|opencode|cursor|grok   Source roots to scan when paths are omitted (default: all)
   --archives / --no-archives      Include Codex archived_sessions rollouts and zip files (default: include)
   --home PATH                     Home directory for default roots (default: current user home)
   --codex-home PATH               Codex data directory (default: CODEX_HOME or ~/.codex)

--- a/lib/core/aggregate.js
+++ b/lib/core/aggregate.js
@@ -19,6 +19,7 @@ const {
 } = require("./report-model");
 const { normalizeUsage } = require("./usage");
 const { calculateCost, normalizeServiceTier } = require("./pricing");
+const { normalizeAgent, normalizeServiceMode } = require("./service-mode");
 
 function addUsage(report, record, options) {
   const timestamp = isValidDate(record.timestamp) ? record.timestamp : new Date(NaN);
@@ -27,8 +28,10 @@ function addUsage(report, record, options) {
   const provider = record.provider || inferProvider(model);
   const effort = normalizeEffort(record.effort);
   const serviceTier = normalizeServiceTier(record.serviceTier);
+  const serviceMode = normalizeServiceMode(record.serviceMode);
+  const agent = normalizeAgent(record.agent, provider);
   const usage = normalizeUsage(record.usage);
-  const cost = calculateCost(provider, model, usage, timestamp, { ...options, serviceTier });
+  const cost = calculateCost(provider, model, usage, timestamp, { ...options, serviceTier, serviceMode });
   const visibleChars = normalizeVisibleChars(record.visibleChars, usage);
 
   addToStats(report.total, usage, cost, visibleChars);
@@ -50,6 +53,8 @@ function addUsage(report, record, options) {
   addToStats(bucket(report.models, model), usage, cost, visibleChars);
   addToStats(bucket(report.providerModels, `${provider}/${model}`), usage, cost, visibleChars);
   addToStats(bucket(report.serviceTiers, serviceTier), usage, cost, visibleChars);
+  addToStats(bucket(report.serviceModes, serviceMode), usage, cost, visibleChars);
+  addToStats(bucket(report.agents, agent), usage, cost, visibleChars);
   addToStats(bucket(report.projects, project), usage, cost, visibleChars);
   addToStats(nestedBucket(report.projectDaily, project, dateKey(timestamp)), usage, cost, visibleChars);
   addToStats(nestedBucket(report.projectModels, project, model), usage, cost, visibleChars);
@@ -74,6 +79,8 @@ function addUsage(report, record, options) {
     project,
     effort,
     serviceTier,
+    serviceMode,
+    agent,
     usage,
     cost: {
       known: cost.known,
@@ -89,7 +96,7 @@ function addUsage(report, record, options) {
     report._usageEvents.push(event);
   }
 
-  return { timestamp, project, model, provider, effort, serviceTier, usage, cost, visibleChars };
+  return { timestamp, project, model, provider, effort, serviceTier, serviceMode, agent, usage, cost, visibleChars };
 }
 
 module.exports = {

--- a/lib/core/configuration.js
+++ b/lib/core/configuration.js
@@ -3,7 +3,7 @@
 const { createHash } = require("node:crypto");
 const { PRICING, PRICING_SOURCES } = require("./pricing");
 
-const PACKAGED_CONFIGURATION_REVISION = "packaged-2";
+const PACKAGED_CONFIGURATION_REVISION = "packaged-3";
 const ALLOWED_SETTINGS = new Set(["openaiContext", "pricingBasis", "pricingRevision", "regionalMultiplier", "monthlyCostLimitUsd", "usageProfile"]);
 const ALLOWED_MATCH_MODES = new Set(["snapshot", "prefix", "exact"]);
 const ALLOWED_VARIANTS = new Set(["standard", "short", "long"]);

--- a/lib/core/derivation.js
+++ b/lib/core/derivation.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // Bump these independently when their derived values can change for the same source bytes.
-const ANALYTICS_DERIVATION_VERSION = 6;
+const ANALYTICS_DERIVATION_VERSION = 7;
 
 function sourceFingerprint(parts, {
   analyticsDerivationVersion = ANALYTICS_DERIVATION_VERSION,

--- a/lib/core/pricing.js
+++ b/lib/core/pricing.js
@@ -7,6 +7,7 @@ const {
   number,
 } = require("./report-model");
 const { normalizeUsage } = require("./usage");
+const { normalizeServiceMode } = require("./service-mode");
 
 const TOKENS_PER_PRICE_UNIT = 1_000_000;
 const UNKNOWN_SERVICE_TIER = "unknown";
@@ -21,6 +22,14 @@ const OPENAI_FAST_MULTIPLIERS = {
   "gpt-5.4": 2,
 };
 
+// Anthropic's fast-mode tariff is model-specific. Keep this allowlist narrow:
+// the current official Claude Code pricing page documents Opus 4.8 at 2x the
+// standard rate, while other models must remain standard-priced until their
+// fast tariff is explicitly verified.
+const ANTHROPIC_FAST_MULTIPLIERS = {
+  "claude-opus-4-8": 2,
+};
+
 const PRICING_SOURCES = {
   openai: "https://developers.openai.com/api/docs/pricing",
   openaiGpt56: "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
@@ -30,6 +39,7 @@ const PRICING_SOURCES = {
   openaiCodexFast: "https://developers.openai.com/codex/speed",
   openaiCodexMini: "https://developers.openai.com/api/docs/models/codex-mini-latest",
   anthropic: "https://docs.anthropic.com/en/docs/about-claude/pricing",
+  anthropicFast: "https://code.claude.com/docs/en/fast-mode",
   omp: "https://docs.z.ai/guides/overview/pricing",
 };
 
@@ -297,13 +307,25 @@ function openAIFastMultiplier(model, serviceTier, options = {}) {
   return 1;
 }
 
+function anthropicFastMultiplier(model, serviceMode, options = {}) {
+  if (normalizeServiceMode(serviceMode) !== "fast") return 1;
+  if (options.pricingBasis === "custom") return 1;
+  const normalized = normalizeModel(model);
+  for (const [priceKey, multiplier] of Object.entries(ANTHROPIC_FAST_MULTIPLIERS)) {
+    if (normalized === priceKey || normalized.startsWith(`${priceKey}-`)) return multiplier;
+  }
+  return 1;
+}
+
 function pricingMultiplier(provider, model, options = {}) {
   const regionalMultiplier = Number.isFinite(Number(options.regionalMultiplier))
     ? Number(options.regionalMultiplier)
     : 1;
   const serviceTierMultiplier = provider === "openai"
     ? openAIFastMultiplier(model, options.serviceTier, options)
-    : 1;
+    : provider === "anthropic"
+      ? anthropicFastMultiplier(model, options.serviceMode, options)
+      : 1;
   return regionalMultiplier * serviceTierMultiplier;
 }
 
@@ -417,6 +439,7 @@ function sumCostBreakdown(breakdown) {
 }
 
 module.exports = {
+  ANTHROPIC_FAST_MULTIPLIERS,
   OPENAI_FAST_MULTIPLIERS,
   PRICING,
   PRICING_SOURCES,
@@ -428,6 +451,7 @@ module.exports = {
   lookupOmpPrices,
   lookupOpenAIPrices,
   normalizeServiceTier,
+  anthropicFastMultiplier,
   openAIFastMultiplier,
   openAIInputTokensForLongPricing,
   pricesFromCatalog,

--- a/lib/core/pricing.js
+++ b/lib/core/pricing.js
@@ -22,11 +22,10 @@ const OPENAI_FAST_MULTIPLIERS = {
   "gpt-5.4": 2,
 };
 
-// Anthropic's fast-mode tariff is model-specific. Keep this allowlist narrow:
-// the current official Claude Code pricing page documents Opus 4.8 at 2x the
-// standard rate, while other models must remain standard-priced until their
-// fast tariff is explicitly verified.
+// Anthropic's fast-mode tariff is model-specific. Opus 5 and Opus 4.8 share
+// the same verified standard ($5/$25) and fast ($10/$50) input/output rates.
 const ANTHROPIC_FAST_MULTIPLIERS = {
+  "claude-opus-5": 2,
   "claude-opus-4-8": 2,
 };
 
@@ -142,6 +141,7 @@ const PRICING = {
     models: {
       "claude-fable-5": { input: 10.00, cacheCreate5m: 12.50, cacheCreate1h: 20.00, cacheRead: 1.00, output: 50.00 },
       "claude-mythos-5": { input: 10.00, cacheCreate5m: 12.50, cacheCreate1h: 20.00, cacheRead: 1.00, output: 50.00 },
+      "claude-opus-5": { input: 5.00, cacheCreate5m: 6.25, cacheCreate1h: 10.00, cacheRead: 0.50, output: 25.00 },
       "claude-opus-4-8": { input: 5.00, cacheCreate5m: 6.25, cacheCreate1h: 10.00, cacheRead: 0.50, output: 25.00 },
       "claude-opus-4-7": { input: 5.00, cacheCreate5m: 6.25, cacheCreate1h: 10.00, cacheRead: 0.50, output: 25.00 },
       "claude-opus-4-6": { input: 5.00, cacheCreate5m: 6.25, cacheCreate1h: 10.00, cacheRead: 0.50, output: 25.00 },

--- a/lib/core/report-model.js
+++ b/lib/core/report-model.js
@@ -82,6 +82,8 @@ function newReport() {
     models: {},
     providerModels: {},
     serviceTiers: {},
+    serviceModes: {},
+    agents: {},
     projects: {},
     projectQuarterHourly: {},
     projectQuarterHourlyProviderModels: {},

--- a/lib/core/service-mode.js
+++ b/lib/core/service-mode.js
@@ -1,0 +1,78 @@
+"use strict";
+
+const UNKNOWN_SERVICE_MODE = "unknown";
+const STANDARD_SERVICE_MODE = "standard";
+const FAST_SERVICE_MODE = "fast";
+
+const UNKNOWN_AGENT = "unknown";
+const CODEX_AGENT = "codex";
+const CLAUDE_CODE_AGENT = "claude-code";
+const OMP_AGENT = "omp";
+const PI_AGENT = "pi";
+const GEMINI_AGENT = "gemini";
+const QWEN_AGENT = "qwen";
+const OPENCODE_AGENT = "opencode";
+
+function normalized(value) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function serviceModeFromClaudeSpeed(value) {
+  const speed = normalized(value);
+  if (speed === "fast") return FAST_SERVICE_MODE;
+  if (speed === "standard" || speed === "normal") return STANDARD_SERVICE_MODE;
+  return UNKNOWN_SERVICE_MODE;
+}
+
+function serviceModeFromCodexTier(value) {
+  const tier = normalized(value);
+  if (tier === "priority" || tier === "fast") return FAST_SERVICE_MODE;
+  if (tier === "default" || tier === "standard" || tier === "normal") return STANDARD_SERVICE_MODE;
+  return UNKNOWN_SERVICE_MODE;
+}
+
+function normalizeServiceMode(value) {
+  const mode = normalized(value);
+  if (mode === FAST_SERVICE_MODE) return FAST_SERVICE_MODE;
+  if (mode === STANDARD_SERVICE_MODE || mode === "normal") return STANDARD_SERVICE_MODE;
+  return UNKNOWN_SERVICE_MODE;
+}
+
+function agentFromProvider(provider) {
+  const normalizedProvider = normalized(provider);
+  if (normalizedProvider === "openai") return CODEX_AGENT;
+  if (normalizedProvider === "anthropic") return CLAUDE_CODE_AGENT;
+  if (normalizedProvider === "omp") return OMP_AGENT;
+  if (normalizedProvider === "pi") return PI_AGENT;
+  if (normalizedProvider === "gemini") return GEMINI_AGENT;
+  if (normalizedProvider === "qwen") return QWEN_AGENT;
+  if (normalizedProvider === "opencode") return OPENCODE_AGENT;
+  return UNKNOWN_AGENT;
+}
+
+function normalizeAgent(value, provider) {
+  const agent = normalized(value);
+  if (!agent) return agentFromProvider(provider);
+  if (agent === UNKNOWN_AGENT) return UNKNOWN_AGENT;
+  if (/^[a-z][a-z0-9_-]{0,63}$/.test(agent)) return agent;
+  return UNKNOWN_AGENT;
+}
+
+module.exports = {
+  CLAUDE_CODE_AGENT,
+  CODEX_AGENT,
+  FAST_SERVICE_MODE,
+  GEMINI_AGENT,
+  OPENCODE_AGENT,
+  OMP_AGENT,
+  PI_AGENT,
+  QWEN_AGENT,
+  STANDARD_SERVICE_MODE,
+  UNKNOWN_AGENT,
+  UNKNOWN_SERVICE_MODE,
+  agentFromProvider,
+  normalizeAgent,
+  normalizeServiceMode,
+  serviceModeFromClaudeSpeed,
+  serviceModeFromCodexTier,
+};

--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -320,6 +320,50 @@ function providerModelEffortDailyStats(data) {
   return groups.sort((a, b) => b.costUsd - a.costUsd || a.provider.localeCompare(b.provider) || a.model.localeCompare(b.model) || a.effort.localeCompare(b.effort));
 }
 
+function observedHarnessStats(report) {
+  const groups = new Map();
+  for (const session of report.sessions || []) {
+    const observation = session?.stats?.observation;
+    if (!observation || observation.measurement !== "observed-only") continue;
+    const key = [observation.agent, observation.provider, observation.model].join("\u0000");
+    let row = groups.get(key);
+    if (!row) {
+      row = {
+        agent: observation.agent || "unknown",
+        provider: observation.provider || "unknown",
+        model: observation.model || "(unknown model)",
+        project: observation.project || "(unknown project)",
+        projectCount: 0,
+        projects: [],
+        measurement: "observed-only",
+        exactUsageAvailable: false,
+        sessionCount: 0,
+        latestSourceTimestamp: null,
+        contextTokens: null,
+        contextWindowTokens: null,
+      };
+      groups.set(key, row);
+    }
+    row.sessionCount += 1;
+    const project = observation.project || "(unknown project)";
+    if (!row.projects.includes(project)) {
+      row.projectCount += 1;
+      row.projects.push(project);
+    }
+    const candidate = observation.sourceTimestamp;
+    if (candidate && (!row.latestSourceTimestamp || Date.parse(candidate) > Date.parse(row.latestSourceTimestamp))) {
+      row.latestSourceTimestamp = candidate;
+      row.sourceTimestampProvenance = observation.sourceTimestampProvenance || "unknown";
+      row.contextTokens = observation.contextTokens ?? null;
+      row.contextWindowTokens = observation.contextWindowTokens ?? null;
+    }
+  }
+  return [...groups.values()]
+    .map((row) => ({ ...row, projects: row.projects.slice(0, 5) }))
+    .sort((a, b) =>
+      a.agent.localeCompare(b.agent) || a.provider.localeCompare(b.provider) || a.model.localeCompare(b.model) || a.project.localeCompare(b.project));
+}
+
 function webSummary(report, options = {}) {
   const top = options.top || 25;
   const requestedNow = typeof options.now === "function" ? options.now() : options.now;
@@ -366,6 +410,9 @@ function webSummary(report, options = {}) {
     topProjects: topStats(report.projects, top),
     topEfforts: topStats(report.efforts, top),
     serviceTiers: topStats(report.serviceTiers, Number.MAX_SAFE_INTEGER),
+    serviceModes: topStats(report.serviceModes, Number.MAX_SAFE_INTEGER),
+    agents: topStats(report.agents, Number.MAX_SAFE_INTEGER),
+    observedHarnesses: observedHarnessStats(report),
     daily: chronologicalEntries(report.daily).map(([name, stats]) => ({ name, ...serializableStats(stats) })),
     weekly: chronologicalEntries(report.weekly).map(([name, stats]) => ({ name, ...serializableStats(stats) })),
     monthly: chronologicalEntries(report.monthly).map(([name, stats]) => ({ name, ...serializableStats(stats) })),

--- a/lib/ingest/harnesses.js
+++ b/lib/ingest/harnesses.js
@@ -1,0 +1,453 @@
+"use strict";
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const Path = require("node:path");
+const os = require("node:os");
+const readline = require("node:readline");
+const { addUsage } = require("../core/aggregate");
+const {
+  UNKNOWN_MODEL,
+  UNKNOWN_PROJECT,
+  UNKNOWN_EFFORT,
+  addToStats,
+  number,
+} = require("../core/report-model");
+const {
+  discoverOpenCodeInputs,
+  processOpenCodeDb,
+} = require("./opencode");
+const {
+  discoverCursorInputs,
+  discoverGrokInputs,
+  processObservedHarnessFile,
+} = require("./observed-harnesses");
+
+const UNKNOWN_SERVICE_MODE = "unknown";
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : null;
+}
+
+function numeric(value) {
+  const parsed = number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function expandHome(value, home) {
+  if (value === "~") return home;
+  if (value.startsWith("~/") || value.startsWith(`~${Path.sep}`)) {
+    return Path.join(home, value.slice(2));
+  }
+  return value;
+}
+
+async function realPathOrResolve(path) {
+  try {
+    return await fsp.realpath(path);
+  } catch {
+    return Path.resolve(path);
+  }
+}
+
+async function walkFiles(root, predicate, out = []) {
+  let entries;
+  try {
+    entries = await fsp.readdir(root, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const fullPath = Path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      await walkFiles(fullPath, predicate, out);
+    } else if (entry.isFile() && predicate(fullPath)) {
+      out.push(fullPath);
+    }
+  }
+  return out;
+}
+
+function claudeConfigDirs(home) {
+  const multi = nonEmptyString(process.env.CLAUDE_CONFIG_DIRS);
+  if (multi) {
+    const dirs = multi
+      .split(Path.delimiter)
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .map((value) => Path.resolve(expandHome(value, home)));
+    if (dirs.length > 0) return [...new Set(dirs)];
+  }
+  const single = nonEmptyString(process.env.CLAUDE_CONFIG_DIR);
+  if (single) return [Path.resolve(expandHome(single, home))];
+  return [Path.join(home, ".claude")];
+}
+
+function desktopSessionRoots(home) {
+  const override = nonEmptyString(process.env.CLAUDE_DESKTOP_SESSIONS_DIR) ||
+    nonEmptyString(process.env.CODEBURN_DESKTOP_SESSIONS_DIR);
+  if (override) return [Path.resolve(expandHome(override, home))];
+  // Keep all platform roots in the candidate set. This matters for portable
+  // archives and tests that use a synthetic home while running on another OS.
+  return [
+    Path.join(home, "Library", "Application Support", "Claude", "local-agent-mode-sessions"),
+    Path.join(home, ".config", "Claude", "local-agent-mode-sessions"),
+    Path.join(home, "AppData", "Roaming", "Claude", "local-agent-mode-sessions"),
+  ];
+}
+
+function isClaudeDesktopProjectFile(path) {
+  if (!path.endsWith(".jsonl")) return false;
+  const normalized = path.replace(/\\/g, "/");
+  return /\/\.claude\/projects\/[^/]+\//.test(normalized);
+}
+
+async function discoverClaudeInputs(home) {
+  const paths = [];
+  for (const root of claudeConfigDirs(home)) {
+    paths.push(...await walkFiles(Path.join(root, "projects"), (path) => path.endsWith(".jsonl")));
+  }
+  for (const root of desktopSessionRoots(home)) {
+    paths.push(...await walkFiles(root, isClaudeDesktopProjectFile));
+  }
+  return paths.map((path) => ({ kind: "jsonl", adapter: "claude", path }));
+}
+
+async function discoverPiInputs(home) {
+  const root = Path.join(home, ".pi", "agent", "sessions");
+  const paths = await walkFiles(root, (path) => path.endsWith(".jsonl"));
+  return paths.map((path) => ({ kind: "jsonl", adapter: "pi", path }));
+}
+
+async function discoverGeminiInputs(home) {
+  const root = nonEmptyString(process.env.GEMINI_TMP_DIR)
+    ? Path.resolve(expandHome(process.env.GEMINI_TMP_DIR, home))
+    : Path.join(home, ".gemini", "tmp");
+  const paths = [];
+  let projects;
+  try {
+    projects = await fsp.readdir(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  for (const project of projects) {
+    if (!project.isDirectory()) continue;
+    const chats = Path.join(root, project.name, "chats");
+    let files;
+    try { files = await fsp.readdir(chats, { withFileTypes: true }); } catch { continue; }
+    for (const file of files) {
+      if (!file.isFile() || !file.name.startsWith("session-")) continue;
+      if (!file.name.endsWith(".json") && !file.name.endsWith(".jsonl")) continue;
+      paths.push({ kind: "jsonl", adapter: "gemini", path: Path.join(chats, file.name) });
+    }
+  }
+  return paths;
+}
+
+async function discoverQwenInputs(home) {
+  const root = nonEmptyString(process.env.QWEN_DATA_DIR)
+    ? Path.resolve(expandHome(process.env.QWEN_DATA_DIR, home))
+    : Path.join(home, ".qwen", "projects");
+  const paths = [];
+  let projects;
+  try { projects = await fsp.readdir(root, { withFileTypes: true }); } catch { return []; }
+  for (const project of projects) {
+    if (!project.isDirectory()) continue;
+    const chats = Path.join(root, project.name, "chats");
+    let files;
+    try { files = await fsp.readdir(chats, { withFileTypes: true }); } catch { continue; }
+    for (const file of files) {
+      if (file.isFile() && file.name.endsWith(".jsonl")) {
+        paths.push({ kind: "jsonl", adapter: "qwen", path: Path.join(chats, file.name) });
+      }
+    }
+  }
+  return paths;
+}
+
+async function dedupeInputs(inputs) {
+  const seen = new Set();
+  const output = [];
+  for (const input of inputs) {
+    const resolved = await realPathOrResolve(input.path);
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+    output.push({ ...input, path: resolved, realPath: resolved, sourceIdentity: resolved });
+  }
+  return output;
+}
+
+async function discoverHarnessInputs(options = {}) {
+  const home = Path.resolve(options.home || os.homedir());
+  const source = options.source || "all";
+  const inputs = [];
+  if (source === "all" || source === "claude") inputs.push(...await discoverClaudeInputs(home));
+  if (source === "all" || source === "pi") inputs.push(...await discoverPiInputs(home));
+  if (source === "all" || source === "gemini") inputs.push(...await discoverGeminiInputs(home));
+  if (source === "all" || source === "qwen") inputs.push(...await discoverQwenInputs(home));
+  if (source === "all" || source === "opencode") inputs.push(...await discoverOpenCodeInputs(home));
+  if (source === "all" || source === "cursor") inputs.push(...await discoverCursorInputs(home));
+  if (source === "all" || source === "grok") inputs.push(...await discoverGrokInputs(home));
+  return dedupeInputs(inputs);
+}
+
+function adapterForPath(filename, hint = null) {
+  if (hint) return hint;
+  const normalized = filename.replace(/\\/g, "/");
+  if (Path.extname(filename).toLowerCase() === ".db") return "opencode";
+  if (Path.extname(filename).toLowerCase() === ".json") return "gemini";
+  if (normalized.includes("/.pi/agent/sessions/")) return "pi";
+  if (normalized.includes("/.gemini/tmp/") && /\/chats\/session-[^/]+\.jsonl$/.test(normalized)) return "gemini";
+  if (normalized.includes("/.qwen/projects/") && /\/chats\/[^/]+\.jsonl$/.test(normalized)) return "qwen";
+  if (normalized.includes("/.cursor/projects/") && normalized.includes("/agent-transcripts/")) return "cursor";
+  if (Path.basename(filename) === "updates.jsonl" && normalized.includes("/.grok/sessions/")) return "grok";
+  return "generic";
+}
+
+function fileKind(filename) {
+  const extension = Path.extname(filename).toLowerCase();
+  if (extension === ".db") return "db";
+  if (extension === ".json") return "json";
+  return "jsonl";
+}
+
+function parseError(report, session, filename, lineNo, error, options) {
+  report.sources.parseErrors += 1;
+  if (session) session.parseErrors += 1;
+  if (options.strictJson) {
+    const suffix = lineNo == null ? "" : `:${lineNo}`;
+    const reason = error && error.message ? `: ${error.message}` : "";
+    throw new Error(`Invalid JSON in ${filename}${suffix}${reason}`);
+  }
+}
+
+async function processJsonlRecords(filename, report, options, session, callback) {
+  const stream = fs.createReadStream(filename, { encoding: "utf8" });
+  const lines = readline.createInterface({ input: stream, crlfDelay: Infinity });
+  let lineNo = 0;
+  try {
+    for await (const line of lines) {
+      lineNo += 1;
+      session.lines += 1;
+      if (!line.trim()) continue;
+      let json;
+      try {
+        json = JSON.parse(line);
+      } catch (error) {
+        parseError(report, session, filename, lineNo, error, options);
+        continue;
+      }
+      session.records += 1;
+      await callback(json, lineNo);
+    }
+  } finally {
+    lines.close();
+    stream.destroy();
+  }
+}
+
+function explicitProvider(...values) {
+  for (const value of values) {
+    const provider = nonEmptyString(value);
+    if (provider) return provider;
+  }
+  return null;
+}
+
+function timestamp(value) {
+  return new Date(value);
+}
+
+function addHarnessUsage(report, session, options, record) {
+  const added = addUsage(report, {
+    provider: record.provider,
+    model: record.model || UNKNOWN_MODEL,
+    project: record.project || UNKNOWN_PROJECT,
+    effort: UNKNOWN_EFFORT,
+    serviceMode: UNKNOWN_SERVICE_MODE,
+    agent: record.agent,
+    timestamp: record.timestamp,
+    usage: record.usage,
+    sourcePath: session?.path || record.sourcePath,
+    lineNo: record.lineNo,
+  }, options);
+  if (session) addToStats(session.stats, added.usage, added.cost);
+  return added;
+}
+
+function pathProject(filename, segmentsFromEnd = 2) {
+  const parts = filename.replace(/\\/g, "/").split("/").filter(Boolean);
+  return parts.length >= segmentsFromEnd ? parts[parts.length - segmentsFromEnd] : UNKNOWN_PROJECT;
+}
+
+async function processPiJsonl(filename, report, options, session) {
+  const state = { sessionId: Path.basename(filename, ".jsonl"), project: pathProject(filename, 2), seen: new Set() };
+  await processJsonlRecords(filename, report, options, session, async (json, lineNo) => {
+    if (json.type === "session") {
+      state.sessionId = nonEmptyString(json.id) || state.sessionId;
+      state.project = nonEmptyString(json.cwd) || state.project;
+      return;
+    }
+    if (json.type !== "message" || json.message?.role !== "assistant" || !json.message?.usage) return;
+    const usage = json.message.usage;
+    const input = numeric(usage.input);
+    const output = numeric(usage.output);
+    const cacheRead = numeric(usage.cacheRead);
+    const cacheWrite = numeric(usage.cacheWrite);
+    if (input === 0 && output === 0 && cacheRead === 0 && cacheWrite === 0) return;
+    const key = `${state.sessionId}:${json.message.responseId || json.id || lineNo}`;
+    if (state.seen.has(key)) return;
+    state.seen.add(key);
+    addHarnessUsage(report, session, options, {
+      provider: explicitProvider(json.message.provider, json.message.providerID, json.message.providerId, json.provider) || "pi",
+      agent: "pi",
+      model: nonEmptyString(json.message.model) || UNKNOWN_MODEL,
+      project: state.project,
+      timestamp: timestamp(json.timestamp),
+      usage: {
+        input,
+        inputIncludesCacheRead: false,
+        cacheCreate5m: cacheWrite,
+        cacheRead,
+        output,
+        reasoningOutput: 0,
+      },
+      lineNo,
+    });
+  });
+}
+
+function addGeminiMessage(json, state, report, session, options, lineNo) {
+  if (!json || json.type !== "gemini" || !json.tokens) return;
+  const tokens = json.tokens;
+  const input = numeric(tokens.input);
+  const cacheRead = numeric(tokens.cached);
+  const reasoningOutput = numeric(tokens.thoughts);
+  // Gemini reports visible output and thoughts as disjoint buckets. Local
+  // sessions satisfy total = input + output + thoughts (+ tool tokens), so the
+  // canonical output bucket must include thoughts for complete token and cost
+  // accounting while reasoningOutput remains the attributed subset.
+  const output = numeric(tokens.output) + reasoningOutput;
+  if (input === 0 && cacheRead === 0 && output === 0 && reasoningOutput === 0) return;
+  const key = `${state.sessionId}:${json.id || lineNo}`;
+  if (state.seen.has(key)) return;
+  state.seen.add(key);
+  addHarnessUsage(report, session, options, {
+    provider: explicitProvider(json.provider, json.providerID, json.providerId) || "gemini",
+    agent: "gemini",
+    model: nonEmptyString(json.model) || UNKNOWN_MODEL,
+    project: state.project,
+    timestamp: timestamp(json.timestamp || state.startTime),
+    // Gemini's `input` already includes the cached subset. normalizeUsage
+    // subtracts cacheRead exactly once because this flag remains true.
+    usage: { input, cacheRead, output, reasoningOutput },
+    lineNo,
+  });
+}
+
+function parseGeminiDocument(document, report, session, options, filename) {
+  if (!document || typeof document !== "object" || !Array.isArray(document.messages) || !nonEmptyString(document.sessionId)) {
+    parseError(report, session, filename, null, new Error("missing Gemini session shape"), options);
+    return;
+  }
+  const state = {
+    sessionId: document.sessionId,
+    startTime: document.startTime,
+    project: pathProject(filename, 3),
+    seen: new Set(),
+  };
+  for (const [index, message] of document.messages.entries()) {
+    session.records += 1;
+    addGeminiMessage(message, state, report, session, options, index + 1);
+  }
+}
+
+async function processGeminiJsonOrJsonl(filename, report, options, session) {
+  if (Path.extname(filename).toLowerCase() === ".json") {
+    let document;
+    try {
+      document = JSON.parse(await fsp.readFile(filename, "utf8"));
+      session.lines = 1;
+    } catch (error) {
+      parseError(report, session, filename, null, error, options);
+      return;
+    }
+    parseGeminiDocument(document, report, session, options, filename);
+    return;
+  }
+
+  const state = {
+    sessionId: Path.basename(filename, ".jsonl"),
+    startTime: null,
+    project: pathProject(filename, 3),
+    seen: new Set(),
+  };
+  await processJsonlRecords(filename, report, options, session, async (json, lineNo) => {
+    if (nonEmptyString(json.sessionId)) {
+      state.sessionId = json.sessionId;
+      state.startTime = json.startTime || state.startTime;
+      if (json.project) state.project = json.project;
+      return;
+    }
+    addGeminiMessage(json, state, report, session, options, lineNo);
+  });
+}
+
+async function processQwenJsonl(filename, report, options, session) {
+  const state = { project: pathProject(filename, 3), seen: new Set() };
+  await processJsonlRecords(filename, report, options, session, async (json, lineNo) => {
+    if (json.cwd) state.project = json.cwd;
+    if (json.type !== "assistant" || !json.usageMetadata) return;
+    const usage = json.usageMetadata;
+    const input = numeric(usage.promptTokenCount);
+    const cacheRead = numeric(usage.cachedContentTokenCount);
+    const reasoningOutput = numeric(usage.thoughtsTokenCount);
+    // Qwen's Gemini-compatible UsageMetadata reports candidates and thoughts
+    // separately; both are output-billed tokens.
+    const output = numeric(usage.candidatesTokenCount) + reasoningOutput;
+    if (input === 0 && cacheRead === 0 && output === 0 && reasoningOutput === 0) return;
+    const key = `${json.sessionId || Path.basename(filename)}:${json.uuid || lineNo}`;
+    if (state.seen.has(key)) return;
+    state.seen.add(key);
+    addHarnessUsage(report, session, options, {
+      provider: explicitProvider(json.provider, json.providerID, json.providerId) || "qwen",
+      agent: "qwen",
+      model: nonEmptyString(json.model) || nonEmptyString(json.message?.model) || UNKNOWN_MODEL,
+      project: state.project,
+      timestamp: timestamp(json.timestamp),
+      // Qwen's cachedContentTokenCount is a subset of promptTokenCount.
+      usage: { input, cacheRead, output, reasoningOutput },
+      lineNo,
+    });
+  });
+}
+
+async function processHarnessFile(filename, report, options, session, hint = null) {
+  const adapter = adapterForPath(filename, hint);
+  if (adapter === "cursor" || adapter === "grok") {
+    await processObservedHarnessFile(filename, report, options, session, adapter);
+  } else if (adapter === "pi") {
+    await processPiJsonl(filename, report, options, session);
+  } else if (adapter === "gemini") {
+    await processGeminiJsonOrJsonl(filename, report, options, session);
+  } else if (adapter === "qwen") {
+    await processQwenJsonl(filename, report, options, session);
+  } else if (adapter === "opencode") {
+    processOpenCodeDb(filename, report, options, session);
+  }
+}
+
+module.exports = {
+  adapterForPath,
+  claudeConfigDirs,
+  discoverCursorInputs,
+  desktopSessionRoots,
+  discoverClaudeInputs,
+  discoverGeminiInputs,
+  discoverHarnessInputs,
+  discoverGrokInputs,
+  discoverPiInputs,
+  discoverQwenInputs,
+  fileKind,
+  processHarnessFile,
+};

--- a/lib/ingest/observed-harnesses.js
+++ b/lib/ingest/observed-harnesses.js
@@ -1,0 +1,223 @@
+"use strict";
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const Path = require("node:path");
+const {
+  UNKNOWN_MODEL,
+  UNKNOWN_PROJECT,
+} = require("../core/report-model");
+
+const OBSERVED_MEASUREMENT = "observed-only";
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : null;
+}
+
+function nonNegativeNumber(value) {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function expandHome(value, home) {
+  if (value === "~") return home;
+  if (value.startsWith("~/") || value.startsWith(`~${Path.sep}`)) return Path.join(home, value.slice(2));
+  return value;
+}
+
+async function walkFiles(root, predicate, out = []) {
+  let entries;
+  try {
+    entries = await fsp.readdir(root, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const fullPath = Path.join(root, entry.name);
+    if (entry.isDirectory()) await walkFiles(fullPath, predicate, out);
+    else if (entry.isFile() && predicate(fullPath)) out.push(fullPath);
+  }
+  return out;
+}
+
+function observedSourceError(report, session, filename, error, options) {
+  report.sources.parseErrors += 1;
+  if (session) session.parseErrors += 1;
+  if (!options.strictJson) return;
+  const reason = error && error.message ? `: ${error.message}` : "";
+  throw new Error(`Invalid JSON in ${filename}${reason}`);
+}
+
+function isoTimestamp(value) {
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : null;
+}
+
+function observationBase({ agent, provider, model, project, sourceTimestamp, sourceTimestampProvenance }) {
+  return {
+    agent: nonEmptyString(agent) || "unknown",
+    provider: nonEmptyString(provider) || "unknown",
+    model: nonEmptyString(model) || UNKNOWN_MODEL,
+    project: nonEmptyString(project) || UNKNOWN_PROJECT,
+    measurement: OBSERVED_MEASUREMENT,
+    exactUsageAvailable: false,
+    sourceTimestamp: sourceTimestamp || null,
+    sourceTimestampProvenance: sourceTimestampProvenance || "unknown",
+  };
+}
+
+function cursorProject(filename) {
+  const normalized = filename.replace(/\\/g, "/");
+  const match = normalized.match(/\/\.cursor\/projects\/([^/]+)\/agent-transcripts(?:\/|$)/);
+  return nonEmptyString(match?.[1]) || UNKNOWN_PROJECT;
+}
+
+function cursorRoot(home) {
+  const override = nonEmptyString(process.env.CURSOR_DATA_DIR) || nonEmptyString(process.env.CURSOR_HOME);
+  return Path.join(Path.resolve(expandHome(override || Path.join(home, ".cursor"), home)), "projects");
+}
+
+async function discoverCursorInputs(home) {
+  const paths = await walkFiles(cursorRoot(home), (filename) => {
+    const normalized = filename.replace(/\\/g, "/");
+    return filename.endsWith(".jsonl") && normalized.includes("/agent-transcripts/");
+  });
+  return paths.map((path) => ({ kind: "jsonl", adapter: "cursor", path }));
+}
+
+function grokRoot(home) {
+  const override = nonEmptyString(process.env.GROK_DATA_DIR) || nonEmptyString(process.env.GROK_HOME);
+  return Path.join(Path.resolve(expandHome(override || Path.join(home, ".grok"), home)), "sessions");
+}
+
+async function discoverGrokInputs(home) {
+  const paths = await walkFiles(grokRoot(home), (filename) => Path.basename(filename) === "updates.jsonl");
+  return paths.map((path) => ({ kind: "jsonl", adapter: "grok", path }));
+}
+
+function projectFromGrokSummary(summary, encodedProject) {
+  const direct = nonEmptyString(summary?.info?.cwd) ||
+    nonEmptyString(summary?.cwd) ||
+    nonEmptyString(summary?.git_root_dir);
+  if (direct) return direct;
+  try {
+    const decoded = decodeURIComponent(encodedProject || "");
+    return nonEmptyString(decoded) || UNKNOWN_PROJECT;
+  } catch {
+    return nonEmptyString(encodedProject) || UNKNOWN_PROJECT;
+  }
+}
+
+function grokTimestamp(summary) {
+  const fields = [
+    ["updated_at", summary?.updated_at ?? summary?.updatedAt],
+    ["last_active_at", summary?.last_active_at ?? summary?.lastActiveAt],
+    ["created_at", summary?.created_at ?? summary?.createdAt],
+  ];
+  for (const [field, value] of fields) {
+    const timestamp = isoTimestamp(value);
+    if (timestamp) return { timestamp, provenance: `summary.${field}` };
+  }
+  return { timestamp: null, provenance: "summary.timestamp-unavailable" };
+}
+
+function grokModel(summary, signals) {
+  return nonEmptyString(summary?.current_model_id ?? summary?.currentModelId) ||
+    nonEmptyString(summary?.primary_model_id ?? summary?.primaryModelId) ||
+    nonEmptyString(summary?.model_id ?? summary?.modelId) ||
+    nonEmptyString(signals?.primaryModelId) ||
+    nonEmptyString(signals?.modelId) ||
+    UNKNOWN_MODEL;
+}
+
+async function readJsonMetadata(filename, report, session, options) {
+  let value;
+  try {
+    value = JSON.parse(await fsp.readFile(filename, "utf8"));
+  } catch (error) {
+    observedSourceError(report, session, filename, error, options);
+    return null;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    observedSourceError(report, session, filename, new Error("metadata must be an object"), options);
+    return null;
+  }
+  return value;
+}
+
+async function processCursorObserved(filename, report, options, session) {
+  let stat;
+  try {
+    stat = await fsp.stat(filename);
+  } catch (error) {
+    observedSourceError(report, session, filename, error, options);
+    return;
+  }
+  // Cursor transcript JSONL has no trustworthy per-session model or event
+  // timestamp fields. Do not parse its conversation content and do not infer a
+  // model from the global CLI config; only path and mtime are admissible here.
+  session.stats.observation = observationBase({
+    agent: "cursor-agent",
+    provider: "cursor",
+    model: UNKNOWN_MODEL,
+    project: cursorProject(filename),
+    sourceTimestamp: Number.isFinite(stat.mtimeMs) ? new Date(stat.mtimeMs).toISOString() : null,
+    sourceTimestampProvenance: "fileModifiedAt",
+  });
+}
+
+async function processGrokObserved(filename, report, options, session) {
+  const sessionDir = Path.dirname(filename);
+  const summaryPath = Path.join(sessionDir, "summary.json");
+  const signalsPath = Path.join(sessionDir, "signals.json");
+  const summary = await readJsonMetadata(summaryPath, report, session, options);
+  if (!summary) return;
+
+  let signals = null;
+  try {
+    await fsp.access(signalsPath, fs.constants.R_OK);
+  } catch {
+    // Signals are optional for a completed session; absence is not a zero.
+  }
+  if (fs.existsSync(signalsPath)) signals = await readJsonMetadata(signalsPath, report, session, options);
+  if (options.strictJson && session.parseErrors > 0) return;
+
+  const encodedProject = Path.basename(Path.dirname(sessionDir));
+  const sourceTimestamp = grokTimestamp(summary);
+  const observation = observationBase({
+    agent: "grok-build",
+    provider: "grok",
+    model: grokModel(summary, signals),
+    project: projectFromGrokSummary(summary, encodedProject),
+    sourceTimestamp: sourceTimestamp.timestamp,
+    sourceTimestampProvenance: sourceTimestamp.provenance,
+  });
+  const contextTokens = nonNegativeNumber(signals?.contextTokensUsed);
+  const contextWindowTokens = nonNegativeNumber(signals?.contextWindowTokens);
+  if (contextTokens !== null) observation.contextTokens = contextTokens;
+  if (contextWindowTokens !== null) observation.contextWindowTokens = contextWindowTokens;
+  session.stats.observation = observation;
+}
+
+function adapterForObservedPath(filename, hint = null) {
+  if (hint === "cursor" || hint === "grok") return hint;
+  const normalized = filename.replace(/\\/g, "/");
+  if (normalized.includes("/.cursor/projects/") && normalized.includes("/agent-transcripts/")) return "cursor";
+  if (Path.basename(filename) === "updates.jsonl" && normalized.includes("/.grok/sessions/")) return "grok";
+  return null;
+}
+
+async function processObservedHarnessFile(filename, report, options, session, hint = null) {
+  const adapter = adapterForObservedPath(filename, hint);
+  if (adapter === "cursor") return processCursorObserved(filename, report, options, session);
+  if (adapter === "grok") return processGrokObserved(filename, report, options, session);
+  return false;
+}
+
+module.exports = {
+  OBSERVED_MEASUREMENT,
+  adapterForObservedPath,
+  discoverCursorInputs,
+  discoverGrokInputs,
+  processObservedHarnessFile,
+};

--- a/lib/ingest/opencode.js
+++ b/lib/ingest/opencode.js
@@ -1,0 +1,232 @@
+"use strict";
+
+const fsp = require("node:fs/promises");
+const Path = require("node:path");
+const { DatabaseSync } = require("node:sqlite");
+const { addUsage } = require("../core/aggregate");
+const {
+  UNKNOWN_EFFORT,
+  UNKNOWN_MODEL,
+  UNKNOWN_PROJECT,
+  addToStats,
+  newStats,
+} = require("../core/report-model");
+
+const UNKNOWN_SERVICE_MODE = "unknown";
+const OPENCODE_AGENT = "opencode";
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : null;
+}
+
+function expandHome(value, home) {
+  if (value === "~") return home;
+  if (value.startsWith("~/") || value.startsWith(`~${Path.sep}`)) {
+    return Path.join(home, value.slice(2));
+  }
+  return value;
+}
+
+function sqliteText(value) {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (Buffer.isBuffer(value)) return value.toString("utf8");
+  if (value instanceof Uint8Array) return Buffer.from(value).toString("utf8");
+  return String(value);
+}
+
+function tokenNumber(value) {
+  const parsed = typeof value === "number"
+    ? value
+    : (typeof value === "string" && value.trim() !== "" ? Number(value) : 0);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function timestampFromSql(value) {
+  const numeric = typeof value === "number" ? value : Number(value);
+  if (Number.isFinite(numeric)) {
+    // OpenCode stores milliseconds. Accept seconds as a harmless fixture/
+    // migration compatibility fallback without changing normal DB values.
+    return new Date(Math.abs(numeric) < 1e12 ? numeric * 1000 : numeric);
+  }
+  return new Date(value);
+}
+
+function parseError(report, session, filename, rowNo, error, options) {
+  if (report.sources) report.sources.parseErrors = (report.sources.parseErrors || 0) + 1;
+  if (session) session.parseErrors = (session.parseErrors || 0) + 1;
+  if (!options?.strictJson) return;
+
+  const suffix = rowNo == null ? "" : `:${rowNo}`;
+  const reason = error && error.message ? `: ${error.message}` : "";
+  throw new Error(`Malformed OpenCode data in ${filename}${suffix}${reason}`);
+}
+
+function openCodeDataRoot(home) {
+  const dataBase = nonEmptyString(process.env.XDG_DATA_HOME)
+    ? Path.resolve(expandHome(process.env.XDG_DATA_HOME, home))
+    : Path.join(home, ".local", "share");
+  return nonEmptyString(process.env.OPENCODE_DATA_DIR)
+    ? Path.resolve(expandHome(process.env.OPENCODE_DATA_DIR, home))
+    : Path.join(dataBase, "opencode");
+}
+
+/**
+ * Discover OpenCode's SQLite stores without opening or mutating them.
+ *
+ * The input kind deliberately remains `jsonl` for the historical ingest
+ * dispatcher; the processing path identifies the `.db` representation and
+ * creates a `session.kind === "db"` record.
+ */
+async function discoverOpenCodeInputs(home) {
+  const resolvedHome = Path.resolve(home || process.env.HOME || ".");
+  const root = openCodeDataRoot(resolvedHome);
+  const prefix = nonEmptyString(process.env.OPENCODE_DB_PREFIX) || "opencode";
+  let files;
+  try {
+    files = await fsp.readdir(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  return files
+    .filter((entry) => entry.isFile() && entry.name.startsWith(prefix) && entry.name.endsWith(".db"))
+    .map((entry) => ({
+      kind: "jsonl",
+      adapter: OPENCODE_AGENT,
+      path: Path.join(root, entry.name),
+    }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function isOpenCodeDbPath(filename) {
+  return typeof filename === "string" && Path.extname(filename).toLowerCase() === ".db";
+}
+
+function projectForSession(row) {
+  return nonEmptyString(sqliteText(row.directory)) ||
+    nonEmptyString(sqliteText(row.title)) ||
+    UNKNOWN_PROJECT;
+}
+
+function usageFromMessageData(data) {
+  // OpenCode's SQLite message.data contract is the nested `tokens` object.
+  // Do not infer from provider-reported cost or alternate usage fields: the
+  // normal pricing path must recompute the amount from these exact buckets.
+  const tokens = data && typeof data.tokens === "object" && data.tokens !== null
+    ? data.tokens
+    : {};
+  const cache = tokens.cache && typeof tokens.cache === "object" ? tokens.cache : {};
+  return {
+    input: tokenNumber(tokens.input),
+    cacheCreate5m: tokenNumber(cache.write),
+    cacheRead: tokenNumber(cache.read),
+    output: tokenNumber(tokens.output),
+    reasoningOutput: tokenNumber(tokens.reasoning),
+    inputIncludesCacheRead: false,
+  };
+}
+
+function processOpenCodeDb(filename, report, options = {}, session) {
+  if (session) session.kind = "db";
+  let db;
+  try {
+    // This adapter is intentionally read-only. In particular, do not issue
+    // PRAGMA writes or migrations against a user's active OpenCode database.
+    db = new DatabaseSync(filename, { readOnly: true });
+  } catch (error) {
+    parseError(report, session, filename, null, error, options);
+    return;
+  }
+
+  try {
+    let topLevelSessions;
+    try {
+      topLevelSessions = db.prepare(`
+        SELECT id, CAST(directory AS BLOB) AS directory, CAST(title AS BLOB) AS title
+        FROM session
+        WHERE parent_id IS NULL AND time_archived IS NULL
+        ORDER BY time_created ASC, id ASC
+      `).all();
+    } catch (error) {
+      parseError(report, session, filename, null, error, options);
+      return;
+    }
+
+    if (session) session.lines = topLevelSessions.length;
+    if (topLevelSessions.length === 0) return;
+
+    const projects = new Map(
+      topLevelSessions.map((row) => [String(row.id), projectForSession(row)]),
+    );
+
+    let messages;
+    try {
+      // Join against the same top-level predicate instead of interpolating a
+      // potentially large IN list. Child and archived sessions are excluded
+      // even when their messages remain in the DB.
+      messages = db.prepare(`
+        SELECT m.id, m.session_id, m.time_created, CAST(m.data AS BLOB) AS data
+        FROM message AS m
+        JOIN session AS s ON s.id = m.session_id
+        WHERE s.parent_id IS NULL AND s.time_archived IS NULL
+        ORDER BY m.time_created ASC, m.id ASC
+      `).all();
+    } catch (error) {
+      parseError(report, session, filename, null, error, options);
+      return;
+    }
+
+    for (const row of messages) {
+      if (session) session.records = (session.records || 0) + 1;
+      const rowNo = session?.records || null;
+      let data;
+      try {
+        data = JSON.parse(sqliteText(row.data));
+        if (!data || typeof data !== "object" || Array.isArray(data)) {
+          throw new Error("message.data must be an object");
+        }
+      } catch (error) {
+        parseError(report, session, filename, rowNo, error, options);
+        continue;
+      }
+
+      if (data.role !== "assistant" && data.role !== "model") continue;
+      const usage = usageFromMessageData(data);
+      if (
+        usage.input === 0 &&
+        usage.cacheCreate5m === 0 &&
+        usage.cacheRead === 0 &&
+        usage.output === 0 &&
+        usage.reasoningOutput === 0
+      ) continue;
+
+      const provider = nonEmptyString(data.providerID) || OPENCODE_AGENT;
+      const model = nonEmptyString(data.modelID) || UNKNOWN_MODEL;
+      const added = addUsage(report, {
+        provider,
+        model,
+        project: projects.get(String(row.session_id)) || UNKNOWN_PROJECT,
+        effort: UNKNOWN_EFFORT,
+        serviceMode: UNKNOWN_SERVICE_MODE,
+        agent: OPENCODE_AGENT,
+        timestamp: timestampFromSql(row.time_created),
+        usage,
+        sourcePath: session?.path || filename,
+        lineNo: rowNo,
+      }, options);
+      if (session) {
+        if (!session.stats) session.stats = newStats();
+        addToStats(session.stats, added.usage, added.cost);
+      }
+    }
+  } finally {
+    db.close();
+  }
+}
+
+module.exports = {
+  discoverOpenCodeInputs,
+  isOpenCodeDbPath,
+  processOpenCodeDb,
+};

--- a/lib/ingest/parser.js
+++ b/lib/ingest/parser.js
@@ -32,6 +32,14 @@ const {
   UNKNOWN_SERVICE_TIER,
   normalizeServiceTier,
 } = require("../core/pricing");
+const {
+  CLAUDE_CODE_AGENT,
+  CODEX_AGENT: CODEX_SERVICE_AGENT,
+  OMP_AGENT,
+  UNKNOWN_SERVICE_MODE,
+  serviceModeFromClaudeSpeed,
+  serviceModeFromCodexTier,
+} = require("../core/service-mode");
 const { addRateLimitSnapshot } = require("../core/rate-limits");
 const { addTelemetrySnapshot } = require("../core/telemetry");
 
@@ -53,6 +61,7 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
     provider: "openai",
     effort: UNKNOWN_EFFORT,
     serviceTier: UNKNOWN_SERVICE_TIER,
+    serviceMode: UNKNOWN_SERVICE_MODE,
     assistantOutputChars: newAssistantOutputChars(),
     output: 0,
     reasoningOutput: 0,
@@ -72,6 +81,7 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
     provider: "openai",
     effort: UNKNOWN_EFFORT,
     serviceTier: UNKNOWN_SERVICE_TIER,
+    serviceMode: UNKNOWN_SERVICE_MODE,
     totalUsage: null,
     visibleChars: newVisibleChars(),
     assistantOutputChars: newAssistantOutputChars(),
@@ -94,6 +104,7 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
     codexState.turn.provider = codexState.provider || "openai";
     codexState.turn.effort = codexState.effort;
     codexState.turn.serviceTier = codexState.serviceTier;
+    codexState.turn.serviceMode = codexState.serviceMode;
   };
 
   const flushTurn = () => {
@@ -138,6 +149,7 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
     // A replay can contain the parent's thread_settings_applied record before
     // its first traced turn. Do not leak that tier into child-only usage.
     codexState.serviceTier = UNKNOWN_SERVICE_TIER;
+    codexState.serviceMode = UNKNOWN_SERVICE_MODE;
     updateTurnMeta();
   };
 
@@ -174,6 +186,7 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
     const timestamp = new Date(json.timestamp);
     const added = addUsage(report, {
       provider: "omp", // A3: explicit pin; inferProvider is never called
+      agent: OMP_AGENT,
       model,
       project: ompState.project,
       effort: UNKNOWN_EFFORT, // omp has no effort concept (D4 flat)
@@ -301,6 +314,7 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
       const serviceTier = normalizeServiceTier(json.payload.thread_settings?.service_tier);
       if (serviceTier !== UNKNOWN_SERVICE_TIER) {
         codexState.serviceTier = serviceTier;
+        codexState.serviceMode = serviceModeFromCodexTier(serviceTier);
         updateTurnMeta();
       }
       return;
@@ -396,6 +410,8 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
         project: codexState.project,
         effort,
         serviceTier: codexState.turn?.serviceTier || codexState.serviceTier,
+        serviceMode: codexState.turn?.serviceMode || codexState.serviceMode,
+        agent: CODEX_SERVICE_AGENT,
         timestamp,
         usage: codexUsage.usage,
         visibleChars: codexState.visibleChars,
@@ -481,11 +497,14 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
       if (json.error === "rate_limit") return;
       const added = addUsage(report, {
         provider: inferProvider(model, "anthropic"),
+        agent: CLAUDE_CODE_AGENT,
         model,
         project: json.cwd || UNKNOWN_PROJECT,
         effort: UNKNOWN_EFFORT,
+        serviceTier: normalizeServiceTier(json.message.usage.service_tier),
         timestamp: new Date(json.timestamp),
         usage: usageFromClaudeUsage(json.message.usage),
+        serviceMode: serviceModeFromClaudeSpeed(json.message.usage.speed),
         sourcePath: session?.path || sourceLabel,
         lineNo,
       }, options);

--- a/lib/ingest/sources.js
+++ b/lib/ingest/sources.js
@@ -14,6 +14,12 @@ const {
 const { finalizeRateLimits } = require("../core/rate-limits");
 const { createLineProcessor } = require("./parser");
 const { listZipEntries, openZipEntryStream } = require("./archive");
+const {
+  adapterForPath,
+  discoverHarnessInputs,
+  fileKind,
+  processHarnessFile,
+} = require("./harnesses");
 
 function resolveOmpAgentDir(home) {
   // A1: PI_CODING_AGENT_DIR moves ~/.omp/agent outright (highest precedence
@@ -54,14 +60,29 @@ function createIngestSources({
     return decoder;
   }
 
-  async function processJsonlFile(filename, report, options) {
+  async function processJsonlFile(filename, report, options, inputMeta = null) {
     report.sources.files += 1;
     const stat = await fsp.stat(filename);
+    const adapter = adapterForPath(filename, inputMeta?.adapter || null);
+    const kind = fileKind(filename);
     const session = startSession(report, options, {
-      kind: "jsonl",
+      kind,
       path: filename,
       sizeBytes: stat.size,
     });
+
+    // Keep the historical processJsonlFile entry point for storage backends,
+    // while dispatching exact .json/.db and known harness JSONL formats here.
+    // The session kind remains the actual source representation.
+    if (kind !== "jsonl" || ["cursor", "grok", "pi", "gemini", "qwen", "opencode"].includes(adapter)) {
+      try {
+        await processHarnessFile(filename, report, options, session, adapter);
+      } finally {
+        finishSession(session, options);
+      }
+      return;
+    }
+
     const processor = createLineProcessor(report, options, filename, session);
     const stream = openJsonlStream(filename);
     try {
@@ -156,14 +177,14 @@ function createIngestSources({
       for (const inputPath of options.paths) {
         await addInputPath(Path.resolve(inputPath), inputs, options.includeArchives);
       }
-      return sortInputs(inputs);
+      return sortInputs(await dedupeInputPaths(inputs));
     }
 
-    if (source === "all" || source === "claude") {
-      const claudeRoot = Path.join(home, ".claude", "projects");
-      const files = await walkFiles(claudeRoot, (p) => p.endsWith(".jsonl"));
-      inputs.push(...files.map((p) => ({ kind: "jsonl", path: p })));
-    }
+    // Exact local harness adapters (Claude config/Desktop, Pi, Gemini, Qwen,
+    // and OpenCode), plus observed-only Cursor/Grok metadata adapters, share
+    // this operational input kind so existing SQLite and ClickHouse sync paths
+    // can continue to call processJsonlFile unchanged.
+    inputs.push(...await discoverHarnessInputs(options));
 
     if (source === "all" || source === "codex") {
       const codexHome = options.codexHome || Path.join(home, ".codex");
@@ -190,7 +211,7 @@ function createIngestSources({
       inputs.push(...files.map((p) => ({ kind: "jsonl", path: p })));
     }
 
-    return sortInputs(inputs);
+    return sortInputs(await dedupeInputPaths(inputs));
   }
 
   function codexJsonlSource(path) {
@@ -252,6 +273,10 @@ function createIngestSources({
     const sources = [];
     for (const input of inputs) {
       if (input.kind === "jsonl") {
+        // Harness adapters have their own schemas. Do not pre-read every
+        // Claude/Pi/Gemini/Qwen/OpenCode source as a possible Codex rollout
+        // merely because the operational sync kind is historically `jsonl`.
+        if (input.adapter && input.adapter !== "generic" && input.adapter !== "codex") continue;
         if (!sourcePaths || sourcePaths.has(input.path)) sources.push(codexJsonlSource(input.path));
         continue;
       }
@@ -490,17 +515,41 @@ function createIngestSources({
     });
   }
 
+  async function dedupeInputPaths(inputs) {
+    const seen = new Set();
+    const output = [];
+    for (const input of inputs) {
+      let identity;
+      try {
+        identity = await fsp.realpath(input.path);
+      } catch {
+        identity = Path.resolve(input.path);
+      }
+      if (seen.has(identity)) continue;
+      seen.add(identity);
+      // Keep the caller's resolved path as the report/source identity while
+      // using the real path only for duplicate suppression. This preserves
+      // explicit-path UX and still collapses symlink aliases.
+      output.push({ ...input, realPath: identity, sourceIdentity: identity });
+    }
+    return output;
+  }
+
   async function addInputPath(inputPath, inputs, includeArchives) {
     const stat = await fsp.stat(inputPath);
     if (stat.isDirectory()) {
-      const files = await walkFiles(inputPath, (p) => isJsonlPath(p) || (includeArchives && p.endsWith(".zip")));
+      const files = await walkFiles(inputPath, (p) => isJsonlPath(p) || p.endsWith(".json") || p.endsWith(".db") || (includeArchives && p.endsWith(".zip")));
       for (const file of preferPlainRollouts(files)) {
-        inputs.push({ kind: file.endsWith(".zip") ? "zip" : "jsonl", path: file });
+        inputs.push({
+          kind: file.endsWith(".zip") ? "zip" : "jsonl",
+          adapter: file.endsWith(".zip") ? null : adapterForPath(file),
+          path: file,
+        });
       }
     } else if (inputPath.endsWith(".zip")) {
       if (includeArchives) inputs.push({ kind: "zip", path: inputPath });
-    } else if (isJsonlPath(inputPath)) {
-      inputs.push({ kind: "jsonl", path: inputPath });
+    } else if (isJsonlPath(inputPath) || inputPath.endsWith(".json") || inputPath.endsWith(".db")) {
+      inputs.push({ kind: "jsonl", adapter: adapterForPath(inputPath), path: inputPath });
     }
   }
 
@@ -528,7 +577,7 @@ function createIngestSources({
           report.sources.skippedFiles += 1;
           continue;
         }
-        await processJsonlFile(input.path, report, processingOptions);
+        await processJsonlFile(input.path, report, processingOptions, input);
       } else if (input.kind === "zip") {
         await processZipFile(input.path, report, processingOptions, limiter);
       }

--- a/lib/report/text.js
+++ b/lib/report/text.js
@@ -249,11 +249,13 @@ function renderTextReport(report, options) {
   const lines = [];
   lines.push("Tokenomics Viewer");
   lines.push(`Sources: files=${formatInt(report.sources.files)}, zip_files=${formatInt(report.sources.zipFiles)}, zip_entries=${formatInt(report.sources.zipEntries)}, skipped=${formatInt(report.sources.skippedFiles)}, token_count_snapshots=${formatInt(report.sources.tokenCountSnapshots)}, skipped_token_count_snapshots=${formatInt(report.sources.skippedTokenCountSnapshots)}, parse_errors=${formatInt(report.sources.parseErrors)}`);
-  lines.push(`Pricing sources: OpenAI=${PRICING_SOURCES.openai}; OpenAI GPT-5.6=${PRICING_SOURCES.openaiGpt56}; OpenAI models=${PRICING_SOURCES.openaiGpt5}; OpenAI Codex=${PRICING_SOURCES.openaiCodex}; Codex fast mode=${PRICING_SOURCES.openaiCodexFast}; Anthropic=${PRICING_SOURCES.anthropic}`);
+  lines.push(`Pricing sources: OpenAI=${PRICING_SOURCES.openai}; OpenAI GPT-5.6=${PRICING_SOURCES.openaiGpt56}; OpenAI models=${PRICING_SOURCES.openaiGpt5}; OpenAI Codex=${PRICING_SOURCES.openaiCodex}; Codex fast mode=${PRICING_SOURCES.openaiCodexFast}; Anthropic=${PRICING_SOURCES.anthropic}; Claude fast mode=${PRICING_SOURCES.anthropicFast}`);
   lines.push(`OpenAI context pricing mode: ${options.openaiContext}`);
   lines.push(formatStatsLine("Total", report.total));
   lines.push(printSection("By provider", report.providers, options.top));
   lines.push(printSection("By model", report.models, options.top));
+  lines.push(printSection("By agent", report.agents, options.top));
+  lines.push(printSection("By service mode", report.serviceModes, options.top));
   lines.push(printSection("By service tier", report.serviceTiers, options.top));
   lines.push(printEffortSection("By effort", report.efforts, options.top));
   lines.push(printSection("By model/effort", flattenNestedStats(report.modelEfforts), options.top));

--- a/lib/storage/clickhouse-pricing.js
+++ b/lib/storage/clickhouse-pricing.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { normalizeConfiguration } = require("../core/configuration");
-const { OPENAI_FAST_MULTIPLIERS } = require("../core/pricing");
+const { ANTHROPIC_FAST_MULTIPLIERS, OPENAI_FAST_MULTIPLIERS } = require("../core/pricing");
 
 const CLICKHOUSE_COST_COLUMNS = [
   "priced",
@@ -78,6 +78,25 @@ function openAIFastMultiplierExpression(configuration, expressions) {
   return `multiIf(${[...pairs, "1"].join(", ")})`;
 }
 
+function anthropicFastMultiplierExpression(configuration, expressions) {
+  if (configuration.settings.pricingBasis === "custom") return "1";
+  const modelsByMultiplier = new Map();
+  for (const [model, multiplier] of Object.entries(ANTHROPIC_FAST_MULTIPLIERS)) {
+    const models = modelsByMultiplier.get(multiplier) || [];
+    models.push(model);
+    modelsByMultiplier.set(multiplier, models);
+  }
+  const fastMode = `${expressions.serviceMode} = 'fast'`;
+  const pairs = [];
+  for (const [multiplier, models] of modelsByMultiplier) {
+    const modelMatches = models
+      .map((model) => `(${expressions.model} = ${encodedString(model)} OR startsWith(${expressions.model}, concat(${encodedString(model)}, '-'))) `)
+      .join(" OR ");
+    pairs.push(`(${expressions.provider} = 'anthropic' AND ${fastMode} AND (${modelMatches}))`, String(multiplier));
+  }
+  return `multiIf(${[...pairs, "1"].join(", ")})`;
+}
+
 function buildClickHouseCostProjection(sourceConfiguration, sourceExpressions = {}) {
   const configuration = normalizeConfiguration(sourceConfiguration);
   const alias = sourceExpressions.alias || "raw";
@@ -85,6 +104,7 @@ function buildClickHouseCostProjection(sourceConfiguration, sourceExpressions = 
     provider: sourceExpressions.provider || `lowerUTF8(trimBoth(toString(${alias}.provider)))`,
     model: sourceExpressions.model || `lowerUTF8(trimBoth(toString(${alias}.model)))`,
     serviceTier: sourceExpressions.serviceTier || `lowerUTF8(trimBoth(toString(${alias}.service_tier)))`,
+    serviceMode: sourceExpressions.serviceMode || `lowerUTF8(trimBoth(toString(${alias}.service_mode)))`,
     timestamp: sourceExpressions.timestamp
       ? sourceExpressions.timestampIsDateTime
         ? sourceExpressions.timestamp
@@ -138,7 +158,8 @@ function buildClickHouseCostProjection(sourceConfiguration, sourceExpressions = 
   const known = `isNotNull(${price(1)})`;
   const regionalMultiplier = Number(configuration.settings.regionalMultiplier);
   const serviceTierMultiplier = openAIFastMultiplierExpression(configuration, expressions);
-  const amount = (tokens, unitPrice) => `if(${known}, toFloat64(${tokens}) * ifNull(${unitPrice}, 0) * ${regionalMultiplier} * (${serviceTierMultiplier}) / 1000000, 0)`;
+  const serviceModeMultiplier = anthropicFastMultiplierExpression(configuration, expressions);
+  const amount = (tokens, unitPrice) => `if(${known}, toFloat64(${tokens}) * ifNull(${unitPrice}, 0) * ${regionalMultiplier} * (${serviceTierMultiplier}) * (${serviceModeMultiplier}) / 1000000, 0)`;
   const costs = {
     input: amount(expressions.input, price(1)),
     cacheCreate5m: amount(expressions.cacheCreate5m, price(2)),

--- a/lib/storage/clickhouse.js
+++ b/lib/storage/clickhouse.js
@@ -528,7 +528,7 @@ function createClickHouseBackend(dependencies = {}) {
     };
   }
 
-  async function configurationAtClickHouseRevision(client, revision) {
+  async function clickHouseConfigurationSourceAtRevision(client, revision) {
     const settingsRows = await clickHouseJsonEachRow(client, `
       SELECT DISTINCT key, value_json
       FROM analytics_settings
@@ -541,11 +541,15 @@ function createClickHouseBackend(dependencies = {}) {
       WHERE revision = {revision:String}
       ORDER BY provider, model, variant, row_id
     `, { params: { revision } });
-    return normalizeConfiguration({
+    return {
       revision,
       settings: Object.fromEntries(settingsRows.map((row) => [row.key, JSON.parse(row.value_json)])),
       prices: priceRows.map(clickHousePricingRow),
-    });
+    };
+  }
+
+  async function configurationAtClickHouseRevision(client, revision) {
+    return normalizeConfiguration(await clickHouseConfigurationSourceAtRevision(client, revision));
   }
 
   async function insertClickHouseConfigurationData(client, configuration, options = {}) {
@@ -592,8 +596,42 @@ function createClickHouseBackend(dependencies = {}) {
 
   async function ensureClickHouseConfiguration(client, options = {}) {
     const current = await latestClickHouseConfigurationRevision(client);
-    if (current) return configurationAtClickHouseRevision(client, current.revision);
-    return insertClickHouseConfiguration(client, defaultConfiguration(), "", 0, options);
+    if (!current) return insertClickHouseConfiguration(client, defaultConfiguration(), "", 0, options);
+
+    const source = await clickHouseConfigurationSourceAtRevision(client, current.revision);
+    const configuration = normalizeConfiguration(source);
+    const storedPricingRevision = String(
+      source.settings?.pricingRevision || source.revision || "",
+    ).trim();
+    if (storedPricingRevision === configuration.settings.pricingRevision) return configuration;
+
+    // A packaged pricing-engine revision changed. Publish the normalized
+    // catalog and its repricing overlays under a fresh append-only
+    // configuration revision, then expose the marker last. This makes newly
+    // supported models visible for already-imported usage without reopening
+    // source transcripts.
+    const upgradeRevision = randomUUID();
+    const upgraded = normalizeConfiguration({
+      ...configuration,
+      revision: upgradeRevision,
+      settings: {
+        ...configuration.settings,
+        // Derive a unique packaged-3 pricing revision for this append-only
+        // migration. Retries and concurrent starters then write disjoint
+        // overlay keys instead of duplicating rows under plain `packaged-3`.
+        pricingRevision: upgradeRevision,
+      },
+    });
+    await insertClickHouseConfigurationData(client, upgraded, options);
+    const generation = await ensureClickHouseBaselineGeneration(client, options);
+    await insertClickHousePricingOverlays(client, upgraded, generation?.generation_id || "");
+    return commitClickHouseConfiguration(
+      client,
+      upgraded,
+      current.revision,
+      current.committed_at_ms,
+      options,
+    );
   }
 
   async function loadClickHouseConfiguration(options = {}) {

--- a/lib/storage/clickhouse.js
+++ b/lib/storage/clickhouse.js
@@ -27,6 +27,7 @@ const {
 } = require("../core/configuration");
 const { normalizeCodexUuid } = require("../core/usage");
 const { normalizeServiceTier } = require("../core/pricing");
+const { normalizeAgent, normalizeServiceMode } = require("../core/service-mode");
 const { emitSyncProgress } = require("../core/sync-progress");
 const { newRateLimitAttribution, newRateLimitStats } = require("../core/rate-limits");
 const { CLICKHOUSE_COST_COLUMNS, buildClickHouseCostProjection } = require("./clickhouse-pricing");
@@ -246,6 +247,8 @@ function createClickHouseBackend(dependencies = {}) {
         project String CODEC(ZSTD(3)),
         effort LowCardinality(String) CODEC(ZSTD(1)),
         service_tier LowCardinality(String) DEFAULT 'unknown' CODEC(ZSTD(1)),
+        service_mode LowCardinality(String) DEFAULT 'unknown' CODEC(ZSTD(1)),
+        agent LowCardinality(String) DEFAULT 'unknown' CODEC(ZSTD(1)),
         input UInt64 CODEC(Delta, ZSTD(1)),
         cache_create_5m UInt64 CODEC(Delta, ZSTD(1)),
         cache_create_30m UInt64 CODEC(Delta, ZSTD(1)),
@@ -274,6 +277,8 @@ function createClickHouseBackend(dependencies = {}) {
       ALTER TABLE usage_events
         ADD COLUMN IF NOT EXISTS import_id String DEFAULT '' CODEC(ZSTD(3)),
         ADD COLUMN IF NOT EXISTS service_tier LowCardinality(String) DEFAULT 'unknown' CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS service_mode LowCardinality(String) DEFAULT 'unknown' CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS agent LowCardinality(String) DEFAULT 'unknown' CODEC(ZSTD(1)),
         ADD COLUMN IF NOT EXISTS cache_create_30m UInt64 DEFAULT 0 CODEC(Delta, ZSTD(1)),
         ADD COLUMN IF NOT EXISTS cost_cache_create_30m_usd Float64 DEFAULT 0 CODEC(Gorilla, ZSTD(1)),
         ADD COLUMN IF NOT EXISTS visible_input_chars UInt64 DEFAULT 0 CODEC(Delta, ZSTD(1)),
@@ -792,6 +797,8 @@ function createClickHouseBackend(dependencies = {}) {
       project: event.project,
       effort: event.effort,
       service_tier: normalizeServiceTier(event.serviceTier),
+      service_mode: normalizeServiceMode(event.serviceMode),
+      agent: normalizeAgent(event.agent, event.provider),
       input: number(event.usage.input),
       cache_create_5m: number(event.usage.cacheCreate5m),
       cache_create_30m: number(event.usage.cacheCreate30m),
@@ -1234,6 +1241,8 @@ function createClickHouseBackend(dependencies = {}) {
     "project",
     "effort",
     "service_tier",
+    "service_mode",
+    "agent",
   ];
 
   const CLICKHOUSE_USAGE_GROUPS = [
@@ -1255,6 +1264,8 @@ function createClickHouseBackend(dependencies = {}) {
     { bucket: "projectProviderModels", grouped: ["project", "provider", "model"], keys: ["project", "provider", "model"] },
     { bucket: "efforts", grouped: ["effort"], keys: ["effort"] },
     { bucket: "serviceTiers", grouped: ["service_tier"], keys: ["service_tier"] },
+    { bucket: "serviceModes", grouped: ["service_mode"], keys: ["service_mode"] },
+    { bucket: "agents", grouped: ["agent"], keys: ["agent"] },
     { bucket: "modelEfforts", grouped: ["model", "effort"], keys: ["model", "effort"] },
     { bucket: "providerModelEffortDaily", grouped: ["provider", "model", "effort", "date_key"], keys: ["provider", "model", "effort", "date_key"] },
   ];
@@ -1373,6 +1384,8 @@ function createClickHouseBackend(dependencies = {}) {
       else if (row.bucket === "models") report.models[row.key1] = stats;
       else if (row.bucket === "providerModels") report.providerModels[row.key1] = stats;
       else if (row.bucket === "serviceTiers") report.serviceTiers[row.key1] = stats;
+      else if (row.bucket === "serviceModes") report.serviceModes[row.key1] = stats;
+      else if (row.bucket === "agents") report.agents[row.key1] = stats;
       else if (row.bucket === "projects") report.projects[row.key1] = stats;
       else if (row.bucket === "projectDaily") {
         report.projectDaily[row.key1] ??= {};

--- a/lib/storage/sqlite.js
+++ b/lib/storage/sqlite.js
@@ -29,6 +29,7 @@ const {
   yearKey,
 } = require("../core/report-model");
 const { calculateCost, normalizeServiceTier } = require("../core/pricing");
+const { normalizeAgent, normalizeServiceMode } = require("../core/service-mode");
 const { sameSourceFingerprint, sourceFingerprint } = require("../core/derivation");
 const {
   defaultConfiguration,
@@ -165,6 +166,8 @@ function createSqliteBackend(dependencies = {}) {
         project TEXT NOT NULL,
         effort TEXT NOT NULL,
         service_tier TEXT NOT NULL DEFAULT 'unknown',
+        service_mode TEXT NOT NULL DEFAULT 'unknown',
+        agent TEXT NOT NULL DEFAULT 'unknown',
         input INTEGER NOT NULL,
         cache_create_5m INTEGER NOT NULL,
         cache_create_30m INTEGER NOT NULL DEFAULT 0,
@@ -258,6 +261,8 @@ function createSqliteBackend(dependencies = {}) {
     `);
     ensureSqliteColumn(db, "usage_events", "visible_input_chars", "INTEGER NOT NULL DEFAULT 0");
     ensureSqliteColumn(db, "usage_events", "service_tier", "TEXT NOT NULL DEFAULT 'unknown'");
+    ensureSqliteColumn(db, "usage_events", "service_mode", "TEXT NOT NULL DEFAULT 'unknown'");
+    ensureSqliteColumn(db, "usage_events", "agent", "TEXT NOT NULL DEFAULT 'unknown'");
     ensureSqliteColumn(db, "usage_events", "cache_create_30m", "INTEGER NOT NULL DEFAULT 0");
     ensureSqliteColumn(db, "usage_events", "cost_cache_create_30m_usd", "REAL NOT NULL DEFAULT 0");
     ensureSqliteColumn(db, "usage_events", "visible_output_chars", "INTEGER NOT NULL DEFAULT 0");
@@ -518,13 +523,13 @@ function createSqliteBackend(dependencies = {}) {
       insertUsage: db.prepare(`
         INSERT INTO usage_events(
           source_path, line_no, timestamp, date_key, week_key, month_key, year_key,
-          provider, model, project, effort, service_tier,
+          provider, model, project, effort, service_tier, service_mode, agent,
           input, cache_create_5m, cache_create_30m, cache_create_1h, cache_read, output, reasoning_output,
           context_window, priced, cost_usd, reasoning_cost_usd,
           cost_input_usd, cost_cache_create_5m_usd, cost_cache_create_30m_usd, cost_cache_create_1h_usd,
           cost_cache_read_usd, cost_output_usd,
           visible_input_chars, visible_output_chars, visible_total_chars, visible_chars_per_token
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `),
       insertOutputCharMetric: db.prepare(`
         INSERT INTO output_char_metrics(
@@ -598,6 +603,8 @@ function createSqliteBackend(dependencies = {}) {
       event.project,
       event.effort,
       normalizeServiceTier(event.serviceTier),
+      normalizeServiceMode(event.serviceMode),
+      normalizeAgent(event.agent, event.provider),
       event.usage.input,
       event.usage.cacheCreate5m,
       event.usage.cacheCreate30m,
@@ -860,9 +867,12 @@ function createSqliteBackend(dependencies = {}) {
       inputIncludesCacheRead: false,
     };
     const serviceTier = normalizeServiceTier(row.service_tier);
+    const serviceMode = normalizeServiceMode(row.service_mode);
+    const agent = normalizeAgent(row.agent, row.provider);
     const cost = calculateCost(row.provider || "unknown", row.model || UNKNOWN_MODEL, usage, timestamp, {
       ...options,
       serviceTier,
+      serviceMode,
     });
     const visibleChars = normalizeVisibleChars({
       input: row.visible_input_chars,
@@ -894,6 +904,8 @@ function createSqliteBackend(dependencies = {}) {
     addToStats(bucket(report.models, model), usage, cost, visibleChars);
     addToStats(bucket(report.providerModels, provider + "/" + model), usage, cost, visibleChars);
     addToStats(bucket(report.serviceTiers, serviceTier), usage, cost, visibleChars);
+    addToStats(bucket(report.serviceModes, serviceMode), usage, cost, visibleChars);
+    addToStats(bucket(report.agents, agent), usage, cost, visibleChars);
     addToStats(bucket(report.projects, project), usage, cost, visibleChars);
     addToStats(nestedBucket(report.projectDaily, project, dateKey(timestamp)), usage, cost, visibleChars);
     addToStats(nestedBucket(report.projectModels, project, model), usage, cost, visibleChars);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tokenomics-viewer",
   "version": "0.0.1",
-  "description": "View token usage, costs, and rate-limit metrics from Codex, Claude Code, and omp (oh-my-pi) sessions",
+  "description": "Local token, cost, and harness analytics for Codex, Claude Code, omp, Pi, Gemini, Qwen, OpenCode, Cursor, and Grok Build",
   "keywords": [
     "codex",
     "claude",

--- a/public/index.html
+++ b/public/index.html
@@ -45,6 +45,16 @@
     .token-card .value { font-size:16px; white-space:nowrap; }
     .plan-grid, .quota-grid { display:grid; grid-template-columns:repeat(auto-fit, minmax(280px, 1fr)); gap:12px; }
     .plan-grid { margin-bottom:12px; }
+    .service-mode-grid { display:grid; grid-template-columns:repeat(3, minmax(0, 1fr)); gap:10px; }
+    .service-mode-card { border:1px solid var(--line); border-left:4px solid var(--service-mode-color); border-radius:6px; padding:10px 12px; min-width:0; }
+    .service-mode-card-head { display:flex; align-items:center; justify-content:space-between; gap:8px; }
+    .service-mode-card-label { font-weight:650; }
+    .service-mode-card-value { color:var(--muted); font-size:12px; margin-top:4px; }
+    .observed-harness-grid { display:grid; grid-template-columns:repeat(auto-fit, minmax(280px, 1fr)); gap:10px; }
+    .observed-harness-card { border:1px solid var(--line); border-radius:6px; padding:10px 12px; min-width:0; }
+    .observed-harness-card-head { display:flex; align-items:flex-start; justify-content:space-between; gap:8px; }
+    .observed-harness-card-label { font-weight:650; overflow-wrap:anywhere; }
+    .observed-harness-card-meta { color:var(--muted); font-size:12px; margin-top:4px; overflow-wrap:anywhere; }
     .plan-item, .quota-item { min-width:0; border:1px solid var(--line); border-radius:6px; padding:12px; }
     .plan-head { display:flex; align-items:center; justify-content:space-between; gap:12px; }
     .plan-name { margin-top:5px; font-size:16px; font-weight:700; }
@@ -155,8 +165,8 @@
     body[data-dashboard-mode="settings"] #pricing-settings { display:block; }
     body[data-dashboard-mode="settings"] .section-nav { display:none; }
     @media (max-width: 1180px) { .cards { grid-template-columns:repeat(3, minmax(0, 1fr)); } .card:nth-child(3) { border-right:0; } .card:nth-child(n+4) { border-top:1px solid var(--line); } }
-    @media (max-width: 760px) { .cards { grid-template-columns:repeat(2, minmax(0, 1fr)); } .card, .card:nth-child(3) { border-right:1px solid var(--line); border-top:1px solid var(--line); } .card:nth-child(-n+2) { border-top:0; } .card:nth-child(2n) { border-right:0; } .card:last-child { grid-column:1 / -1; border-right:0; } .panel-head { display:grid; } .chart-head-meta { justify-items:start; } .hover-legend { justify-items:start; } .legend-line { justify-content:flex-start; } .date-controls { justify-content:flex-start; } .recommendation-list { grid-template-columns:1fr; } .recommendation-item:nth-child(odd) { border-right:0; } .settings-grid { grid-template-columns:1fr; } .settings-actions { justify-content:flex-start; } .pricing-table th:nth-child(2), .pricing-table td:nth-child(2) { position:static; box-shadow:none; } }
-    @media (max-width: 560px) { .brand-row { align-items:flex-start; flex-wrap:wrap; } .brand-group { align-items:flex-start; flex-direction:column; gap:3px; } .header-actions { width:100%; justify-content:space-between; } .sync-state { max-width:240px; } .section-nav { gap:18px; } main { padding:12px; } section { scroll-margin-top:170px; } .cards { grid-template-columns:1fr; } .card, .card:nth-child(3), .card:nth-child(2n) { border-right:0; border-top:1px solid var(--line); } .card:first-child { border-top:0; } .card:last-child { grid-column:auto; } .token-card .value { white-space:normal; } .chart-wrap, .project-chart-wrap { min-height:330px; } .mix-canvas { height:330px; } .date-control-group { flex-wrap:wrap; } .chart-help::after { position:fixed; inset:auto 12px 12px 12px; width:auto; transform:translateY(3px); } }
+    @media (max-width: 760px) { .cards { grid-template-columns:repeat(2, minmax(0, 1fr)); } .card, .card:nth-child(3) { border-right:1px solid var(--line); border-top:1px solid var(--line); } .card:nth-child(-n+2) { border-top:0; } .card:nth-child(2n) { border-right:0; } .card:last-child { grid-column:1 / -1; border-right:0; } .service-mode-grid { grid-template-columns:1fr; } .panel-head { display:grid; } .chart-head-meta { justify-items:start; } .hover-legend { justify-items:start; } .legend-line { justify-content:flex-start; } .date-controls { justify-content:flex-start; } .recommendation-list { grid-template-columns:1fr; } .recommendation-item:nth-child(odd) { border-right:0; } .settings-grid { grid-template-columns:1fr; } .settings-actions { justify-content:flex-start; } .pricing-table th:nth-child(2), .pricing-table td:nth-child(2) { position:static; box-shadow:none; } }
+    @media (max-width: 560px) { .brand-row { align-items:flex-start; flex-wrap:wrap; } .brand-group { align-items:flex-start; flex-direction:column; gap:3px; } .header-actions { width:100%; justify-content:space-between; } .sync-state { max-width:240px; } .section-nav { gap:18px; } main { padding:12px; } section { scroll-margin-top:170px; } .cards { grid-template-columns:1fr; } .card, .card:nth-child(3), .card:nth-child(2n) { border-right:0; border-top:1px solid var(--line); } .card:first-child { border-top:0; } .card:last-child { grid-column:auto; } .observed-harness-grid { grid-template-columns:1fr; } .token-card .value { white-space:normal; } .chart-wrap, .project-chart-wrap { min-height:330px; } .mix-canvas { height:330px; } .date-control-group { flex-wrap:wrap; } .chart-help::after { position:fixed; inset:auto 12px 12px 12px; width:auto; transform:translateY(3px); } }
   </style>
 </head>
 <body data-dashboard-mode="overview">
@@ -179,11 +189,21 @@
       <button class="nav-button active" type="button" data-section-target="overview-section">Summary</button>
       <button class="nav-button analyst-only" type="button" data-section-target="projects-section">Projects</button>
       <button class="nav-button" type="button" data-section-target="models-section">Models</button>
+      <button class="nav-button" type="button" data-section-target="service-mode-section">Service Mode</button>
+      <button class="nav-button" type="button" data-section-target="observed-harness-section">Observed</button>
       <button class="nav-button analyst-only" type="button" data-section-target="efficiency-section">Diagnostics</button>
     </nav>
   </header>
   <main>
     <section class="kpi-band" id="overview-section"><div class="cards" id="cards"></div></section>
+    <section id="service-mode-section" class="service-mode-panel">
+      <div class="panel-head"><div class="panel-title-stack"><h2>Service Mode</h2><div class="muted">Explicit per-request mode telemetry; unknown is not guessed from the model name.</div></div></div>
+      <div class="service-mode-grid" id="service-mode-grid"></div>
+    </section>
+    <section id="observed-harness-section">
+      <div class="panel-head"><div class="panel-title-stack"><h2>Observed Harness Coverage</h2><div class="muted">Session metadata only; usage unavailable and excluded from token and cost totals.</div></div></div>
+      <div class="observed-harness-grid" id="observed-harness-grid"></div>
+    </section>
     <section class="is-hidden" id="subscription-limits">
       <div class="panel-head"><div class="panel-title-stack"><h2>Subscription Limits</h2><div class="muted" id="subscription-limits-summary"></div></div></div>
       <div class="plan-grid" id="subscription-plan-grid"></div>
@@ -336,8 +356,12 @@
     const compactUsd = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', notation: 'compact', compactDisplay: 'short', maximumFractionDigits: 1 });
     const colors = {
       input: getComputedStyle(document.documentElement).getPropertyValue('--accent').trim(),
+      accent: getComputedStyle(document.documentElement).getPropertyValue('--accent').trim(),
       cache: getComputedStyle(document.documentElement).getPropertyValue('--cache').trim(),
       output: getComputedStyle(document.documentElement).getPropertyValue('--out').trim(),
+      standard: getComputedStyle(document.documentElement).getPropertyValue('--cache').trim(),
+      fast: getComputedStyle(document.documentElement).getPropertyValue('--accent').trim(),
+      unknown: getComputedStyle(document.documentElement).getPropertyValue('--axis').trim(),
       fg: getComputedStyle(document.documentElement).getPropertyValue('--fg').trim(),
       muted: getComputedStyle(document.documentElement).getPropertyValue('--muted').trim(),
       panel: getComputedStyle(document.documentElement).getPropertyValue('--panel').trim(),
@@ -376,6 +400,50 @@
         : formatUsdCompact(month.remainingUsd || 0) + ' left';
       return label + ' ' + spend + ' / ' + formatUsdCompact(month.limitUsd) +
         ' · ' + formatPct(month.usedRatio || 0) + ' used · ' + distance;
+    }
+
+    function renderServiceModes(summary) {
+      const grid = document.getElementById('service-mode-grid');
+      if (!grid) return;
+      const stats = new Map((summary.serviceModes || []).map(row => [row.name, row]));
+      const modes = [
+        { name: 'standard', label: 'Standard', color: colors.standard || colors.cache },
+        { name: 'fast', label: 'Fast', color: colors.fast || colors.accent },
+        { name: 'unknown', label: 'Unknown', color: colors.unknown || colors.axis },
+      ];
+      grid.innerHTML = modes.map(mode => {
+        const row = stats.get(mode.name) || {};
+        const requests = Number(row.requests || 0);
+        return '<article class="service-mode-card" style="--service-mode-color:' + esc(mode.color) + '">' +
+          '<div class="service-mode-card-head"><span class="service-mode-card-label">' + esc(mode.label) + '</span>' +
+          '<strong>' + esc(formatUsdCompact(row.costUsd || 0)) + '</strong></div>' +
+          '<div class="service-mode-card-value">' + esc(formatTokenCount(requests)) + ' request' + (requests === 1 ? '' : 's') + '</div></article>';
+      }).join('');
+    }
+
+    function renderObservedHarnesses(summary) {
+      const grid = document.getElementById('observed-harness-grid');
+      if (!grid) return;
+      const rows = summary.observedHarnesses || [];
+      if (!rows.length) {
+        grid.innerHTML = '<div class="muted">No observed-only harness sessions discovered.</div>';
+        return;
+      }
+      grid.innerHTML = rows.map(row => {
+        const model = row.model || '(unknown model)';
+        const sessions = Number(row.sessionCount || 0);
+        const project = row.projectCount > 1
+          ? row.projectCount + ' projects' + ((row.projects || []).length ? ' · ' + row.projects.slice(0, 3).join(', ') : '')
+          : (row.projects || [row.project || '(unknown project)'])[0];
+        const timestamp = row.latestSourceTimestamp ? new Date(row.latestSourceTimestamp).toLocaleString() : 'Timestamp unavailable';
+        const context = Number.isFinite(row.contextTokens)
+          ? ' · context ' + formatTokenCount(row.contextTokens) + (Number.isFinite(row.contextWindowTokens) ? '/' + formatTokenCount(row.contextWindowTokens) : '')
+          : '';
+        return '<article class="observed-harness-card"><div class="observed-harness-card-head"><span class="observed-harness-card-label">' +
+          esc(row.agent) + ' · ' + esc(row.provider) + '</span><strong>' + esc(String(sessions)) + ' session' + (sessions === 1 ? '' : 's') + '</strong></div>' +
+          '<div class="observed-harness-card-meta">' + esc(model + ' · ' + project) + '</div>' +
+          '<div class="observed-harness-card-meta">' + esc(timestamp + context + ' · usage unavailable') + '</div></article>';
+      }).join('');
     }
 
     function quotaWindowLabel(minutes) {
@@ -1764,6 +1832,8 @@
         card('Cache Tokens', segmentCardText(summary.total, 'cache'), 'token-card'),
         card('Output Tokens', segmentCardText(summary.total, 'output'), 'token-card'),
       ].join('');
+      renderServiceModes(summary);
+      renderObservedHarnesses(summary);
       renderSubscriptionWindows(summary);
       for (const range of Object.values(timelineRanges)) {
         range.monthStartAt = summary.currentMonth?.startAt || '';
@@ -2297,7 +2367,7 @@
     function syncSectionNav() {
       const threshold = document.getElementById('app-header').getBoundingClientRect().height + 24;
       if (dashboardMode === 'settings') return;
-      const orderedTargets = ['overview-section', 'projects-section', 'models-section', 'efficiency-section'];
+      const orderedTargets = ['overview-section', 'projects-section', 'models-section', 'service-mode-section', 'observed-harness-section', 'efficiency-section'];
       if (window.scrollY < 80) {
         activeSectionTarget = 'overview-section';
       } else {

--- a/test/cli-input.test.js
+++ b/test/cli-input.test.js
@@ -100,7 +100,7 @@ test("main writes final JSON report with per-session metrics", async () => {
 
 test("parseArgs rejects invalid values across the supported validation matrix", () => {
   const invalidCases = [
-    [["--source", "invalid"], "--source must be all, claude, codex, or omp"],
+    [["--source", "invalid"], "--source must be all, claude, codex, omp, pi, gemini, qwen, opencode, cursor, or grok"],
     [["--openai-context", "invalid"], "--openai-context must be auto, short, or long"],
     [["--format", "xml"], "--format must be text or json"],
     [["--db-engine", "invalid"], "--db-engine must be sqlite or clickhouse"],

--- a/test/clickhouse-pricing.test.js
+++ b/test/clickhouse-pricing.test.js
@@ -50,6 +50,7 @@ test("ClickHouse pricing projection uses canonical service_mode for Anthropic fa
 
   assert.match(sql.projection, /raw\.service_mode/);
   assert.match(sql.projection, /'anthropic'/);
+  assert.match(sql.projection, /Y2xhdWRlLW9wdXMtNQ==/);
   assert.match(sql.projection, /Y2xhdWRlLW9wdXMtNC04/);
   assert.match(sql.projection, /, 2,/);
 

--- a/test/clickhouse-pricing.test.js
+++ b/test/clickhouse-pricing.test.js
@@ -44,3 +44,17 @@ test("ClickHouse pricing projection applies packaged fast multipliers from servi
   const customSql = buildClickHouseCostProjection(custom, { alias: "raw" });
   assert.doesNotMatch(customSql.projection, /raw\.service_tier/);
 });
+
+test("ClickHouse pricing projection uses canonical service_mode for Anthropic fast pricing", () => {
+  const sql = buildClickHouseCostProjection(defaultConfiguration(), { alias: "raw" });
+
+  assert.match(sql.projection, /raw\.service_mode/);
+  assert.match(sql.projection, /'anthropic'/);
+  assert.match(sql.projection, /Y2xhdWRlLW9wdXMtNC04/);
+  assert.match(sql.projection, /, 2,/);
+
+  const custom = defaultConfiguration();
+  custom.settings.pricingBasis = "custom";
+  const customSql = buildClickHouseCostProjection(custom, { alias: "raw" });
+  assert.doesNotMatch(customSql.projection, /raw\.service_mode/);
+});

--- a/test/clickhouse.test.js
+++ b/test/clickhouse.test.js
@@ -312,6 +312,44 @@ test("ClickHouse configuration revisions publish marker-last and reject stale wr
   });
 });
 
+test("ClickHouse packaged pricing upgrade publishes Opus 5 overlays before the revision marker", async () => {
+  const mock = createClickHouseServer();
+  await withServer(mock, async (clickhouseUrl) => {
+    const options = defaultOptions({ dbEngine: "clickhouse", clickhouseUrl, clickhouseDatabase: "tokenomics_packaged_upgrade_test" });
+    await loadConfiguration(options);
+
+    const legacyRevision = "legacy-packaged-2";
+    mock.activeRows.configuration_revisions[0].revision = legacyRevision;
+    for (const row of mock.activeRows.analytics_settings) {
+      row.revision = legacyRevision;
+      if (row.key === "pricingRevision") row.value_json = JSON.stringify("packaged-2");
+    }
+    mock.activeRows.pricing_catalog = mock.activeRows.pricing_catalog
+      .filter((row) => row.model !== "claude-opus-5")
+      .map((row) => ({ ...row, revision: legacyRevision }));
+
+    const before = mock.requests.length;
+    const upgraded = await loadConfiguration(options);
+    const requests = mock.requests.slice(before);
+
+    assert.notEqual(upgraded.revision, legacyRevision);
+    assert.match(upgraded.settings.pricingRevision, /^packaged-3:[0-9a-f]{32}$/);
+    assert.ok(upgraded.prices.some((row) => row.provider === "anthropic" && row.model === "claude-opus-5"));
+    const usageOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO usage_event_costs"));
+    const rateLimitOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO rate_limit_sample_costs"));
+    const marker = requests.findIndex((request) => request.query.startsWith("INSERT INTO configuration_revisions"));
+    assert.ok(usageOverlay >= 0 && rateLimitOverlay > usageOverlay && marker > rateLimitOverlay);
+
+    const stableStart = mock.requests.length;
+    const stable = await loadConfiguration(options);
+    const repeatedInserts = mock.requests
+      .slice(stableStart)
+      .filter((request) => request.query.trimStart().startsWith("INSERT INTO"));
+    assert.equal(stable.revision, upgraded.revision);
+    assert.equal(repeatedInserts.length, 0, "completed packaged upgrade must not replay pricing overlays");
+  });
+});
+
 test("ClickHouse pricing overlay failure leaves the previous configuration visible", async () => {
   const mock = createClickHouseServer({ failureQueryIncludes: "INSERT INTO rate_limit_sample_costs" });
   await withServer(mock, async (clickhouseUrl) => {

--- a/test/clickhouse.test.js
+++ b/test/clickhouse.test.js
@@ -428,6 +428,8 @@ test("ClickHouse sync streams usage rows in bounded insert chunks", async () => 
     assert.ok(queries.some((query) => (
       query.includes("CREATE TABLE IF NOT EXISTS usage_events")
       && query.includes("service_tier LowCardinality(String)")
+      && query.includes("service_mode LowCardinality(String)")
+      && query.includes("agent LowCardinality(String)")
       && query.includes("CODEC(ZSTD(3))")
       && query.includes("CODEC(Delta, ZSTD(1))")
       && query.includes("CODEC(Gorilla, ZSTD(1))")
@@ -439,16 +441,23 @@ test("ClickHouse sync streams usage rows in bounded insert chunks", async () => 
     const alter = queries.find((query) => query.trim().startsWith("ALTER TABLE usage_events"));
     assert.ok(alter, "long ALTER TABLE SQL should be observed from the request body");
     assert.match(alter, /ADD COLUMN IF NOT EXISTS service_tier/);
+    assert.match(alter, /ADD COLUMN IF NOT EXISTS service_mode/);
+    assert.match(alter, /ADD COLUMN IF NOT EXISTS agent/);
     assert.match(alter, /ADD COLUMN IF NOT EXISTS visible_chars_per_token/);
     const usageStatsQuery = queries.find((query) => query.includes("FROM usage_events") && query.includes("GROUP BY GROUPING SETS"));
     assert.ok(usageStatsQuery);
     assert.match(usageStatsQuery, /'providerModelEffortDaily'/);
     assert.match(usageStatsQuery, /'serviceTiers'/);
+    assert.match(usageStatsQuery, /'serviceModes'/);
+    assert.match(usageStatsQuery, /'agents'/);
     assert.match(usageStatsQuery, /\(provider, model, effort, date_key\)/);
     assert.equal((usageStatsQuery.match(/FROM usage_events AS raw/g) || []).length, 1);
     assert.doesNotMatch(usageStatsQuery, /UNION ALL/);
     assert.equal(mock.inserts.usage_events.reduce((sum, insert) => sum + insert.rows, 0), rows);
     assert.equal(JSON.parse(mock.inserts.usage_events[0].body.trim().split("\n")[0]).service_tier, "unknown");
+    const firstUsageRow = JSON.parse(mock.inserts.usage_events[0].body.trim().split("\n")[0]);
+    assert.equal(firstUsageRow.service_mode, "unknown");
+    assert.equal(firstUsageRow.agent, "codex");
     assert.equal(mock.inserts.telemetry_events.reduce((sum, insert) => sum + insert.rows, 0), rows);
     assert.match(mock.inserts.telemetry_events[0].body, /token_count/);
     assert.ok(mock.inserts.usage_events.length > 1);

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -20,7 +20,7 @@ test("default configuration exposes a validated editable pricing catalog", () =>
   assert.equal(configuration.settings.pricingBasis, "standard");
   assert.equal(configuration.settings.regionalMultiplier, 1);
   assert.equal(configuration.settings.monthlyCostLimitUsd, null);
-  assert.equal(configuration.settings.pricingRevision, "packaged-2");
+  assert.equal(configuration.settings.pricingRevision, "packaged-3");
   assert.deepEqual(configuration.settings.usageProfile, {
     id: "default",
     name: "Work API",
@@ -28,8 +28,31 @@ test("default configuration exposes a validated editable pricing catalog", () =>
   });
   assert.ok(configuration.prices.some((row) => row.provider === "openai" && row.model === "gpt-5.6-luna" && row.variant === "short"));
   assert.ok(configuration.prices.some((row) => row.provider === "openai" && row.model === "codex-auto-review" && row.variant === "short"));
-  assert.ok(configuration.prices.some((row) => row.provider === "anthropic" && row.model === "claude-opus-4-8"));
+  const opus5 = configuration.prices.find((row) => row.provider === "anthropic" && row.model === "claude-opus-5");
+  const opus48 = configuration.prices.find((row) => row.provider === "anthropic" && row.model === "claude-opus-4-8");
+  assert.ok(opus5);
+  assert.ok(opus48);
+  for (const field of ["input", "cacheCreate5m", "cacheCreate1h", "cacheRead", "output"]) {
+    assert.equal(opus5[field], opus48[field], `${field} pricing must match Opus 4.8`);
+  }
   assert.deepEqual(normalizeConfiguration(configuration), configuration);
+});
+
+test("packaged-2 pricing is upgraded with Opus 5 without replacing persisted rows", () => {
+  const configuration = defaultConfiguration();
+  configuration.revision = "packaged-2";
+  configuration.settings.pricingRevision = "packaged-2";
+  configuration.prices = configuration.prices.filter((row) => row.model !== "claude-opus-5");
+  const luna = configuration.prices.find((row) => (
+    row.provider === "openai" && row.model === "gpt-5.6-luna" && row.variant === "short"
+  ));
+  luna.input = 2;
+
+  const normalized = normalizeConfiguration(configuration);
+
+  assert.equal(normalized.settings.pricingRevision, "packaged-3");
+  assert.equal(normalized.prices.find((row) => row.id === luna.id).input, 2);
+  assert.ok(normalized.prices.some((row) => row.provider === "anthropic" && row.model === "claude-opus-5"));
 });
 
 test("packaged-1 pricing is upgraded with codex-auto-review without replacing persisted rows", () => {
@@ -44,7 +67,7 @@ test("packaged-1 pricing is upgraded with codex-auto-review without replacing pe
 
   const normalized = normalizeConfiguration(configuration);
 
-  assert.equal(normalized.settings.pricingRevision, "packaged-2");
+  assert.equal(normalized.settings.pricingRevision, "packaged-3");
   assert.equal(normalized.prices.find((row) => row.id === luna.id).input, 2);
   assert.ok(normalized.prices.some((row) => row.provider === "openai" && row.model === "codex-auto-review"));
 });
@@ -56,7 +79,7 @@ test("standard edited catalogs get a stable pricing-engine revision and auto-rev
 
   const normalized = normalizeConfiguration(configuration);
 
-  assert.match(normalized.settings.pricingRevision, /^packaged-2:[0-9a-f]{32}$/);
+  assert.match(normalized.settings.pricingRevision, /^packaged-3:[0-9a-f]{32}$/);
   assert.equal(normalizeConfiguration(normalized).settings.pricingRevision, normalized.settings.pricingRevision);
   assert.ok(normalized.prices.some((row) => row.provider === "openai" && row.model === "codex-auto-review"));
 

--- a/test/dashboard-report.test.js
+++ b/test/dashboard-report.test.js
@@ -17,6 +17,21 @@ test("dashboard summary keeps daily buckets chronological for time-series charts
   assert.deepEqual(summary.daily.map((row) => row.name), ["2026-01-01", "2026-01-02", "2026-01-03"]);
 });
 
+test("dashboard summary exposes service modes as distinct analytics buckets", () => {
+  const report = newReport();
+  report.serviceModes.standard = statsFixture({ requests: 1, costUsd: 3 });
+  report.serviceModes.fast = statsFixture({ requests: 2, costUsd: 6 });
+  report.serviceModes.unknown = statsFixture({ requests: 3, costUsd: 0 });
+
+  const summary = webSummary(report, defaultOptions());
+
+  assert.deepEqual(summary.serviceModes.map((row) => row.name), ["fast", "standard", "unknown"]);
+  const html = require("../lib/dashboard").dashboardHtml();
+  assert.match(html, /service-mode/);
+  assert.match(html, /Fast/);
+  assert.match(html, /Unknown/);
+});
+
 test("dashboard summary exposes the current UTC calendar month", () => {
   const report = newReport();
   report.monthlyCostLimitUsd = 100;

--- a/test/harnesses.test.js
+++ b/test/harnesses.test.js
@@ -1,0 +1,130 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const Path = require("node:path");
+const os = require("node:os");
+const test = require("node:test");
+const { buildReport, discoverInputs } = require("../app");
+const { defaultOptions } = require("./support/fixtures");
+
+function tempHome() {
+  return fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-harnesses-"));
+}
+
+function writeJsonl(file, rows) {
+  fs.mkdirSync(Path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, rows.map((row) => typeof row === "string" ? row : JSON.stringify(row)).join("\n") + "\n");
+}
+
+test("discovers Claude config dirs, Desktop nested projects, and exact harness roots", async () => {
+  const home = tempHome();
+  const configA = Path.join(home, "claude-a");
+  const configB = Path.join(home, "claude-b");
+  const same = Path.join(configA, "projects", "same", "session.jsonl");
+  const sameLink = Path.join(configB, "projects", "same-link", "session.jsonl");
+  writeJsonl(same, []);
+  fs.mkdirSync(Path.dirname(sameLink), { recursive: true });
+  fs.symlinkSync(same, sameLink);
+  writeJsonl(Path.join(configB, "projects", "other", "session.jsonl"), []);
+
+  const desktop = Path.join(home, "Library", "Application Support", "Claude", "local-agent-mode-sessions", "app", "workspace", "local_1", ".claude", "projects", "desktop-project", "desktop.jsonl");
+  writeJsonl(desktop, []);
+
+  writeJsonl(Path.join(home, ".pi", "agent", "sessions", "project", "pi.jsonl"), []);
+  writeJsonl(Path.join(home, ".gemini", "tmp", "project", "chats", "session-g.jsonl"), []);
+  writeJsonl(Path.join(home, ".qwen", "projects", "project", "chats", "qwen.jsonl"), []);
+  const previousDirs = process.env.CLAUDE_CONFIG_DIRS;
+  const previousDir = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIRS = `${configA}${Path.delimiter}${configB}`;
+  delete process.env.CLAUDE_CONFIG_DIR;
+  try {
+    const inputs = await discoverInputs(defaultOptions({ home, source: "all" }));
+    const paths = inputs.map((input) => input.path);
+    assert.equal(paths.filter((path) => path === fs.realpathSync(same)).length, 1, "same real path is deduped");
+    assert.ok(paths.some((path) => path.endsWith("other/session.jsonl")));
+    assert.ok(paths.some((path) => path.endsWith("desktop-project/desktop.jsonl")));
+    assert.ok(paths.some((path) => path.endsWith("/.pi/agent/sessions/project/pi.jsonl")));
+    assert.ok(paths.some((path) => path.endsWith("/.gemini/tmp/project/chats/session-g.jsonl")));
+    assert.ok(paths.some((path) => path.endsWith("/.qwen/projects/project/chats/qwen.jsonl")));
+  } finally {
+    if (previousDirs === undefined) delete process.env.CLAUDE_CONFIG_DIRS;
+    else process.env.CLAUDE_CONFIG_DIRS = previousDirs;
+    if (previousDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = previousDir;
+  }
+});
+
+test("exact Pi/Gemini/Qwen token semantics preserve model, provider, agent, and unknown mode", async () => {
+  const home = tempHome();
+  const pi = Path.join(home, ".pi", "agent", "sessions", "project", "pi.jsonl");
+  writeJsonl(pi, [
+    { type: "session", id: "pi-session", cwd: "/tmp/pi-project" },
+    { type: "message", timestamp: "2026-07-26T00:00:00.000Z", message: {
+      role: "assistant", model: "gpt-5.4", provider: "openai", usage: { input: 100, output: 20, cacheRead: 30, cacheWrite: 4 },
+    } },
+  ]);
+  const gemini = Path.join(home, ".gemini", "tmp", "g", "chats", "session-g.json");
+  writeJsonl(gemini, []);
+  fs.writeFileSync(gemini, JSON.stringify({ sessionId: "g", startTime: "2026-07-26T00:00:00.000Z", messages: [
+    { id: "g-1", type: "gemini", timestamp: "2026-07-26T00:00:01.000Z", model: "gemini-test", tokens: { input: 100, cached: 30, output: 20, thoughts: 5 } },
+  ] }));
+  const qwen = Path.join(home, ".qwen", "projects", "q", "chats", "session.jsonl");
+  writeJsonl(qwen, [{ type: "assistant", uuid: "q-1", sessionId: "q", timestamp: "2026-07-26T00:00:02.000Z", model: "qwen-test", usageMetadata: {
+    promptTokenCount: 100, cachedContentTokenCount: 30, candidatesTokenCount: 20, thoughtsTokenCount: 5,
+  } }]);
+
+  const report = await buildReport(defaultOptions({ home, source: "all", progress: false }));
+  const events = report._usageEvents;
+  const byAgent = Object.fromEntries(events.map((event) => [event.agent, event]));
+  assert.equal(byAgent.pi.provider, "openai");
+  assert.equal(byAgent.pi.model, "gpt-5.4");
+  assert.deepEqual(byAgent.pi.usage, { input: 100, cacheCreate5m: 4, cacheCreate30m: 0, cacheCreate1h: 0, cacheRead: 30, output: 20, reasoningOutput: 0, contextWindow: 0, inputIncludesCacheRead: false });
+  assert.equal(byAgent.gemini.provider, "gemini");
+  assert.equal(byAgent.gemini.usage.input, 70);
+  assert.equal(byAgent.gemini.usage.cacheRead, 30);
+  assert.equal(byAgent.gemini.usage.output, 25);
+  assert.equal(byAgent.gemini.usage.reasoningOutput, 5);
+  assert.equal(byAgent.qwen.provider, "qwen");
+  assert.equal(byAgent.qwen.usage.input, 70);
+  assert.equal(byAgent.qwen.usage.cacheRead, 30);
+  assert.equal(byAgent.qwen.usage.output, 25);
+  assert.equal(byAgent.qwen.usage.reasoningOutput, 5);
+  for (const event of events) assert.equal(event.serviceMode, "unknown");
+  assert.equal(report.total.requests, 3);
+
+  const explicit = await buildReport(defaultOptions({ home, paths: [gemini], progress: false }));
+  assert.equal(explicit.sessions[0].kind, "json");
+  assert.equal(explicit.total.requests, 1);
+});
+
+test("malformed harness source is isolated in lenient mode and strict mode throws", async () => {
+  const home = tempHome();
+  const badGemini = Path.join(home, ".gemini", "tmp", "bad", "chats", "session-bad.json");
+  fs.mkdirSync(Path.dirname(badGemini), { recursive: true });
+  fs.writeFileSync(badGemini, "{not-json");
+  const goodQwen = Path.join(home, ".qwen", "projects", "good", "chats", "session.jsonl");
+  writeJsonl(goodQwen, [{ type: "assistant", uuid: "q-1", sessionId: "q", timestamp: "2026-07-26T00:00:02.000Z", model: "qwen-test", usageMetadata: {
+    promptTokenCount: 5, cachedContentTokenCount: 1, candidatesTokenCount: 2, thoughtsTokenCount: 0,
+  } }]);
+
+  const lenient = await buildReport(defaultOptions({ home, source: "all", progress: false }));
+  assert.equal(lenient.total.requests, 1);
+  assert.ok(lenient.sources.parseErrors >= 1);
+  assert.ok(lenient.sessions.some((session) => session.path === fs.realpathSync(badGemini) && session.parseErrors >= 1));
+  await assert.rejects(
+    () => buildReport(defaultOptions({ home, source: "all", strictJson: true, progress: false })),
+    /Invalid JSON|Malformed JSON|Unexpected token/,
+  );
+});
+
+test("model names do not infer fast service mode", async () => {
+  const home = tempHome();
+  const gemini = Path.join(home, ".gemini", "tmp", "g", "chats", "session-fast.jsonl");
+  writeJsonl(gemini, [
+    { sessionId: "g", startTime: "2026-07-26T00:00:00.000Z" },
+    { id: "g-1", type: "gemini", timestamp: "2026-07-26T00:00:01.000Z", model: "gemini-fast", tokens: { input: 1, cached: 0, output: 1 } },
+  ]);
+  const report = await buildReport(defaultOptions({ home, source: "gemini", progress: false }));
+  assert.equal(report._usageEvents[0].serviceMode, "unknown");
+});

--- a/test/observed-harnesses.test.js
+++ b/test/observed-harnesses.test.js
@@ -1,0 +1,168 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const Path = require("node:path");
+const test = require("node:test");
+const {
+  buildReport,
+  buildReportFromDatabase,
+  syncDatabase,
+} = require("../app");
+const { webSummary } = require("../lib/dashboard");
+const { defaultOptions } = require("./support/fixtures");
+
+function tempHome() {
+  return fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-observed-harnesses-"));
+}
+
+function writeJson(path, value) {
+  fs.mkdirSync(Path.dirname(path), { recursive: true });
+  fs.writeFileSync(path, JSON.stringify(value) + "\n");
+}
+
+function observedFixture(home) {
+  const cursorTranscript = Path.join(
+    home,
+    ".cursor",
+    "projects",
+    "tokenomics-project",
+    "agent-transcripts",
+    "cursor-session.jsonl",
+  );
+  fs.mkdirSync(Path.dirname(cursorTranscript), { recursive: true });
+  // The parser must not use transcript content for observed-only ingestion.
+  fs.writeFileSync(cursorTranscript, "not-json transcript content\n");
+  const cursorAt = new Date("2026-07-20T01:02:03.000Z");
+  fs.utimesSync(cursorTranscript, cursorAt, cursorAt);
+
+  const grokDir = Path.join(
+    home,
+    ".grok",
+    "sessions",
+    "%2Ftmp%2Fgrok-project",
+    "grok-session",
+  );
+  writeJson(Path.join(grokDir, "summary.json"), {
+    info: { id: "grok-session", cwd: "/tmp/grok-project" },
+    created_at: "2026-07-21T01:02:03.000Z",
+    updated_at: "2026-07-21T01:04:05.000Z",
+    current_model_id: "grok-4.20-0309-non-reasoning",
+  });
+  writeJson(Path.join(grokDir, "signals.json"), {
+    contextTokensUsed: 65432,
+    contextWindowTokens: 128000,
+  });
+  // The updates stream is deliberately invalid: observed ingestion reads only
+  // summary/signals metadata and must not parse conversation/tool content.
+  fs.writeFileSync(Path.join(grokDir, "updates.jsonl"), "not-json updates content\n");
+
+  return { cursorTranscript, grokUpdates: Path.join(grokDir, "updates.jsonl") };
+}
+
+test("Cursor Agent and Grok Build are observed-only and excluded from exact totals", async () => {
+  const home = tempHome();
+  const paths = observedFixture(home);
+  const report = await buildReport(defaultOptions({ home, source: "all", progress: false }));
+
+  assert.equal(report.total.requests, 0);
+  assert.equal(report.total.input, 0);
+  assert.equal(report.total.output, 0);
+  assert.equal(report.total.costUsd, 0);
+  assert.deepEqual(report.agents, {});
+  assert.deepEqual(report.serviceModes, {});
+  assert.equal(report.sessions.length, 2);
+
+  const cursor = report.sessions.find((session) => session.path === fs.realpathSync(paths.cursorTranscript));
+  assert.ok(cursor);
+  assert.deepEqual(cursor.stats.observation, {
+    agent: "cursor-agent",
+    provider: "cursor",
+    model: "(unknown model)",
+    project: "tokenomics-project",
+    measurement: "observed-only",
+    exactUsageAvailable: false,
+    sourceTimestamp: "2026-07-20T01:02:03.000Z",
+    sourceTimestampProvenance: "fileModifiedAt",
+  });
+
+  const grok = report.sessions.find((session) => session.path === fs.realpathSync(paths.grokUpdates));
+  assert.ok(grok);
+  assert.deepEqual(grok.stats.observation, {
+    agent: "grok-build",
+    provider: "grok",
+    model: "grok-4.20-0309-non-reasoning",
+    project: "/tmp/grok-project",
+    measurement: "observed-only",
+    exactUsageAvailable: false,
+    sourceTimestamp: "2026-07-21T01:04:05.000Z",
+    sourceTimestampProvenance: "summary.updated_at",
+    contextTokens: 65432,
+    contextWindowTokens: 128000,
+  });
+  assert.equal(grok.lines, 0);
+  assert.equal(grok.records, 0);
+});
+
+test("observed metadata survives SQLite stats_json persistence", async () => {
+  const home = tempHome();
+  observedFixture(home);
+  const db = Path.join(home, "tokenomics.sqlite");
+  const options = defaultOptions({ home, source: "all", db, progress: false });
+  const synced = await syncDatabase(options);
+  const reloaded = buildReportFromDatabase(db, options);
+  assert.equal(synced.total.requests, 0);
+  assert.equal(reloaded.total.requests, 0);
+  assert.equal(reloaded.sessions.length, 2);
+  assert.equal(reloaded.sessions.every((session) => session.stats.observation?.measurement === "observed-only"), true);
+  assert.equal(reloaded.sessions.find((session) => session.stats.observation?.agent === "grok-build").stats.observation.contextTokens, 65432);
+});
+
+test("dashboard exposes observed harness coverage without usage totals", async () => {
+  const home = tempHome();
+  observedFixture(home);
+  const report = await buildReport(defaultOptions({ home, source: "all", progress: false }));
+  const summary = webSummary(report, defaultOptions({ now: new Date("2026-07-22T00:00:00.000Z") }));
+  assert.equal(summary.total.requests, 0);
+  assert.equal(summary.observedHarnesses.length, 2);
+  assert.deepEqual(summary.observedHarnesses.map((row) => row.agent).sort(), ["cursor-agent", "grok-build"]);
+  assert.equal(summary.observedHarnesses.every((row) => row.measurement === "observed-only" && row.exactUsageAvailable === false), true);
+  assert.match(require("../lib/dashboard").dashboardHtml(), /Observed Harness Coverage/);
+  assert.match(require("../lib/dashboard").dashboardHtml(), /usage unavailable/i);
+});
+
+test("malformed observed metadata is isolated in lenient mode and strict mode throws", async () => {
+  const home = tempHome();
+  const badDir = Path.join(home, ".grok", "sessions", "%2Ftmp%2Fbad", "bad-session");
+  fs.mkdirSync(badDir, { recursive: true });
+  fs.writeFileSync(Path.join(badDir, "summary.json"), "{not-json\n");
+  fs.writeFileSync(Path.join(badDir, "updates.jsonl"), "unused\n");
+  const good = Path.join(home, ".cursor", "projects", "good", "agent-transcripts", "session.jsonl");
+  fs.mkdirSync(Path.dirname(good), { recursive: true });
+  fs.writeFileSync(good, "unused\n");
+
+  const lenient = await buildReport(defaultOptions({ home, source: "all", progress: false }));
+  assert.equal(lenient.total.requests, 0);
+  assert.ok(lenient.sources.parseErrors >= 1);
+  assert.ok(lenient.sessions.some((session) => session.path.endsWith("bad-session/updates.jsonl") && session.parseErrors >= 1));
+  await assert.rejects(
+    () => buildReport(defaultOptions({ home, source: "all", strictJson: true, progress: false })),
+    /Invalid JSON|Malformed JSON|Unexpected token/,
+  );
+});
+
+test("observed model names containing fast do not create service modes", async () => {
+  const home = tempHome();
+  const grokDir = Path.join(home, ".grok", "sessions", "%2Ftmp%2Ffast-project", "fast-session");
+  writeJson(Path.join(grokDir, "summary.json"), {
+    info: { id: "fast-session", cwd: "/tmp/fast-project" },
+    updated_at: "2026-07-21T01:04:05.000Z",
+    current_model_id: "grok-fast",
+  });
+  fs.writeFileSync(Path.join(grokDir, "updates.jsonl"), "unused\n");
+  const report = await buildReport(defaultOptions({ home, source: "grok", progress: false }));
+  assert.equal(report.total.requests, 0);
+  assert.deepEqual(report.serviceModes, {});
+  assert.equal(report.sessions[0].stats.observation.model, "grok-fast");
+});

--- a/test/opencode.test.js
+++ b/test/opencode.test.js
@@ -1,0 +1,188 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const Path = require("node:path");
+const test = require("node:test");
+const { DatabaseSync } = require("node:sqlite");
+
+const { newReport, newStats } = require("../lib/core/report-model");
+const {
+  discoverOpenCodeInputs,
+  isOpenCodeDbPath,
+  processOpenCodeDb,
+} = require("../lib/ingest/opencode");
+
+function tempHome() {
+  return fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-opencode-"));
+}
+
+function sessionFor(file) {
+  return {
+    kind: "db",
+    path: file,
+    lines: 0,
+    records: 0,
+    parseErrors: 0,
+    stats: newStats(),
+  };
+}
+
+function options(extra = {}) {
+  return {
+    strictJson: false,
+    openaiContext: "short",
+    ...extra,
+  };
+}
+
+function createDb(file, setup) {
+  fs.mkdirSync(Path.dirname(file), { recursive: true });
+  const db = new DatabaseSync(file);
+  db.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      parent_id TEXT,
+      directory TEXT,
+      title TEXT,
+      time_created INTEGER,
+      time_archived INTEGER
+    );
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      time_created INTEGER,
+      data TEXT NOT NULL
+    );
+  `);
+  setup(db);
+  db.close();
+}
+
+function addSession(db, id, parentId, directory, archived = null) {
+  db.prepare(
+    "INSERT INTO session(id, parent_id, directory, title, time_created, time_archived) VALUES (?, ?, ?, ?, ?, ?)",
+  ).run(id, parentId, directory, id, 1_700_000_000_000, archived);
+}
+
+test("discovers opencode*.db under the default data root and recognizes explicit DB paths", async () => {
+  const home = tempHome();
+  const root = Path.join(home, ".local", "share", "opencode");
+  fs.mkdirSync(root, { recursive: true });
+  fs.writeFileSync(Path.join(root, "opencode.db"), "");
+  fs.writeFileSync(Path.join(root, "opencode-work.db"), "");
+  fs.writeFileSync(Path.join(root, "other.db"), "");
+  fs.writeFileSync(Path.join(root, "opencode.db-wal"), "");
+
+  const inputs = await discoverOpenCodeInputs(home);
+  assert.deepEqual(inputs.map((input) => input.path), [
+    Path.join(root, "opencode-work.db"),
+    Path.join(root, "opencode.db"),
+  ].sort());
+  assert.ok(inputs.every((input) => input.adapter === "opencode"));
+  assert.equal(isOpenCodeDbPath("/tmp/custom/opencode-copy.db"), true);
+  assert.equal(isOpenCodeDbPath("/tmp/custom/opencode-copy.db-wal"), false);
+  assert.equal(isOpenCodeDbPath("/tmp/custom/session.jsonl"), false);
+});
+
+test("reads model-role messages from top-level active sessions, uses providerID, and reprices tokens", () => {
+  const home = tempHome();
+  const file = Path.join(home, "opencode.db");
+  createDb(file, (db) => {
+    addSession(db, "top", null, "/tmp/top");
+    addSession(db, "child", "top", "/tmp/child");
+    addSession(db, "archived", null, "/tmp/archived", 1_700_000_000_001);
+    const insert = db.prepare("INSERT INTO message(id, session_id, time_created, data) VALUES (?, ?, ?, ?)");
+    insert.run("m-top", "top", 1_700_000_000_100, JSON.stringify({
+      role: "model",
+      providerID: "anthropic",
+      modelID: "claude-opus-4-8",
+      cost: 999,
+      tokens: { input: 10, output: 20, reasoning: 3, cache: { read: 4, write: 5 } },
+    }));
+    insert.run("m-child", "child", 1_700_000_000_101, JSON.stringify({
+      role: "assistant", providerID: "child", modelID: "child-model",
+      tokens: { input: 100, output: 100, reasoning: 0, cache: { read: 0, write: 0 } },
+    }));
+    insert.run("m-archived", "archived", 1_700_000_000_102, JSON.stringify({
+      role: "assistant", providerID: "archived", modelID: "archived-model",
+      tokens: { input: 100, output: 100, reasoning: 0, cache: { read: 0, write: 0 } },
+    }));
+  });
+
+  const report = newReport();
+  const session = sessionFor(file);
+  processOpenCodeDb(file, report, options(), session);
+
+  assert.equal(session.kind, "db");
+  assert.equal(report.total.requests, 1);
+  const event = report._usageEvents[0];
+  assert.equal(event.provider, "anthropic");
+  assert.equal(event.agent, "opencode");
+  assert.equal(event.model, "claude-opus-4-8");
+  assert.equal(event.serviceMode, "unknown");
+  assert.deepEqual(event.usage, {
+    input: 10,
+    cacheCreate5m: 5,
+    cacheCreate30m: 0,
+    cacheCreate1h: 0,
+    cacheRead: 4,
+    output: 20,
+    reasoningOutput: 3,
+    contextWindow: 0,
+    inputIncludesCacheRead: false,
+  });
+  assert.notEqual(event.cost.amount, 999);
+  assert.equal(event.cost.known, true);
+});
+
+test("does not infer fast service mode from an OpenCode model name", () => {
+  const home = tempHome();
+  const file = Path.join(home, "opencode.db");
+  createDb(file, (db) => {
+    addSession(db, "top", null, "/tmp/top");
+    db.prepare("INSERT INTO message(id, session_id, time_created, data) VALUES (?, ?, ?, ?)").run(
+      "m-fast",
+      "top",
+      1_700_000_000_100,
+      JSON.stringify({
+        role: "assistant",
+        providerID: "anthropic",
+        modelID: "claude-opus-4-8-fast",
+        tokens: { input: 1, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+      }),
+    );
+  });
+
+  const report = newReport();
+  processOpenCodeDb(file, report, options(), sessionFor(file));
+  assert.equal(report._usageEvents[0].serviceMode, "unknown");
+  assert.equal(report._usageEvents[0].cost.amount, 0.00003);
+});
+
+test("isolates malformed message data in lenient mode and throws in strict mode", () => {
+  const home = tempHome();
+  const file = Path.join(home, "opencode.db");
+  createDb(file, (db) => {
+    addSession(db, "top", null, "/tmp/top");
+    const insert = db.prepare("INSERT INTO message(id, session_id, time_created, data) VALUES (?, ?, ?, ?)");
+    insert.run("m-bad", "top", 1_700_000_000_100, "{not-json");
+    insert.run("m-good", "top", 1_700_000_000_101, JSON.stringify({
+      role: "assistant", providerID: "unknown-provider", modelID: "unknown-model",
+      tokens: { input: 2, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+    }));
+  });
+
+  const lenientReport = newReport();
+  const lenientSession = sessionFor(file);
+  processOpenCodeDb(file, lenientReport, options(), lenientSession);
+  assert.equal(lenientReport.total.requests, 1);
+  assert.equal(lenientReport.sources.parseErrors, 1);
+  assert.equal(lenientSession.parseErrors, 1);
+
+  assert.throws(
+    () => processOpenCodeDb(file, newReport(), options({ strictJson: true }), sessionFor(file)),
+    /Malformed OpenCode|Invalid JSON|Unexpected token/,
+  );
+});

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -248,6 +248,10 @@ test("tracks thread_settings_applied service-tier transitions per Codex thread",
   assert.equal(report._usageEvents.length, 2);
   assert.equal(report._usageEvents[0].serviceTier, "priority");
   assert.equal(report._usageEvents[1].serviceTier, "default");
+  assert.equal(report._usageEvents[0].serviceMode, "fast");
+  assert.equal(report._usageEvents[1].serviceMode, "standard");
+  assert.equal(report._usageEvents[0].agent, "codex");
+  assert.equal(report._usageEvents[1].agent, "codex");
   assert.equal(report._usageEvents[0].cost.amount, 8.75, "priority Sol uses 2.5x standard short pricing");
   assert.equal(report._usageEvents[1].cost.amount, 3.5, "default Sol uses standard short pricing");
   assert.equal(report.total.costUsd, 12.25);
@@ -318,6 +322,45 @@ test("forked child without an explicit tier does not inherit parent priority pri
   assert.equal(report.total.requests, 1);
   assert.equal(report._usageEvents[0].cost.amount, 3.5, "missing child tier must remain standard");
   assert.notEqual(report._usageEvents[0].serviceTier, "priority");
+  assert.equal(report._usageEvents[0].serviceMode, "unknown");
+});
+
+test("Claude speed and service_tier metadata stay separate per request", () => {
+  const report = newReport();
+  const processLine = createLineProcessor(report, defaultOptions(), "claude-mode-fixture");
+  const line = (speed, requestId, service_tier) => JSON.stringify({
+    type: "assistant",
+    timestamp: "2026-07-26T00:00:00.000Z",
+    requestId,
+    cwd: "/tmp/claude-mode",
+    message: {
+      model: "claude-opus-4-8",
+      usage: { input_tokens: 1_000_000, output_tokens: 1, speed, service_tier },
+    },
+  });
+
+  processLine(line("fast", "req-fast"), 1);
+  processLine(line("normal", "req-normal"), 2);
+  processLine(line(undefined, "req-missing"), 3);
+  processLine(line("invalid", "req-invalid"), 4);
+  processLine(line("standard", "req-priority-tier", "priority"), 5);
+
+  assert.deepEqual(report._usageEvents.map((event) => ({
+    serviceTier: event.serviceTier,
+    serviceMode: event.serviceMode,
+    agent: event.agent,
+  })), [
+    { serviceTier: "unknown", serviceMode: "fast", agent: "claude-code" },
+    { serviceTier: "unknown", serviceMode: "standard", agent: "claude-code" },
+    { serviceTier: "unknown", serviceMode: "unknown", agent: "claude-code" },
+    { serviceTier: "unknown", serviceMode: "unknown", agent: "claude-code" },
+    { serviceTier: "priority", serviceMode: "standard", agent: "claude-code" },
+  ]);
+  assert.equal(
+    report._usageEvents[4].cost.amount,
+    report._usageEvents[1].cost.amount,
+    "Anthropic priority service_tier must not imply fast pricing",
+  );
 });
 
 test("omp malformed JSON is counted in lenient mode and rejected in strict mode", async () => {

--- a/test/pricing-usage.test.js
+++ b/test/pricing-usage.test.js
@@ -951,6 +951,44 @@ test("OpenAI priority service tier applies the model-specific fast multiplier", 
   }
 });
 
+test("Anthropic fast pricing is limited to the supported Opus 4.8 catalog entry", () => {
+  const usageValue = simpleUsage(1_000_000, 1_000_000);
+  const date = new Date("2026-07-26T00:00:00.000Z");
+  const standard = pricing.calculateCost("anthropic", "claude-opus-4-8", usageValue, date, {
+    pricingBasis: "standard",
+    serviceMode: "standard",
+  });
+  const fast = pricing.calculateCost("anthropic", "claude-opus-4-8", usageValue, date, {
+    pricingBasis: "standard",
+    serviceMode: "fast",
+  });
+  const unsupported = pricing.calculateCost("anthropic", "claude-sonnet-4-6", usageValue, date, {
+    pricingBasis: "standard",
+    serviceMode: "fast",
+  });
+  assert.equal(standard.amount, 30);
+  assert.equal(fast.amount, 60);
+  assert.equal(unsupported.amount, 18);
+});
+
+test("Anthropic fast mode does not apply packaged multiplier to custom pricing", () => {
+  const usageValue = simpleUsage(1_000_000, 1_000_000);
+  const custom = pricing.calculateCost("anthropic", "claude-opus-4-8", usageValue, new Date("2026-07-26T00:00:00.000Z"), {
+    pricingBasis: "custom",
+    serviceMode: "fast",
+    pricingCatalog: [{
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      variant: "standard",
+      matchMode: "prefix",
+      input: 1,
+      output: 2,
+      cacheRead: 0.1,
+    }],
+  });
+  assert.equal(custom.amount, 3);
+});
+
 test("missing or unknown OpenAI service tiers stay at standard pricing", () => {
   const usageValue = simpleUsage(100_000, 100_000);
   const date = new Date("2026-07-10T00:00:00.000Z");

--- a/test/pricing-usage.test.js
+++ b/test/pricing-usage.test.js
@@ -951,14 +951,25 @@ test("OpenAI priority service tier applies the model-specific fast multiplier", 
   }
 });
 
-test("Anthropic fast pricing is limited to the supported Opus 4.8 catalog entry", () => {
+test("Anthropic Opus 5 and Opus 4.8 share standard and fast pricing", () => {
   const usageValue = simpleUsage(1_000_000, 1_000_000);
+  usageValue.cacheCreate5m = 1_000_000;
+  usageValue.cacheCreate1h = 1_000_000;
+  usageValue.cacheRead = 1_000_000;
   const date = new Date("2026-07-26T00:00:00.000Z");
-  const standard = pricing.calculateCost("anthropic", "claude-opus-4-8", usageValue, date, {
+  const standard48 = pricing.calculateCost("anthropic", "claude-opus-4-8", usageValue, date, {
     pricingBasis: "standard",
     serviceMode: "standard",
   });
-  const fast = pricing.calculateCost("anthropic", "claude-opus-4-8", usageValue, date, {
+  const fast48 = pricing.calculateCost("anthropic", "claude-opus-4-8", usageValue, date, {
+    pricingBasis: "standard",
+    serviceMode: "fast",
+  });
+  const standard5 = pricing.calculateCost("anthropic", "claude-opus-5", usageValue, date, {
+    pricingBasis: "standard",
+    serviceMode: "standard",
+  });
+  const fast5 = pricing.calculateCost("anthropic", "claude-opus-5", usageValue, date, {
     pricingBasis: "standard",
     serviceMode: "fast",
   });
@@ -966,9 +977,15 @@ test("Anthropic fast pricing is limited to the supported Opus 4.8 catalog entry"
     pricingBasis: "standard",
     serviceMode: "fast",
   });
-  assert.equal(standard.amount, 30);
-  assert.equal(fast.amount, 60);
-  assert.equal(unsupported.amount, 18);
+  const unsupportedStandard = pricing.calculateCost("anthropic", "claude-sonnet-4-6", usageValue, date, {
+    pricingBasis: "standard",
+    serviceMode: "standard",
+  });
+  assert.equal(standard48.amount, 46.75);
+  assert.equal(fast48.amount, 93.5);
+  assert.equal(standard5.amount, standard48.amount);
+  assert.equal(fast5.amount, fast48.amount);
+  assert.equal(unsupported.amount, unsupportedStandard.amount);
 });
 
 test("Anthropic fast mode does not apply packaged multiplier to custom pricing", () => {

--- a/test/service-mode.test.js
+++ b/test/service-mode.test.js
@@ -1,0 +1,53 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const {
+  CLAUDE_CODE_AGENT,
+  CODEX_AGENT,
+  FAST_SERVICE_MODE,
+  GEMINI_AGENT,
+  OPENCODE_AGENT,
+  OMP_AGENT,
+  PI_AGENT,
+  QWEN_AGENT,
+  STANDARD_SERVICE_MODE,
+  UNKNOWN_AGENT,
+  UNKNOWN_SERVICE_MODE,
+  agentFromProvider,
+  normalizeAgent,
+  serviceModeFromClaudeSpeed,
+  serviceModeFromCodexTier,
+} = require("../lib/core/service-mode");
+
+test("Claude speed metadata maps fast, standard, and normal without guessing", () => {
+  assert.equal(serviceModeFromClaudeSpeed("fast"), FAST_SERVICE_MODE);
+  assert.equal(serviceModeFromClaudeSpeed("standard"), STANDARD_SERVICE_MODE);
+  assert.equal(serviceModeFromClaudeSpeed("normal"), STANDARD_SERVICE_MODE);
+  assert.equal(serviceModeFromClaudeSpeed(undefined), UNKNOWN_SERVICE_MODE);
+  assert.equal(serviceModeFromClaudeSpeed("turbo"), UNKNOWN_SERVICE_MODE);
+});
+
+test("Codex service tiers map to analytics mode while preserving unknown values", () => {
+  assert.equal(serviceModeFromCodexTier("priority"), FAST_SERVICE_MODE);
+  assert.equal(serviceModeFromCodexTier("default"), STANDARD_SERVICE_MODE);
+  assert.equal(serviceModeFromCodexTier("standard"), STANDARD_SERVICE_MODE);
+  assert.equal(serviceModeFromCodexTier(undefined), UNKNOWN_SERVICE_MODE);
+  assert.equal(serviceModeFromCodexTier("future-tier"), UNKNOWN_SERVICE_MODE);
+});
+
+test("agent normalization preserves supported harness dimensions and explicit slugs", () => {
+  assert.equal(agentFromProvider("openai"), CODEX_AGENT);
+  assert.equal(agentFromProvider("anthropic"), CLAUDE_CODE_AGENT);
+  assert.equal(agentFromProvider("omp"), OMP_AGENT);
+  assert.equal(agentFromProvider("pi"), PI_AGENT);
+  assert.equal(agentFromProvider("gemini"), GEMINI_AGENT);
+  assert.equal(agentFromProvider("qwen"), QWEN_AGENT);
+  assert.equal(agentFromProvider("opencode"), OPENCODE_AGENT);
+  assert.equal(agentFromProvider("future-provider"), UNKNOWN_AGENT);
+
+  assert.equal(normalizeAgent(undefined, "openai"), CODEX_AGENT);
+  assert.equal(normalizeAgent(" Custom-Harness ", "openai"), "custom-harness");
+  assert.equal(normalizeAgent("unknown", "openai"), UNKNOWN_AGENT);
+  assert.equal(normalizeAgent("not a slug", "openai"), UNKNOWN_AGENT);
+});

--- a/test/sqlite.test.js
+++ b/test/sqlite.test.js
@@ -77,6 +77,30 @@ test("SQLite adds service_tier to an existing usage_events table", () => {
   }
 });
 
+test("SQLite adds service_mode and agent to an existing usage_events table", () => {
+  const tmp = fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-service-mode-migration-test-"));
+  const dbPath = Path.join(tmp, "tokenomics.sqlite");
+  const backend = createSqliteBackend();
+  backend.buildReportFromDatabase(dbPath, defaultOptions());
+
+  const legacy = new DatabaseSync(dbPath);
+  legacy.exec("ALTER TABLE usage_events DROP COLUMN service_mode");
+  legacy.exec("ALTER TABLE usage_events DROP COLUMN agent");
+  legacy.close();
+
+  backend.buildReportFromDatabase(dbPath, defaultOptions());
+  const migrated = new DatabaseSync(dbPath);
+  try {
+    const columns = migrated.prepare("SELECT name, dflt_value FROM pragma_table_info('usage_events') WHERE name IN ('service_mode', 'agent') ORDER BY name").all();
+    assert.deepEqual(columns.map((column) => ({ ...column })), [
+      { name: "agent", dflt_value: "'unknown'" },
+      { name: "service_mode", dflt_value: "'unknown'" },
+    ]);
+  } finally {
+    migrated.close();
+  }
+});
+
 test("SQLite fork pre-scan excludes unchanged sources", async () => {
   const tmp = fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-sqlite-prescan-test-"));
   const jsonl = Path.join(tmp, "session.jsonl");
@@ -476,6 +500,16 @@ test("SQLite round-trip preserves raw report key totals", async () => {
   assert.deepEqual(Object.keys(stored.models), Object.keys(raw.models));
   assert.deepEqual(Object.keys(stored.projects), Object.keys(raw.projects));
   assert.deepEqual(stored.providerModelEffortDaily, raw.providerModelEffortDaily);
+  assert.equal(stored.serviceTiers.unknown.requests, 1);
+  assert.equal(stored.agents.codex.requests, 1);
+  assert.equal(stored.serviceModes.unknown.requests, 1);
+  const rows = new DatabaseSync(db);
+  try {
+    const row = rows.prepare("SELECT service_tier, service_mode, agent FROM usage_events").get();
+    assert.deepEqual({ ...row }, { service_tier: "unknown", service_mode: "unknown", agent: "codex" });
+  } finally {
+    rows.close();
+  }
 });
 
 test("changed source replacement removes dependent SQLite rows", async () => {


### PR DESCRIPTION
## What changed

- Add exact ingestion adapters for Claude Code/Desktop, Pi, Gemini CLI, Qwen Code, and OpenCode.
- Add conservative observed-only coverage for Cursor Agent and Grok Build without including unverifiable token or cost totals.
- Persist canonical `standard`, `fast`, and `unknown` service modes separately from harness/agent, billing provider, and provider-specific service tiers.
- Expose service-mode and observed-harness breakdowns in SQLite, ClickHouse, reports, and the dashboard.
- Add Claude Opus 5 at the Opus 4.8 standard/cache prices and apply the same verified 2x Fast tariff.
- Upgrade packaged pricing to revision 3 and migrate existing ClickHouse catalogs with marker-last, retry-safe overlays so historical usage is repriced without transcript reimport.
- Document supported formats, observed-only boundaries, and falsifiers in `docs/HARNESS_FORMAT_FRONTIER.md`.

## Why

The previous ingestion path covered only a narrow set of harness formats and did not consistently preserve execution speed as a first-class dimension. That could collapse Standard and Fast usage into one total, confuse provider tiers with harness modes, and leave new models such as `claude-opus-5` unpriced.

The new adapters keep exact and observed-only evidence separate, retain unknown modes instead of guessing, and make pricing updates database-local rather than forcing source recache.

## User impact

Users can compare Standard and Fast usage distinctly, inspect sessions from more local coding harnesses, and price Claude Opus 5 consistently with Opus 4.8. Cursor and Grok sessions are visible as coverage metadata but remain excluded from exact cost totals until their token semantics are verified.

## Validation

- `npm test` — 245/245 tests pass.
- `node --check` passes for changed production modules.
- `git diff --check` passes.
- Local probes observed exact Gemini/Qwen/Claude/OpenCode semantics and kept Cursor/Grok totals at zero.
- 22 local Claude Opus 5 Standard requests price successfully; Fast pricing is covered by unit and ClickHouse projection tests.
- ClickHouse migration tests cover marker-last publication, failure safety, and idempotent repeat startup.