### PR TITLE
Version GPT-5.6 Luna and Terra pricing by effective date

### DIFF
--- a/docs/PRICING_CONFIGURATION_FRONTIER.md
+++ b/docs/PRICING_CONFIGURATION_FRONTIER.md
@@ -16,7 +16,18 @@ manual derivation-version discipline.
 - SQLite and ClickHouse store the active analytics settings and structured
   pricing rows in backend-owned tables.
 - A packaged catalog seeds an empty database. Once seeded, the database copy is
-  authoritative for database-backed sync and report operations.
+  authoritative for database-backed sync and report operations, except for an
+  explicit managed packaged revision migration; custom and derived revisions
+  remain authoritative.
+- Packaged rows may be time-versioned with inclusive `effectiveFrom` and
+  `effectiveUntil` bounds. Event timestamps select the applicable row; the
+  GPT-5.6 Luna/Terra legacy rates end at `2026-07-29T23:59:59.999Z`, and the
+  current standard rates begin at `2026-07-30T00:00:00.000Z`.
+- A managed packaged revision upgrade promotes legacy timeless Luna/Terra rows
+  to the historical interval and appends the current interval in the database.
+  SQLite and ClickHouse perform this migration without rereading source bytes;
+  ClickHouse publishes cost overlays before its new revision marker. Custom and
+  derived revisions are not overwritten by this migration.
 - Direct scans without a database continue to use the packaged catalog.
 - Configuration reads return a revision. Writes require that revision and
   replace settings and prices atomically from the API consumer's perspective.
@@ -89,6 +100,9 @@ manual derivation-version discipline.
 6. Invalid, ambiguous, overlapping, or negative pricing rows fail closed.
 7. Backend parity is behavioral: SQLite and ClickHouse return the same normalized
    configuration and both reprice without invalidating source fingerprints.
+8. Time-versioned pricing is resolved per event timestamp; a packaged revision
+   change must preserve historical rates and apply current rates only at their
+   admitted boundary.
 
 ## Execution Order
 
@@ -102,6 +116,8 @@ manual derivation-version discipline.
 6. Reprice normalized database rows without opening source files. In ClickHouse,
    write usage and rate-limit cost overlays before the revision marker.
 7. Replace the in-process report cache after repricing; no Sync is required.
+8. For a managed packaged upgrade, migrate legacy boundedness in the database,
+   then publish the new normalized catalog and overlays without source reimport.
 
 ## Falsifier Roster
 
@@ -117,6 +133,10 @@ manual derivation-version discipline.
   rejected.
 - Configuration change: report costs change immediately, source fingerprints and
   import timestamps remain unchanged, and the next Sync reports no changed source.
+- Temporal packaged pricing: one millisecond before, exactly at, and after the
+  admitted boundary select the expected Luna/Terra rates for both short and long
+  contexts; managed SQLite/ClickHouse upgrades yield four historical and four
+  current rows per model without source reimport.
 - Legacy fingerprint: obsolete pricing fields are ignored without causing a
   one-time full reimport.
 - ClickHouse publication failure: a missing overlay or failed repricing query

--- a/lib/core/configuration.js
+++ b/lib/core/configuration.js
@@ -3,7 +3,7 @@
 const { createHash } = require("node:crypto");
 const { PRICING, PRICING_SOURCES } = require("./pricing");
 
-const PACKAGED_CONFIGURATION_REVISION = "packaged-3";
+const PACKAGED_CONFIGURATION_REVISION = "packaged-4";
 const ALLOWED_SETTINGS = new Set(["openaiContext", "pricingBasis", "pricingRevision", "regionalMultiplier", "monthlyCostLimitUsd", "usageProfile"]);
 const ALLOWED_MATCH_MODES = new Set(["snapshot", "prefix", "exact"]);
 const ALLOWED_VARIANTS = new Set(["standard", "short", "long"]);
@@ -17,6 +17,28 @@ function pricingRowId(row) {
     row.effectiveFrom || "",
     row.effectiveUntil || "",
   ].join(":");
+}
+
+function pricingRowKey(row) {
+  return `${row.provider}\u0000${row.model}\u0000${row.variant}`;
+}
+
+function migrateLegacyTimedPackagedRows(rows, packagedRows) {
+  const historicalRows = new Map();
+  for (const row of packagedRows) {
+    if (!row.effectiveUntil || row.effectiveFrom) continue;
+    const key = pricingRowKey(row);
+    const previous = historicalRows.get(key);
+    if (!previous || Date.parse(row.effectiveUntil) < Date.parse(previous.effectiveUntil)) {
+      historicalRows.set(key, row);
+    }
+  }
+  for (const row of rows) {
+    if (row.effectiveFrom || row.effectiveUntil) continue;
+    const historical = historicalRows.get(pricingRowKey(row));
+    if (!historical) continue;
+    Object.assign(row, historical);
+  }
 }
 
 function rowFromPrices(provider, model, variant, prices, extra = {}) {
@@ -45,9 +67,20 @@ function rowFromPrices(provider, model, variant, prices, extra = {}) {
 
 function packagedPricingRows() {
   const rows = [];
-  for (const [model, variants] of Object.entries(PRICING.openai.models)) {
-    for (const [variant, prices] of Object.entries(variants)) {
-      rows.push(rowFromPrices("openai", model, variant, prices));
+  for (const [model, entry] of Object.entries(PRICING.openai.models)) {
+    if (Array.isArray(entry)) {
+      for (const timed of entry) {
+        for (const [variant, prices] of Object.entries(timed.prices)) {
+          rows.push(rowFromPrices("openai", model, variant, prices, {
+            effectiveFrom: timed.from,
+            effectiveUntil: timed.until,
+          }));
+        }
+      }
+    } else {
+      for (const [variant, prices] of Object.entries(entry)) {
+        rows.push(rowFromPrices("openai", model, variant, prices));
+      }
     }
   }
   for (const [model, entry] of Object.entries(PRICING.anthropic.models)) {
@@ -216,6 +249,10 @@ function normalizeConfiguration(source = {}) {
     throw new Error("configuration prices must contain between 1 and 1000 rows");
   }
   const normalizedSourcePrices = source.prices.map(normalizePricingRow);
+  const packagedRows = packagedManagedPricing ? packagedPricingRows() : null;
+  if (packagedRows && requestedPricingRevision !== PACKAGED_CONFIGURATION_REVISION) {
+    migrateLegacyTimedPackagedRows(normalizedSourcePrices, packagedRows);
+  }
   const sourceIds = new Set();
   for (const row of normalizedSourcePrices) {
     if (sourceIds.has(row.id)) throw new Error(`duplicate pricing row: ${row.id}`);
@@ -223,7 +260,7 @@ function normalizeConfiguration(source = {}) {
   }
   if (packagedManagedPricing) {
     const rowsById = new Map(normalizedSourcePrices.map((row) => [row.id, row]));
-    for (const [index, sourceRow] of packagedPricingRows().entries()) {
+    for (const [index, sourceRow] of packagedRows.entries()) {
       const row = normalizePricingRow(sourceRow, normalizedSourcePrices.length + index);
       if (!rowsById.has(row.id)) rowsById.set(row.id, row);
     }

--- a/lib/core/pricing.js
+++ b/lib/core/pricing.js
@@ -54,14 +54,38 @@ const PRICING = {
         short: { input: 5.00, cacheCreate30m: 6.25, cachedInput: 0.50, output: 30.00 },
         long: { input: 10.00, cacheCreate30m: 12.50, cachedInput: 1.00, output: 45.00 },
       },
-      "gpt-5.6-terra": {
-        short: { input: 2.00, cacheCreate30m: 2.50, cachedInput: 0.20, output: 12.00 },
-        long: { input: 4.00, cacheCreate30m: 5.00, cachedInput: 0.40, output: 18.00 },
-      },
-      "gpt-5.6-luna": {
-        short: { input: 0.20, cacheCreate30m: 0.25, cachedInput: 0.02, output: 1.20 },
-        long: { input: 0.40, cacheCreate30m: 0.50, cachedInput: 0.04, output: 1.80 },
-      },
+      "gpt-5.6-terra": [
+        {
+          until: "2026-07-29T23:59:59.999Z",
+          prices: {
+            short: { input: 2.50, cacheCreate30m: 3.125, cachedInput: 0.25, output: 15.00 },
+            long: { input: 5.00, cacheCreate30m: 6.25, cachedInput: 0.50, output: 22.50 },
+          },
+        },
+        {
+          from: "2026-07-30T00:00:00.000Z",
+          prices: {
+            short: { input: 2.00, cacheCreate30m: 2.50, cachedInput: 0.20, output: 12.00 },
+            long: { input: 4.00, cacheCreate30m: 5.00, cachedInput: 0.40, output: 18.00 },
+          },
+        },
+      ],
+      "gpt-5.6-luna": [
+        {
+          until: "2026-07-29T23:59:59.999Z",
+          prices: {
+            short: { input: 1.00, cacheCreate30m: 1.25, cachedInput: 0.10, output: 6.00 },
+            long: { input: 2.00, cacheCreate30m: 2.50, cachedInput: 0.20, output: 9.00 },
+          },
+        },
+        {
+          from: "2026-07-30T00:00:00.000Z",
+          prices: {
+            short: { input: 0.20, cacheCreate30m: 0.25, cachedInput: 0.02, output: 1.20 },
+            long: { input: 0.40, cacheCreate30m: 0.50, cachedInput: 0.04, output: 1.80 },
+          },
+        },
+      ],
       "gpt-5.5-pro": {
         short: { input: 30.00, cachedInput: null, output: 180.00 },
         long: { input: 60.00, cachedInput: null, output: 270.00 },
@@ -187,22 +211,23 @@ const PRICING = {
   },
 };
 
-function lookupAnthropicPrices(model, timestamp) {
-  const normalized = normalizeModel(model);
-  const names = Object.keys(PRICING.anthropic.models).sort((a, b) => b.length - a.length);
-  const key = names.find((name) => normalized === name || normalized.startsWith(`${name}-`));
-  if (!key) return null;
-
-  const entry = PRICING.anthropic.models[key];
+function resolveTimedPricingEntry(entry, timestamp) {
   if (!Array.isArray(entry)) return entry;
-
   const ts = isValidDate(timestamp) ? timestamp.getTime() : Date.now();
   for (const timed of entry) {
     const from = timed.from ? Date.parse(timed.from) : Number.NEGATIVE_INFINITY;
     const until = timed.until ? Date.parse(timed.until) : Number.POSITIVE_INFINITY;
     if (ts >= from && ts <= until) return timed.prices;
   }
-  return entry[entry.length - 1].prices;
+  return entry.at(-1)?.prices || null;
+}
+
+function lookupAnthropicPrices(model, timestamp) {
+  const normalized = normalizeModel(model);
+  const names = Object.keys(PRICING.anthropic.models).sort((a, b) => b.length - a.length);
+  const key = names.find((name) => normalized === name || normalized.startsWith(`${name}-`));
+  if (!key) return null;
+  return resolveTimedPricingEntry(PRICING.anthropic.models[key], timestamp);
 }
 
 function lookupOmpPrices(model, timestamp) {
@@ -210,23 +235,16 @@ function lookupOmpPrices(model, timestamp) {
   const names = Object.keys(PRICING.omp.models).sort((a, b) => b.length - a.length);
   const key = names.find((name) => normalized === name || normalized.startsWith(`${name}-`));
   if (!key) return null;
-  const entry = PRICING.omp.models[key];
-  if (!Array.isArray(entry)) return entry;
-  const ts = isValidDate(timestamp) ? timestamp.getTime() : Date.now();
-  for (const timed of entry) {
-    const from = timed.from ? Date.parse(timed.from) : Number.NEGATIVE_INFINITY;
-    const until = timed.until ? Date.parse(timed.until) : Number.POSITIVE_INFINITY;
-    if (ts >= from && ts <= until) return timed.prices;
-  }
-  return entry[entry.length - 1].prices;
+  return resolveTimedPricingEntry(PRICING.omp.models[key], timestamp);
 }
 
-function lookupOpenAIPrices(model, usage, options = {}) {
+function lookupOpenAIPrices(model, usage, options = {}, timestamp = null) {
   const normalized = normalizeModel(model);
   const names = Object.keys(PRICING.openai.models).sort((a, b) => b.length - a.length);
   const key = names.find((name) => isOpenAIModelPriceMatch(normalized, name));
   if (!key) return null;
-  const entry = PRICING.openai.models[key];
+  const entry = resolveTimedPricingEntry(PRICING.openai.models[key], timestamp);
+  if (!entry) return null;
 
   const mode = options.openaiContext;
   const hasLong = Boolean(entry.long);
@@ -386,7 +404,7 @@ function calculateCost(provider, model, usage, timestamp, options = {}) {
     const packagedAutoReviewFallback = options.pricingBasis !== "custom" &&
       isOpenAIModelPriceMatch(normalizeModel(model), "codex-auto-review");
     const allowPackagedFallback = !Array.isArray(options.pricingCatalog) || packagedAutoReviewFallback;
-    const prices = allowPackagedFallback ? lookupOpenAIPrices(model, normalizedUsage, options) : null;
+    const prices = allowPackagedFallback ? lookupOpenAIPrices(model, normalizedUsage, options, timestamp) : null;
     if (!prices) return { known: false, amount: 0, breakdown: newCostBreakdown(), reasoningAmount: 0 };
     const cachedInputPrice = prices.cachedInput ?? prices.input;
     const breakdown = applyCostMultiplier({

--- a/lib/core/pricing.js
+++ b/lib/core/pricing.js
@@ -55,12 +55,12 @@ const PRICING = {
         long: { input: 10.00, cacheCreate30m: 12.50, cachedInput: 1.00, output: 45.00 },
       },
       "gpt-5.6-terra": {
-        short: { input: 2.50, cacheCreate30m: 3.125, cachedInput: 0.25, output: 15.00 },
-        long: { input: 5.00, cacheCreate30m: 6.25, cachedInput: 0.50, output: 22.50 },
+        short: { input: 2.00, cacheCreate30m: 2.50, cachedInput: 0.20, output: 12.00 },
+        long: { input: 4.00, cacheCreate30m: 5.00, cachedInput: 0.40, output: 18.00 },
       },
       "gpt-5.6-luna": {
-        short: { input: 1.00, cacheCreate30m: 1.25, cachedInput: 0.10, output: 6.00 },
-        long: { input: 2.00, cacheCreate30m: 2.50, cachedInput: 0.20, output: 9.00 },
+        short: { input: 0.20, cacheCreate30m: 0.25, cachedInput: 0.02, output: 1.20 },
+        long: { input: 0.40, cacheCreate30m: 0.50, cachedInput: 0.04, output: 1.80 },
       },
       "gpt-5.5-pro": {
         short: { input: 30.00, cachedInput: null, output: 180.00 },

--- a/lib/storage/clickhouse.js
+++ b/lib/storage/clickhouse.js
@@ -616,9 +616,9 @@ function createClickHouseBackend(dependencies = {}) {
       revision: upgradeRevision,
       settings: {
         ...configuration.settings,
-        // Derive a unique packaged-3 pricing revision for this append-only
-        // migration. Retries and concurrent starters then write disjoint
-        // overlay keys instead of duplicating rows under plain `packaged-3`.
+        // Derive a unique pricing revision for this append-only migration.
+        // Retries and concurrent starters then write disjoint overlay keys
+        // instead of duplicating rows under the packaged revision.
         pricingRevision: upgradeRevision,
       },
     });

--- a/lib/storage/sqlite.js
+++ b/lib/storage/sqlite.js
@@ -32,6 +32,7 @@ const { calculateCost, normalizeServiceTier } = require("../core/pricing");
 const { normalizeAgent, normalizeServiceMode } = require("../core/service-mode");
 const { sameSourceFingerprint, sourceFingerprint } = require("../core/derivation");
 const {
+  PACKAGED_CONFIGURATION_REVISION,
   defaultConfiguration,
   normalizeConfiguration,
   pricingConfigurationSignature,
@@ -282,6 +283,15 @@ function createSqliteBackend(dependencies = {}) {
     `).get() || null;
   }
 
+  function storedSqlitePricingRevision(db, revision) {
+    const row = db.prepare(`
+      SELECT value_json
+      FROM analytics_settings
+      WHERE revision = ? AND key = 'pricingRevision'
+    `).get(revision);
+    return row ? String(JSON.parse(row.value_json) || "").trim() : revision;
+  }
+
   function sqlitePricingRow(row) {
     return {
       id: row.row_id,
@@ -360,7 +370,33 @@ function createSqliteBackend(dependencies = {}) {
 
   function ensureSqliteConfiguration(db) {
     const current = latestSqliteConfigurationRevision(db);
-    if (current) return configurationAtSqliteRevision(db, current.revision);
+    if (current) {
+      const storedPricingRevision = storedSqlitePricingRevision(db, current.revision);
+      const configuration = configurationAtSqliteRevision(db, current.revision);
+      if (configuration.settings.pricingBasis !== "standard" ||
+          !/^packaged-\d+$/.test(storedPricingRevision) ||
+          storedPricingRevision === PACKAGED_CONFIGURATION_REVISION) {
+        return configuration;
+      }
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        const upgradeRevision = randomUUID();
+        const upgraded = normalizeConfiguration({
+          ...configuration,
+          revision: upgradeRevision,
+          settings: {
+            ...configuration.settings,
+            pricingRevision: PACKAGED_CONFIGURATION_REVISION,
+          },
+        });
+        const saved = insertSqliteConfiguration(db, upgraded, current.revision, Math.max(Date.now(), number(current.committed_at_ms) + 1));
+        db.exec("COMMIT");
+        return saved;
+      } catch (error) {
+        db.exec("ROLLBACK");
+        throw error;
+      }
+    }
     db.exec("BEGIN IMMEDIATE");
     try {
       const seeded = insertSqliteConfiguration(db, defaultConfiguration(), null, Date.now());

--- a/test/clickhouse.test.js
+++ b/test/clickhouse.test.js
@@ -336,7 +336,7 @@ test("ClickHouse packaged pricing upgrade publishes Opus 5 overlays before the r
     const requests = mock.requests.slice(before);
 
     assert.notEqual(upgraded.revision, legacyRevision);
-    assert.match(upgraded.settings.pricingRevision, /^packaged-3:[0-9a-f]{32}$/);
+    assert.match(upgraded.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
     assert.ok(upgraded.prices.some((row) => row.provider === "anthropic" && row.model === "claude-opus-5"));
     const usageOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO usage_event_costs"));
     const rateLimitOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO rate_limit_sample_costs"));
@@ -350,6 +350,71 @@ test("ClickHouse packaged pricing upgrade publishes Opus 5 overlays before the r
       .filter((request) => request.query.trimStart().startsWith("INSERT INTO"));
     assert.equal(stable.revision, upgraded.revision);
     assert.equal(repeatedInserts.length, 0, "completed packaged upgrade must not replay pricing overlays");
+  });
+});
+
+test("ClickHouse packaged-3 migration materializes temporal Luna and Terra rows before the revision marker", async () => {
+  const mock = createClickHouseServer();
+  await withServer(mock, async (clickhouseUrl) => {
+    const options = defaultOptions({ dbEngine: "clickhouse", clickhouseUrl, clickhouseDatabase: "tokenomics_temporal_packaged_upgrade_test" });
+    await loadConfiguration(options);
+
+    const legacyRevision = "legacy-packaged-3-temporal";
+    mock.activeRows.configuration_revisions[0].revision = legacyRevision;
+    for (const row of mock.activeRows.analytics_settings) {
+      row.revision = legacyRevision;
+      if (row.key === "pricingRevision") row.value_json = JSON.stringify("packaged-3");
+    }
+    const historicalUntil = "2026-07-29T23:59:59.999Z";
+    const currentFrom = "2026-07-30T00:00:00.000Z";
+    const temporalModels = new Set(["gpt-5.6-luna", "gpt-5.6-terra"]);
+    const currentRows = new Map(mock.activeRows.pricing_catalog
+      .filter((row) => temporalModels.has(row.model) && row.effective_from === currentFrom)
+      .map((row) => [`${row.model}:${row.variant}`, row]));
+    mock.activeRows.pricing_catalog = mock.activeRows.pricing_catalog.flatMap((row) => {
+      if (!temporalModels.has(row.model)) return [{ ...row, revision: legacyRevision }];
+      if (row.effective_until !== historicalUntil) return [];
+      const current = currentRows.get(`${row.model}:${row.variant}`);
+      return [{
+        ...row,
+        revision: legacyRevision,
+        row_id: `${row.provider}:${row.model}:${row.variant}`,
+        effective_from: "",
+        effective_until: "",
+        input: current.input,
+        cache_create_30m: current.cache_create_30m,
+        cache_read: current.cache_read,
+        output: current.output,
+      }];
+    });
+
+    const before = mock.requests.length;
+    const upgraded = await loadConfiguration(options);
+    const requests = mock.requests.slice(before);
+
+    assert.notEqual(upgraded.revision, legacyRevision);
+    assert.match(upgraded.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
+    assert.ok(upgraded.prices.some((row) => row.provider === "anthropic" && row.model === "claude-opus-5"));
+    const temporalRows = upgraded.prices.filter((row) => temporalModels.has(row.model));
+    assert.equal(temporalRows.length, 8);
+    assert.equal(temporalRows.filter((row) => row.effectiveUntil === historicalUntil).length, 4);
+    assert.equal(temporalRows.filter((row) => row.effectiveFrom === currentFrom).length, 4);
+    assert.equal(temporalRows.filter((row) => !row.effectiveFrom && !row.effectiveUntil).length, 0);
+    assert.equal(temporalRows.find((row) => row.model === "gpt-5.6-luna" && row.variant === "short" && row.effectiveUntil === historicalUntil).input, 1);
+    assert.equal(temporalRows.find((row) => row.model === "gpt-5.6-terra" && row.variant === "short" && row.effectiveUntil === historicalUntil).input, 2.5);
+    assert.equal(requests.some((request) => request.query.startsWith("INSERT INTO sources")), false);
+    const usageOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO usage_event_costs"));
+    const rateLimitOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO rate_limit_sample_costs"));
+    const marker = requests.findIndex((request) => request.query.startsWith("INSERT INTO configuration_revisions"));
+    assert.ok(usageOverlay >= 0 && rateLimitOverlay > usageOverlay && marker > rateLimitOverlay);
+
+    const stableStart = mock.requests.length;
+    const stable = await loadConfiguration(options);
+    const repeatedInserts = mock.requests
+      .slice(stableStart)
+      .filter((request) => request.query.trimStart().startsWith("INSERT INTO"));
+    assert.equal(stable.revision, upgraded.revision);
+    assert.equal(repeatedInserts.length, 0, "completed temporal upgrade must not replay pricing overlays");
   });
 });
 

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -38,6 +38,33 @@ test("default configuration exposes a validated editable pricing catalog", () =>
   assert.deepEqual(normalizeConfiguration(configuration), configuration);
 });
 
+test("default GPT-5.6 Luna and Terra rows match the current official standard rates", () => {
+  const configuration = defaultConfiguration();
+  const expected = {
+    "gpt-5.6-terra": {
+      short: { input: 2, cacheRead: 0.2, cacheCreate30m: 2.5, output: 12 },
+      long: { input: 4, cacheRead: 0.4, cacheCreate30m: 5, output: 18 },
+    },
+    "gpt-5.6-luna": {
+      short: { input: 0.2, cacheRead: 0.02, cacheCreate30m: 0.25, output: 1.2 },
+      long: { input: 0.4, cacheRead: 0.04, cacheCreate30m: 0.5, output: 1.8 },
+    },
+  };
+
+  for (const [model, variants] of Object.entries(expected)) {
+    for (const [variant, rates] of Object.entries(variants)) {
+      const row = configuration.prices.find((candidate) => (
+        candidate.provider === "openai" && candidate.model === model && candidate.variant === variant
+      ));
+      assert.ok(row, `${model}/${variant} packaged row is present`);
+      for (const [field, value] of Object.entries(rates)) {
+        assert.equal(row[field], value, `${model}/${variant} ${field} rate`);
+      }
+      assert.equal(row.sourceUrl, "https://developers.openai.com/api/docs/pricing");
+    }
+  }
+});
+
 test("packaged-2 pricing is upgraded with Opus 5 without replacing persisted rows", () => {
   const configuration = defaultConfiguration();
   configuration.revision = "packaged-2";

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -20,7 +20,7 @@ test("default configuration exposes a validated editable pricing catalog", () =>
   assert.equal(configuration.settings.pricingBasis, "standard");
   assert.equal(configuration.settings.regionalMultiplier, 1);
   assert.equal(configuration.settings.monthlyCostLimitUsd, null);
-  assert.equal(configuration.settings.pricingRevision, "packaged-3");
+  assert.equal(configuration.settings.pricingRevision, "packaged-4");
   assert.deepEqual(configuration.settings.usageProfile, {
     id: "default",
     name: "Work API",
@@ -54,13 +54,56 @@ test("default GPT-5.6 Luna and Terra rows match the current official standard ra
   for (const [model, variants] of Object.entries(expected)) {
     for (const [variant, rates] of Object.entries(variants)) {
       const row = configuration.prices.find((candidate) => (
-        candidate.provider === "openai" && candidate.model === model && candidate.variant === variant
+        candidate.provider === "openai" && candidate.model === model && candidate.variant === variant &&
+        candidate.effectiveFrom === "2026-07-30T00:00:00.000Z"
       ));
       assert.ok(row, `${model}/${variant} packaged row is present`);
       for (const [field, value] of Object.entries(rates)) {
         assert.equal(row[field], value, `${model}/${variant} ${field} rate`);
       }
       assert.equal(row.sourceUrl, "https://developers.openai.com/api/docs/pricing");
+    }
+  }
+});
+
+test("default GPT-5.6 Luna and Terra rows preserve the historical pricing boundary", () => {
+  const configuration = defaultConfiguration();
+  const oldUntil = "2026-07-29T23:59:59.999Z";
+  const currentFrom = "2026-07-30T00:00:00.000Z";
+  const expected = {
+    "gpt-5.6-terra": {
+      old: { input: 2.5, cacheRead: 0.25, cacheCreate30m: 3.125, output: 15 },
+      current: { input: 2, cacheRead: 0.2, cacheCreate30m: 2.5, output: 12 },
+    },
+    "gpt-5.6-luna": {
+      old: { input: 1, cacheRead: 0.1, cacheCreate30m: 1.25, output: 6 },
+      current: { input: 0.2, cacheRead: 0.02, cacheCreate30m: 0.25, output: 1.2 },
+    },
+  };
+
+  for (const [model, rates] of Object.entries(expected)) {
+    for (const variant of ["short", "long"]) {
+      const oldRates = variant === "long"
+        ? Object.fromEntries(Object.entries(rates.old).map(([key, value]) => [key, Number((value * (key === "output" ? 1.5 : 2)).toFixed(6))]))
+        : rates.old;
+      const currentRates = variant === "long"
+        ? Object.fromEntries(Object.entries(rates.current).map(([key, value]) => [key, Number((value * (key === "output" ? 1.5 : 2)).toFixed(6))]))
+        : rates.current;
+      const oldRow = configuration.prices.find((row) => (
+        row.provider === "openai" && row.model === model && row.variant === variant && row.effectiveUntil === oldUntil
+      ));
+      const currentRow = configuration.prices.find((row) => (
+        row.provider === "openai" && row.model === model && row.variant === variant && row.effectiveFrom === currentFrom
+      ));
+
+      assert.ok(oldRow, `${model}/${variant} historical packaged row is present`);
+      assert.ok(currentRow, `${model}/${variant} current packaged row is present`);
+      for (const [field, value] of Object.entries(oldRates)) {
+        assert.equal(oldRow[field], value, `${model}/${variant} historical ${field} rate`);
+      }
+      for (const [field, value] of Object.entries(currentRates)) {
+        assert.equal(currentRow[field], value, `${model}/${variant} current ${field} rate`);
+      }
     }
   }
 });
@@ -77,7 +120,7 @@ test("packaged-2 pricing is upgraded with Opus 5 without replacing persisted row
 
   const normalized = normalizeConfiguration(configuration);
 
-  assert.equal(normalized.settings.pricingRevision, "packaged-3");
+  assert.equal(normalized.settings.pricingRevision, "packaged-4");
   assert.equal(normalized.prices.find((row) => row.id === luna.id).input, 2);
   assert.ok(normalized.prices.some((row) => row.provider === "anthropic" && row.model === "claude-opus-5"));
 });
@@ -94,7 +137,7 @@ test("packaged-1 pricing is upgraded with codex-auto-review without replacing pe
 
   const normalized = normalizeConfiguration(configuration);
 
-  assert.equal(normalized.settings.pricingRevision, "packaged-3");
+  assert.equal(normalized.settings.pricingRevision, "packaged-4");
   assert.equal(normalized.prices.find((row) => row.id === luna.id).input, 2);
   assert.ok(normalized.prices.some((row) => row.provider === "openai" && row.model === "codex-auto-review"));
 });
@@ -106,7 +149,7 @@ test("standard edited catalogs get a stable pricing-engine revision and auto-rev
 
   const normalized = normalizeConfiguration(configuration);
 
-  assert.match(normalized.settings.pricingRevision, /^packaged-3:[0-9a-f]{32}$/);
+  assert.match(normalized.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
   assert.equal(normalizeConfiguration(normalized).settings.pricingRevision, normalized.settings.pricingRevision);
   assert.ok(normalized.prices.some((row) => row.provider === "openai" && row.model === "codex-auto-review"));
 

--- a/test/pricing-usage.test.js
+++ b/test/pricing-usage.test.js
@@ -911,6 +911,82 @@ test("OpenAI auto pricing changes variant only above the 272k threshold", () => 
   assert.equal(costFor(272_001).breakdown.input, 2.72001);
 });
 
+test("GPT-5.6 Luna and Terra packaged rates switch at the 2026-07-30 boundary", () => {
+  const { defaultConfiguration } = require("../lib/core/configuration");
+  const pricingCatalog = defaultConfiguration().prices;
+  const usage = {
+    input: 1_000_000,
+    cacheCreate30m: 1_000_000,
+    cacheRead: 1_000_000,
+    output: 1_000_000,
+    inputIncludesCacheRead: false,
+  };
+  const before = new Date("2026-07-29T23:59:59.999Z");
+  const exact = new Date("2026-07-30T00:00:00.000Z");
+  const after = new Date("2026-07-30T00:00:00.001Z");
+  const expected = {
+    "gpt-5.6-terra": {
+      old: { input: 2.5, cachedInput: 0.25, cacheCreate30m: 3.125, output: 15 },
+      current: { input: 2, cachedInput: 0.2, cacheCreate30m: 2.5, output: 12 },
+    },
+    "gpt-5.6-luna": {
+      old: { input: 1, cachedInput: 0.1, cacheCreate30m: 1.25, output: 6 },
+      current: { input: 0.2, cachedInput: 0.02, cacheCreate30m: 0.25, output: 1.2 },
+    },
+  };
+
+  for (const [model, rates] of Object.entries(expected)) {
+    for (const variant of ["short", "long"]) {
+      const usageForVariant = variant === "long" ? { ...usage, input: 272_001 } : usage;
+      const oldRates = variant === "long"
+        ? Object.fromEntries(Object.entries(rates.old).map(([key, value]) => [key, Number((value * (key === "output" ? 1.5 : 2)).toFixed(6))]))
+        : rates.old;
+      const currentRates = variant === "long"
+        ? Object.fromEntries(Object.entries(rates.current).map(([key, value]) => [key, Number((value * (key === "output" ? 1.5 : 2)).toFixed(6))]))
+        : rates.current;
+
+      assert.deepEqual(
+        pricing.lookupOpenAIPrices(model, usageForVariant, { openaiContext: variant }, before),
+        oldRates,
+        `${model}/${variant} uses the previous rates 1 ms before the boundary`,
+      );
+      assert.deepEqual(
+        pricing.lookupOpenAIPrices(model, usageForVariant, { openaiContext: variant }, exact),
+        currentRates,
+        `${model}/${variant} uses the current rates at the boundary`,
+      );
+      assert.deepEqual(
+        pricing.lookupOpenAIPrices(model, usageForVariant, { openaiContext: variant }, after),
+        currentRates,
+        `${model}/${variant} uses the current rates after the boundary`,
+      );
+
+      for (const [timestamp, rates, label] of [
+        [before, oldRates, "historical"],
+        [exact, currentRates, "current"],
+      ]) {
+        const cost = pricing.calculateCost("openai", model, usageForVariant, timestamp, {
+          openaiContext: variant,
+          pricingCatalog,
+        });
+        assert.equal(cost.known, true, `${model}/${variant} ${label} catalog pricing is known`);
+        assert.deepEqual(
+          Object.fromEntries(Object.entries({
+            input: usageForVariant.input * rates.input / 1_000_000,
+            cacheCreate30m: usageForVariant.cacheCreate30m * rates.cacheCreate30m / 1_000_000,
+            cacheRead: usageForVariant.cacheRead * rates.cachedInput / 1_000_000,
+            output: usageForVariant.output * rates.output / 1_000_000,
+          }).map(([key, value]) => [key, Number(value.toFixed(6))])),
+          Object.fromEntries(Object.entries(cost.breakdown)
+            .filter(([key]) => ["input", "cacheCreate30m", "cacheRead", "output"].includes(key))
+            .map(([key, value]) => [key, Number(value.toFixed(6))])),
+          `${model}/${variant} ${label} catalog breakdown`,
+        );
+      }
+    }
+  }
+});
+
 test("unknown providers and models remain unpriced", () => {
   const usageValue = simpleUsage(1_000_000);
 

--- a/test/sqlite.test.js
+++ b/test/sqlite.test.js
@@ -240,6 +240,123 @@ test("pricing edits reprice SQLite reports immediately without reimporting uncha
   assert.deepEqual({ ...sourceAfter }, { ...sourceBefore });
 });
 
+test("SQLite upgrades legacy managed packaged pricing with temporal GPT-5.6 rows without reimport", async () => {
+  const tmp = fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-sqlite-packaged-pricing-upgrade-test-"));
+  const db = Path.join(tmp, "tokenomics.sqlite");
+  const jsonl = Path.join(tmp, "session.jsonl");
+  fs.writeFileSync(jsonl, "{}\n");
+  const options = defaultOptions({ db, paths: [jsonl] });
+
+  await syncDatabase(options);
+  const storedBefore = new DatabaseSync(db);
+  const sourceBefore = storedBefore.prepare("SELECT source_path, fingerprint, imported_at FROM sources").get();
+  const currentRevision = storedBefore.prepare("SELECT revision FROM configuration_revisions ORDER BY committed_at_ms DESC LIMIT 1").get().revision;
+  storedBefore.prepare("UPDATE configuration_revisions SET revision = 'packaged-3' WHERE revision = ?").run(currentRevision);
+  storedBefore.prepare("UPDATE analytics_settings SET revision = 'packaged-3', value_json = ? WHERE revision = ? AND key = 'pricingRevision'").run(JSON.stringify("packaged-3"), currentRevision);
+  storedBefore.prepare("UPDATE analytics_settings SET revision = 'packaged-3' WHERE revision = ?").run(currentRevision);
+  storedBefore.prepare("UPDATE pricing_catalog SET revision = 'packaged-3' WHERE revision = ?").run(currentRevision);
+  storedBefore.prepare("DELETE FROM pricing_catalog WHERE revision = 'packaged-3' AND model IN ('gpt-5.6-terra', 'gpt-5.6-luna')").run();
+  const insertLegacy = storedBefore.prepare(`
+    INSERT INTO pricing_catalog(
+      revision, row_id, provider, model, match_mode, variant,
+      effective_from, effective_until, input, cache_create_5m,
+      cache_create_30m, cache_create_1h, cache_read, output, source_url
+    ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  for (const [model, rates] of Object.entries({
+    "gpt-5.6-terra": { input: 2, cacheCreate30m: 2.5, cacheRead: 0.2, output: 12 },
+    "gpt-5.6-luna": { input: 0.2, cacheCreate30m: 0.25, cacheRead: 0.02, output: 1.2 },
+  })) {
+    for (const variant of ["short", "long"]) {
+      const scale = variant === "long" ? 2 : 1;
+      const outputScale = variant === "long" ? 1.5 : 1;
+      insertLegacy.run(
+        "packaged-3",
+        `openai:${model}:${variant}::`,
+        "openai",
+        model,
+        "snapshot",
+        variant,
+        null,
+        null,
+        rates.input * scale,
+        null,
+        rates.cacheCreate30m * scale,
+        null,
+        rates.cacheRead * scale,
+        rates.output * outputScale,
+        "https://developers.openai.com/api/docs/pricing",
+      );
+    }
+  }
+  storedBefore.close();
+
+  const migrated = await loadConfiguration(options);
+  assert.notEqual(migrated.revision, "packaged-3");
+  assert.equal(migrated.settings.pricingRevision, "packaged-4");
+  const targetRows = migrated.prices.filter((row) => row.provider === "openai" && ["gpt-5.6-terra", "gpt-5.6-luna"].includes(row.model));
+  assert.equal(targetRows.length, 8);
+  assert.equal(targetRows.filter((row) => row.effectiveUntil === "2026-07-29T23:59:59.999Z").length, 4);
+  assert.equal(targetRows.filter((row) => row.effectiveFrom === "2026-07-30T00:00:00.000Z").length, 4);
+  const historicalLuna = targetRows.find((row) => (
+    row.model === "gpt-5.6-luna" && row.variant === "short" &&
+    row.effectiveUntil === "2026-07-29T23:59:59.999Z"
+  ));
+  const historicalTerra = targetRows.find((row) => (
+    row.model === "gpt-5.6-terra" && row.variant === "short" &&
+    row.effectiveUntil === "2026-07-29T23:59:59.999Z"
+  ));
+  assert.deepEqual(
+    { input: historicalLuna.input, cacheCreate30m: historicalLuna.cacheCreate30m, cacheRead: historicalLuna.cacheRead, output: historicalLuna.output },
+    { input: 1, cacheCreate30m: 1.25, cacheRead: 0.1, output: 6 },
+  );
+  assert.deepEqual(
+    { input: historicalTerra.input, cacheCreate30m: historicalTerra.cacheCreate30m, cacheRead: historicalTerra.cacheRead, output: historicalTerra.output },
+    { input: 2.5, cacheCreate30m: 3.125, cacheRead: 0.25, output: 15 },
+  );
+
+  const storedAfter = new DatabaseSync(db);
+  try {
+    const sourceAfter = storedAfter.prepare("SELECT source_path, fingerprint, imported_at FROM sources").get();
+    assert.deepEqual({ ...sourceAfter }, { ...sourceBefore });
+    assert.equal(storedAfter.prepare("SELECT COUNT(*) AS count FROM configuration_revisions").get().count, 2);
+  } finally {
+    storedAfter.close();
+  }
+});
+
+test("SQLite leaves custom and derived pricing revisions untouched during packaged migration", async () => {
+  for (const pricingBasis of ["custom", "derived"]) {
+    const tmp = fs.mkdtempSync(Path.join(os.tmpdir(), `tokenomics-sqlite-${pricingBasis}-pricing-test-`));
+    const db = Path.join(tmp, "tokenomics.sqlite");
+    const options = defaultOptions({ db });
+    const initial = await loadConfiguration(options);
+    const stored = new DatabaseSync(db);
+    const currentRevision = initial.revision;
+    const luna = stored.prepare("SELECT * FROM pricing_catalog WHERE revision = ? AND provider = 'openai' AND model = 'gpt-5.6-luna' AND variant = 'short' LIMIT 1").get(currentRevision);
+    const legacyRevision = pricingBasis === "custom" ? "custom-legacy" : "packaged-3:0123456789abcdef0123456789abcdef";
+    const storedPricingRevision = pricingBasis === "custom" ? "packaged-3" : legacyRevision;
+    stored.prepare("UPDATE configuration_revisions SET revision = ? WHERE revision = ?").run(legacyRevision, currentRevision);
+    stored.prepare("UPDATE analytics_settings SET revision = ?, value_json = ? WHERE revision = ? AND key = 'pricingBasis'").run(legacyRevision, JSON.stringify(pricingBasis === "custom" ? "custom" : "standard"), currentRevision);
+    stored.prepare("UPDATE analytics_settings SET revision = ?, value_json = ? WHERE revision = ? AND key = 'pricingRevision'").run(legacyRevision, JSON.stringify(storedPricingRevision), currentRevision);
+    stored.prepare("UPDATE analytics_settings SET revision = ? WHERE revision = ?").run(legacyRevision, currentRevision);
+    stored.prepare("UPDATE pricing_catalog SET revision = ?, input = ? WHERE revision = ? AND provider = 'openai' AND model = 'gpt-5.6-luna' AND variant = 'short'").run(legacyRevision, 99, currentRevision);
+    stored.prepare("UPDATE pricing_catalog SET revision = ? WHERE revision = ?").run(legacyRevision, currentRevision);
+    stored.close();
+
+    const loaded = await loadConfiguration(options);
+    assert.equal(loaded.revision, legacyRevision);
+    assert.equal(loaded.prices.find((row) => row.id === luna.row_id).input, 99);
+    assert.equal(loaded.prices.some((row) => row.effectiveFrom === "2026-07-30T00:00:00.000Z" && row.model === "gpt-5.6-luna"), true);
+    const check = new DatabaseSync(db);
+    try {
+      assert.equal(check.prepare("SELECT COUNT(*) AS count FROM configuration_revisions").get().count, 1);
+    } finally {
+      check.close();
+    }
+  }
+});
+
 test("SQLite persists versioned fingerprints and reimports a stale derivation", async () => {
   const tmp = fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-sqlite-derivation-version-test-"));
   const jsonl = Path.join(tmp, "session.jsonl");


### PR DESCRIPTION
## Summary

- version GPT-5.6 Luna and Terra pricing by event timestamp
- preserve the previous rates through `2026-07-29T23:59:59.999Z`
- apply the reduced rates from `2026-07-30T00:00:00.000Z`
- upgrade managed packaged catalogs to `packaged-4` without rereading session sources
- keep custom and derived pricing catalogs authoritative

## Why

The reduced Luna and Terra defaults were initially represented as timeless
replacements. That would retroactively reprice historical usage. This change
models the price cut as a temporal boundary and migrates legacy managed rows
into canonical historical and current intervals.

## Impact

SQLite and ClickHouse databases using an older managed packaged revision are
upgraded in place. Source fingerprints and import timestamps remain unchanged.
ClickHouse publishes repricing overlays before the new configuration marker,
and repeated loads are idempotent.

## Validation

- `npm test`: 251 passed
- boundary coverage at 1 ms before, exactly at, and 1 ms after the UTC transition
- direct lookup and database-backed catalog coverage for Luna and Terra, short and long context
- SQLite and ClickHouse migration, custom/derived preservation, marker ordering, and idempotency
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`

Official pricing source: https://developers.openai.com/api/docs/pricing
