### PR TITLE
Fix ClickHouse rate-limit repricing startup

### DIFF
--- a/lib/storage/clickhouse.js
+++ b/lib/storage/clickhouse.js
@@ -1215,6 +1215,7 @@ function createClickHouseBackend(dependencies = {}) {
     const rateDefinitions = clickHouseRepricedDefinitions("rate_limit_samples", "repriced_rate_limit_samples", configuration, {
       provider,
       serviceTier: "'unknown'",
+      serviceMode: "'unknown'",
       timestamp: "fromUnixTimestamp64Milli(toInt64(raw.timestamp_ms))",
       timestampIsDateTime: true,
       cacheCreate5m: "0",

--- a/test/clickhouse.test.js
+++ b/test/clickhouse.test.js
@@ -307,6 +307,9 @@ test("ClickHouse configuration revisions publish marker-last and reject stale wr
     const markerInsert = mock.requests.findLastIndex((request) => request.query.startsWith("INSERT INTO configuration_revisions"));
     assert.ok(settingsInsert >= 0 && pricingInsert > settingsInsert);
     assert.ok(usageOverlay > pricingInsert && rateLimitOverlay > usageOverlay && markerInsert > rateLimitOverlay);
+    const rateLimitOverlayQuery = mock.requests[rateLimitOverlay].query;
+    assert.doesNotMatch(rateLimitOverlayQuery, /raw\.service_mode/);
+    assert.match(rateLimitOverlayQuery, /'unknown' = 'fast'/);
     assert.ok(mock.requests.some((request) => request.query.includes("SELECT DISTINCT key, value_json")));
     assert.ok(mock.requests.some((request) => request.query.includes("SELECT DISTINCT *") && request.query.includes("FROM pricing_catalog")));
   });


### PR DESCRIPTION
## Summary

- fix launcher startup after the packaged pricing upgrade
- bind service mode to unknown when repricing rate-limit samples, whose schema does not store that dimension
- add a regression assertion for the generated rate-limit overlay SQL

## Root cause

The shared ClickHouse pricing projection began using service_mode for Anthropic fast pricing, while rate_limit_samples has no service_mode column. The packaged pricing migration executed that overlay during startup and ClickHouse rejected raw.service_mode with UNKNOWN_IDENTIFIER.

## Verification

- node --test — 245 passed, 0 failed
- focused ClickHouse tests — 22 passed, 0 failed
- launcher before/after on ClickHouse 26.7.1.448: exact Code 47 failure before; Tokenomics is ready after
- synthetic rate-limit pricing query via clickhouse local 26.6.1 — passed
- node --check and git diff --check — passed

## Skipped gates

- no repository build script exists
- CI pending after PR creation
- no production or mixed-version validation