### PR TITLE
Fix chained ClickHouse pricing migrations

### DIFF
--- a/docs/PRICING_CONFIGURATION_FRONTIER.md
+++ b/docs/PRICING_CONFIGURATION_FRONTIER.md
@@ -28,6 +28,11 @@ manual derivation-version discipline.
   SQLite and ClickHouse perform this migration without rereading source bytes;
   ClickHouse publishes cost overlays before its new revision marker. Custom and
   derived revisions are not overwritten by this migration.
+- ClickHouse uses an explicit `packaged-N:managed:<digest>` overlay revision to
+  retain packaged-catalog provenance across later upgrades. The legacy
+  derived-hash repair is admitted only for the exact 63-row packaged-3 catalog
+  snapshot, even if a prior engine bump rebased its revision prefix; any row
+  difference remains an authoritative derived catalog.
 - Direct scans without a database continue to use the packaged catalog.
 - Configuration reads return a revision. Writes require that revision and
   replace settings and prices atomically from the API consumer's perspective.

--- a/lib/core/configuration.js
+++ b/lib/core/configuration.js
@@ -8,6 +8,14 @@ const ALLOWED_SETTINGS = new Set(["openaiContext", "pricingBasis", "pricingRevis
 const ALLOWED_MATCH_MODES = new Set(["snapshot", "prefix", "exact"]);
 const ALLOWED_VARIANTS = new Set(["standard", "short", "long"]);
 const PRICE_FIELDS = ["input", "cacheCreate5m", "cacheCreate30m", "cacheCreate1h", "cacheRead", "output"];
+const DERIVED_PACKAGED_REVISION_RE = /^packaged-(\d+):([0-9a-f]{32})$/;
+const MANAGED_PACKAGED_REVISION_RE = /^packaged-(\d+):managed:([0-9a-f]{32})$/;
+const LEGACY_PACKAGED_CONFIGURATION_REVISION = "packaged-3";
+// Exact normalized 63-row packaged-3 catalog. This admits the one-time repair
+// without guessing that arbitrary derived standard catalogs are managed.
+const LEGACY_PACKAGED_3_CATALOG_SIGNATURE = "35dc489b59c5c2075f4e995081f3f110505a7da73312c6febd1b3b9926c069e5";
+// The same catalog after the Float64 JSON round trip observed in ClickHouse.
+const LEGACY_PACKAGED_3_CLICKHOUSE_CATALOG_SIGNATURE = "74902efdcc89bc1aece721d1e99eee36a2791aa023f1f33cadf15ac5753f8e8d";
 
 function pricingRowId(row) {
   return [
@@ -148,10 +156,28 @@ function normalizeUsageProfile(source) {
 function normalizedPricingRevision(requestedRevision, pricingBasis) {
   if (pricingBasis === "custom") return requestedRevision;
   if (/^packaged-\d+$/.test(requestedRevision)) return PACKAGED_CONFIGURATION_REVISION;
+  const managedMatch = requestedRevision.match(MANAGED_PACKAGED_REVISION_RE);
+  if (managedMatch) {
+    if (`packaged-${managedMatch[1]}` === PACKAGED_CONFIGURATION_REVISION) return requestedRevision;
+    return `${PACKAGED_CONFIGURATION_REVISION}:managed:${createHash("sha256").update(requestedRevision).digest("hex").slice(0, 32)}`;
+  }
   const derivedPattern = new RegExp(`^${PACKAGED_CONFIGURATION_REVISION}:[0-9a-f]{32}$`);
   if (derivedPattern.test(requestedRevision)) return requestedRevision;
   const digest = createHash("sha256").update(requestedRevision).digest("hex").slice(0, 32);
   return `${PACKAGED_CONFIGURATION_REVISION}:${digest}`;
+}
+
+function isDerivedPackagedPricingRevision(value) {
+  return DERIVED_PACKAGED_REVISION_RE.test(String(value || "").trim());
+}
+
+function isManagedPackagedPricingRevision(value) {
+  return MANAGED_PACKAGED_REVISION_RE.test(String(value || "").trim());
+}
+
+function managedPackagedPricingRevision(revision) {
+  const digest = createHash("sha256").update(String(revision || "")).digest("hex").slice(0, 32);
+  return `${PACKAGED_CONFIGURATION_REVISION}:managed:${digest}`;
 }
 
 function normalizedDate(value, field, rowId) {
@@ -208,6 +234,38 @@ function normalizePricingRow(source, index) {
   return row;
 }
 
+function comparablePricingRow(row) {
+  return {
+    provider: row.provider,
+    model: row.model,
+    matchMode: row.matchMode,
+    variant: row.variant,
+    effectiveFrom: row.effectiveFrom,
+    effectiveUntil: row.effectiveUntil,
+    input: row.input,
+    cacheCreate5m: row.cacheCreate5m,
+    cacheCreate30m: row.cacheCreate30m,
+    cacheCreate1h: row.cacheCreate1h,
+    cacheRead: row.cacheRead,
+    output: row.output,
+    sourceUrl: row.sourceUrl,
+  };
+}
+
+function isLegacyPackagedPricingCatalog(sourceRows) {
+  if (!Array.isArray(sourceRows)) return false;
+  try {
+    const rows = sourceRows
+      .map((row, index) => JSON.stringify(comparablePricingRow(normalizePricingRow(row, index))))
+      .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    const signature = createHash("sha256").update(`[${rows.join(",")}]`).digest("hex");
+    return signature === LEGACY_PACKAGED_3_CATALOG_SIGNATURE ||
+      signature === LEGACY_PACKAGED_3_CLICKHOUSE_CATALOG_SIGNATURE;
+  } catch {
+    return false;
+  }
+}
+
 function normalizeConfiguration(source = {}) {
   const revision = String(source.revision || "").trim();
   if (!revision || revision.length > 160) throw new Error("configuration revision must be a non-empty string");
@@ -225,7 +283,7 @@ function normalizeConfiguration(source = {}) {
   }
   const requestedPricingRevision = String(rawSettings.pricingRevision || revision).trim();
   const packagedManagedPricing = pricingBasis === "standard" &&
-    (!requestedPricingRevision || /^packaged-\d+$/.test(requestedPricingRevision));
+    (!requestedPricingRevision || /^packaged-\d+$/.test(requestedPricingRevision) || isManagedPackagedPricingRevision(requestedPricingRevision));
   const pricingRevision = normalizedPricingRevision(requestedPricingRevision, pricingBasis);
   if (!pricingRevision || pricingRevision.length > 160) {
     throw new Error("pricingRevision must be a non-empty string");
@@ -321,9 +379,14 @@ function pricingConfigurationSignature(configuration) {
 }
 
 module.exports = {
+  LEGACY_PACKAGED_CONFIGURATION_REVISION,
   PACKAGED_CONFIGURATION_REVISION,
   PRICE_FIELDS,
   defaultConfiguration,
+  isDerivedPackagedPricingRevision,
+  isLegacyPackagedPricingCatalog,
+  isManagedPackagedPricingRevision,
+  managedPackagedPricingRevision,
   normalizeConfiguration,
   normalizeUsageProfile,
   packagedPricingRows,

--- a/lib/storage/clickhouse.js
+++ b/lib/storage/clickhouse.js
@@ -21,6 +21,11 @@ const {
 const { sameSourceFingerprint, sourceFingerprint } = require("../core/derivation");
 const {
   defaultConfiguration,
+  LEGACY_PACKAGED_CONFIGURATION_REVISION,
+  isDerivedPackagedPricingRevision,
+  isLegacyPackagedPricingCatalog,
+  isManagedPackagedPricingRevision,
+  managedPackagedPricingRevision,
   normalizeConfiguration,
   pricingConfigurationSignature,
   pricingOptionsFromConfiguration,
@@ -599,10 +604,23 @@ function createClickHouseBackend(dependencies = {}) {
     if (!current) return insertClickHouseConfiguration(client, defaultConfiguration(), "", 0, options);
 
     const source = await clickHouseConfigurationSourceAtRevision(client, current.revision);
-    const configuration = normalizeConfiguration(source);
     const storedPricingRevision = String(
       source.settings?.pricingRevision || source.revision || "",
     ).trim();
+    const legacyManagedPricing = source.settings?.pricingBasis === "standard" &&
+      isDerivedPackagedPricingRevision(storedPricingRevision) &&
+      isLegacyPackagedPricingCatalog(source.prices);
+    const configuration = normalizeConfiguration(legacyManagedPricing
+      ? {
+        ...source,
+        settings: {
+          ...source.settings,
+          pricingRevision: LEGACY_PACKAGED_CONFIGURATION_REVISION,
+        },
+      }
+      : source);
+    const managedPricing = legacyManagedPricing || isManagedPackagedPricingRevision(storedPricingRevision) ||
+      /^packaged-\d+$/.test(storedPricingRevision);
     if (storedPricingRevision === configuration.settings.pricingRevision) return configuration;
 
     // A packaged pricing-engine revision changed. Publish the normalized
@@ -617,9 +635,12 @@ function createClickHouseBackend(dependencies = {}) {
       settings: {
         ...configuration.settings,
         // Derive a unique pricing revision for this append-only migration.
-        // Retries and concurrent starters then write disjoint overlay keys
-        // instead of duplicating rows under the packaged revision.
-        pricingRevision: upgradeRevision,
+        // Retries and concurrent starters then write disjoint overlay keys.
+        // Preserve managed provenance without claiming derived catalogs are
+        // safe to replace during a later packaged upgrade.
+        pricingRevision: managedPricing
+          ? managedPackagedPricingRevision(upgradeRevision)
+          : upgradeRevision,
       },
     });
     await insertClickHouseConfigurationData(client, upgraded, options);

--- a/test/clickhouse.test.js
+++ b/test/clickhouse.test.js
@@ -336,7 +336,7 @@ test("ClickHouse packaged pricing upgrade publishes Opus 5 overlays before the r
     const requests = mock.requests.slice(before);
 
     assert.notEqual(upgraded.revision, legacyRevision);
-    assert.match(upgraded.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
+    assert.match(upgraded.settings.pricingRevision, /^packaged-4:managed:[0-9a-f]{32}$/);
     assert.ok(upgraded.prices.some((row) => row.provider === "anthropic" && row.model === "claude-opus-5"));
     const usageOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO usage_event_costs"));
     const rateLimitOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO rate_limit_sample_costs"));
@@ -393,7 +393,7 @@ test("ClickHouse packaged-3 migration materializes temporal Luna and Terra rows 
     const requests = mock.requests.slice(before);
 
     assert.notEqual(upgraded.revision, legacyRevision);
-    assert.match(upgraded.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
+    assert.match(upgraded.settings.pricingRevision, /^packaged-4:managed:[0-9a-f]{32}$/);
     assert.ok(upgraded.prices.some((row) => row.provider === "anthropic" && row.model === "claude-opus-5"));
     const temporalRows = upgraded.prices.filter((row) => temporalModels.has(row.model));
     assert.equal(temporalRows.length, 8);
@@ -415,6 +415,128 @@ test("ClickHouse packaged-3 migration materializes temporal Luna and Terra rows 
       .filter((request) => request.query.trimStart().startsWith("INSERT INTO"));
     assert.equal(stable.revision, upgraded.revision);
     assert.equal(repeatedInserts.length, 0, "completed temporal upgrade must not replay pricing overlays");
+  });
+});
+
+test("ClickHouse repairs a chained derived packaged migration only for an unchanged legacy catalog", async () => {
+  const mock = createClickHouseServer();
+  await withServer(mock, async (clickhouseUrl) => {
+    const options = defaultOptions({ dbEngine: "clickhouse", clickhouseUrl, clickhouseDatabase: "tokenomics_chained_packaged_upgrade_test" });
+    await loadConfiguration(options);
+
+    const legacyRevision = "81fbbf48-6215-419b-bffb-ddd36a1e96d4";
+    const legacyPricingRevision = "packaged-4:fd7377f5073cecef6e9f9b83e190c1c4";
+    const historicalUntil = "2026-07-29T23:59:59.999Z";
+    const temporalModels = new Set(["gpt-5.6-luna", "gpt-5.6-terra"]);
+    mock.activeRows.configuration_revisions[0].revision = legacyRevision;
+    for (const row of mock.activeRows.analytics_settings) {
+      row.revision = legacyRevision;
+      if (row.key === "pricingRevision") row.value_json = JSON.stringify(legacyPricingRevision);
+    }
+    mock.activeRows.pricing_catalog = mock.activeRows.pricing_catalog.flatMap((row) => {
+      if (!temporalModels.has(row.model)) {
+        return [{
+          ...row,
+          revision: legacyRevision,
+          input: row.input === 0.6 ? 0.6000000000000001 : row.input,
+          cache_read: row.cache_read === 0.3
+            ? 0.30000000000000004
+            : row.cache_read === 0.175 ? 0.17500000000000004 : row.cache_read,
+        }];
+      }
+      if (row.effective_until !== historicalUntil) return [];
+      return [{
+        ...row,
+        revision: legacyRevision,
+        row_id: `${row.provider}:${row.model}:${row.variant}`,
+        effective_from: "",
+        effective_until: "",
+      }];
+    });
+
+    const before = mock.requests.length;
+    const upgraded = await loadConfiguration(options);
+    const requests = mock.requests.slice(before);
+    const temporalRows = upgraded.prices.filter((row) => temporalModels.has(row.model));
+
+    assert.notEqual(upgraded.revision, legacyRevision);
+    assert.equal(temporalRows.length, 8);
+    assert.equal(temporalRows.filter((row) => row.effectiveUntil === historicalUntil).length, 4);
+    assert.equal(temporalRows.filter((row) => row.effectiveFrom === "2026-07-30T00:00:00.000Z").length, 4);
+    assert.equal(temporalRows.filter((row) => !row.effectiveFrom && !row.effectiveUntil).length, 0);
+    assert.equal(requests.some((request) => request.query.startsWith("INSERT INTO sources")), false);
+    assert.ok(requests.some((request) => request.query.trimStart().startsWith("INSERT INTO usage_event_costs")));
+    assert.ok(requests.some((request) => request.query.trimStart().startsWith("INSERT INTO rate_limit_sample_costs")));
+    assert.match(upgraded.settings.pricingRevision, /^packaged-4:managed:[0-9a-f]{32}$/);
+
+    const stableStart = mock.requests.length;
+    assert.equal((await loadConfiguration(options)).revision, upgraded.revision);
+    assert.equal(mock.requests.slice(stableStart).some((request) => request.query.trimStart().startsWith("INSERT INTO")), false);
+  });
+});
+
+test("ClickHouse preserves edited standard rows while rebasing only older derived overlays", async () => {
+  const mock = createClickHouseServer();
+  await withServer(mock, async (clickhouseUrl) => {
+    const options = defaultOptions({ dbEngine: "clickhouse", clickhouseUrl, clickhouseDatabase: "tokenomics_edited_derived_packaged_test" });
+    await loadConfiguration(options);
+
+    const legacyRevision = "81fbbf48-6215-419b-bffb-ddd36a1e96d4";
+    const legacyPricingRevision = "packaged-4:fd7377f5073cecef6e9f9b83e190c1c4";
+    const historicalUntil = "2026-07-29T23:59:59.999Z";
+    const temporalModels = new Set(["gpt-5.6-luna", "gpt-5.6-terra"]);
+    mock.activeRows.configuration_revisions[0].revision = legacyRevision;
+    for (const row of mock.activeRows.analytics_settings) {
+      row.revision = legacyRevision;
+      if (row.key === "pricingRevision") row.value_json = JSON.stringify(legacyPricingRevision);
+    }
+    mock.activeRows.pricing_catalog = mock.activeRows.pricing_catalog.flatMap((row) => {
+      if (!temporalModels.has(row.model)) return [{ ...row, revision: legacyRevision }];
+      if (row.effective_until !== historicalUntil) return [];
+      return [{
+        ...row,
+        revision: legacyRevision,
+        row_id: `${row.provider}:${row.model}:${row.variant}`,
+        effective_from: "",
+        effective_until: "",
+        input: row.model === "gpt-5.6-luna" && row.variant === "short" ? 99 : row.input,
+      }];
+    });
+
+    const before = mock.requests.length;
+    const preserved = await loadConfiguration(options);
+    const requests = mock.requests.slice(before);
+    const luna = preserved.prices.find((row) => row.model === "gpt-5.6-luna" && row.variant === "short");
+
+    assert.equal(preserved.revision, legacyRevision);
+    assert.equal(preserved.settings.pricingRevision, legacyPricingRevision);
+    assert.equal(luna.input, 99);
+    assert.equal(preserved.prices.some((row) => row.effectiveFrom === "2026-07-30T00:00:00.000Z"), false);
+    assert.equal(requests.some((request) => request.query.trimStart().startsWith("INSERT INTO usage_event_costs")), false);
+    assert.equal(requests.some((request) => request.query.trimStart().startsWith("INSERT INTO rate_limit_sample_costs")), false);
+    assert.equal(requests.some((request) => request.query.startsWith("INSERT INTO configuration_revisions")), false);
+
+    const stableStart = mock.requests.length;
+    assert.equal((await loadConfiguration(options)).revision, preserved.revision);
+    assert.equal(mock.requests.slice(stableStart).some((request) => request.query.trimStart().startsWith("INSERT INTO")), false);
+
+    for (const row of mock.activeRows.analytics_settings) {
+      if (row.revision === legacyRevision && row.key === "pricingRevision") {
+        row.value_json = JSON.stringify("packaged-3:98676efa611fd1bf680b1262d5515820");
+      }
+    }
+    const rebaseStart = mock.requests.length;
+    const rebased = await loadConfiguration(options);
+    const rebaseRequests = mock.requests.slice(rebaseStart);
+    const rebasedLuna = rebased.prices.find((row) => row.model === "gpt-5.6-luna" && row.variant === "short");
+
+    assert.notEqual(rebased.revision, legacyRevision);
+    assert.match(rebased.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
+    assert.equal(rebasedLuna.input, 99);
+    assert.equal(rebased.prices.some((row) => row.effectiveFrom === "2026-07-30T00:00:00.000Z"), false);
+    assert.ok(rebaseRequests.some((request) => request.query.trimStart().startsWith("INSERT INTO usage_event_costs")));
+    assert.ok(rebaseRequests.some((request) => request.query.trimStart().startsWith("INSERT INTO rate_limit_sample_costs")));
+    assert.ok(rebaseRequests.some((request) => request.query.startsWith("INSERT INTO configuration_revisions")));
   });
 });
 

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -7,6 +7,7 @@ const Path = require("node:path");
 const test = require("node:test");
 const {
   defaultConfiguration,
+  isLegacyPackagedPricingCatalog,
   normalizeConfiguration,
 } = require("../lib/core/configuration");
 const { calculateCost } = require("../lib/core/pricing");
@@ -108,6 +109,19 @@ test("default GPT-5.6 Luna and Terra rows preserve the historical pricing bounda
   }
 });
 
+test("legacy packaged catalog recognition rejects even tiny tariff edits", () => {
+  const temporalModels = new Set(["gpt-5.6-luna", "gpt-5.6-terra"]);
+  const legacy = defaultConfiguration().prices.flatMap((row) => {
+    if (!temporalModels.has(row.model)) return [row];
+    if (!row.effectiveUntil) return [];
+    return [{ ...row, effectiveFrom: null, effectiveUntil: null }];
+  });
+
+  assert.equal(isLegacyPackagedPricingCatalog(legacy), true);
+  legacy.find((row) => row.model === "gpt-5.6-luna" && row.variant === "short").input = 1.000000000000001;
+  assert.equal(isLegacyPackagedPricingCatalog(legacy), false);
+});
+
 test("packaged-2 pricing is upgraded with Opus 5 without replacing persisted rows", () => {
   const configuration = defaultConfiguration();
   configuration.revision = "packaged-2";
@@ -157,6 +171,20 @@ test("standard edited catalogs get a stable pricing-engine revision and auto-rev
   const custom = normalizeConfiguration(configuration);
   assert.equal(custom.settings.pricingRevision, "edited-catalog-1");
   assert.equal(custom.prices.some((row) => row.model === "codex-auto-review"), false);
+});
+
+test("managed packaged overlay revisions remain distinct from edited standard catalogs", () => {
+  const configuration = defaultConfiguration();
+  const currentManagedRevision = `packaged-4:managed:${"a".repeat(32)}`;
+  configuration.settings.pricingRevision = currentManagedRevision;
+
+  assert.equal(normalizeConfiguration(configuration).settings.pricingRevision, currentManagedRevision);
+
+  configuration.settings.pricingRevision = `packaged-3:managed:${"b".repeat(32)}`;
+  assert.match(
+    normalizeConfiguration(configuration).settings.pricingRevision,
+    /^packaged-4:managed:[0-9a-f]{32}$/,
+  );
 });
 
 test("database pricing rows override packaged prices and apply the regional multiplier", () => {


### PR DESCRIPTION
## Summary

- repair the chained ClickHouse packaged-pricing migration only when the stored 63-row catalog exactly matches the legacy packaged-3 snapshot
- retain packaged provenance with explicit `packaged-N:managed:<digest>` overlay revisions
- preserve any edited standard catalog, including tiny tariff differences
- materialize temporal Luna and Terra rows and publish cost overlays before the revision marker

## Root cause

An automatic ClickHouse pricing migration used a random revision. Normalization encoded it as a generic derived `packaged-N:<hash>` revision, so later package revisions treated the previously managed catalog as user-edited. The old Luna and Terra rows therefore remained active while the application reported pricing as current.

## Verification

- `npm test`: 255 passed, 0 failed
- focused configuration and ClickHouse tests: 38 passed, 0 failed
- syntax and `git diff --check`: passed
- live read-only check: the active 63-row catalog matches the exact observed ClickHouse legacy signature
- independent hostile diff review: APPROVE, no blocker/major findings

## Safety and residual risk

The repair is fail-closed: it accepts only the exact nominal legacy catalog or the exact Float64 representation observed in ClickHouse. Any row difference remains authoritative and is not replaced. Publication keeps the existing unique-overlay and marker-last ordering. Simultaneous real-process starters are not covered by a dedicated integration test; the existing concurrency semantics are exercised by the backend tests.

The local database restart and resulting recalculation are intentionally separate from this PR operation and require an explicit live-remediation confirmation.
