### PR TITLE
Fix temporal ClickHouse overlay repricing

### DIFF
--- a/docs/PRICING_CONFIGURATION_FRONTIER.md
+++ b/docs/PRICING_CONFIGURATION_FRONTIER.md
@@ -28,11 +28,15 @@ manual derivation-version discipline.
   SQLite and ClickHouse perform this migration without rereading source bytes;
   ClickHouse publishes cost overlays before its new revision marker. Custom and
   derived revisions are not overwritten by this migration.
-- ClickHouse uses an explicit `packaged-N:managed:<digest>` overlay revision to
-  retain packaged-catalog provenance across later upgrades. The legacy
+- ClickHouse retains packaged-catalog provenance in backend metadata while its
+  public pricing revision stays compatible with older readers. The legacy
   derived-hash repair is admitted only for the exact 63-row packaged-3 catalog
   snapshot, even if a prior engine bump rebased its revision prefix; any row
   difference remains an authoritative derived catalog.
+- ClickHouse pricing overlays evaluate temporal catalog rows against each
+  usage event timestamp. An internal projection revision invalidates and
+  rebuilds existing standard, derived, managed, and custom overlays when those
+  semantics change.
 - Direct scans without a database continue to use the packaged catalog.
 - Configuration reads return a revision. Writes require that revision and
   replace settings and prices atomically from the API consumer's perspective.

--- a/lib/core/configuration.js
+++ b/lib/core/configuration.js
@@ -16,6 +16,8 @@ const LEGACY_PACKAGED_CONFIGURATION_REVISION = "packaged-3";
 const LEGACY_PACKAGED_3_CATALOG_SIGNATURE = "35dc489b59c5c2075f4e995081f3f110505a7da73312c6febd1b3b9926c069e5";
 // The same catalog after the Float64 JSON round trip observed in ClickHouse.
 const LEGACY_PACKAGED_3_CLICKHOUSE_CATALOG_SIGNATURE = "74902efdcc89bc1aece721d1e99eee36a2791aa023f1f33cadf15ac5753f8e8d";
+const PACKAGED_4_CATALOG_SIGNATURE = "90161eead388329f274372c80e38da02a5c9f35ba53bf1e8bfc37e4dd79a078a";
+const PACKAGED_4_CLICKHOUSE_CATALOG_SIGNATURE = "363f3a993b26f3680bf0842577c14e93efbf76726ea9130eb75eba5ecdf483ef";
 
 function pricingRowId(row) {
   return [
@@ -175,11 +177,6 @@ function isManagedPackagedPricingRevision(value) {
   return MANAGED_PACKAGED_REVISION_RE.test(String(value || "").trim());
 }
 
-function managedPackagedPricingRevision(revision) {
-  const digest = createHash("sha256").update(String(revision || "")).digest("hex").slice(0, 32);
-  return `${PACKAGED_CONFIGURATION_REVISION}:managed:${digest}`;
-}
-
 function normalizedDate(value, field, rowId) {
   if (value === null || value === undefined || value === "") return null;
   const text = String(value);
@@ -252,18 +249,36 @@ function comparablePricingRow(row) {
   };
 }
 
-function isLegacyPackagedPricingCatalog(sourceRows) {
-  if (!Array.isArray(sourceRows)) return false;
+function pricingCatalogSignature(sourceRows) {
+  if (!Array.isArray(sourceRows)) return "";
   try {
     const rows = sourceRows
       .map((row, index) => JSON.stringify(comparablePricingRow(normalizePricingRow(row, index))))
       .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
-    const signature = createHash("sha256").update(`[${rows.join(",")}]`).digest("hex");
-    return signature === LEGACY_PACKAGED_3_CATALOG_SIGNATURE ||
-      signature === LEGACY_PACKAGED_3_CLICKHOUSE_CATALOG_SIGNATURE;
+    return createHash("sha256").update(`[${rows.join(",")}]`).digest("hex");
   } catch {
-    return false;
+    return "";
   }
+}
+
+function isLegacyPackagedPricingCatalog(sourceRows) {
+  return packagedPricingCatalogRevision(sourceRows) === LEGACY_PACKAGED_CONFIGURATION_REVISION;
+}
+
+function isCurrentPackagedPricingCatalog(sourceRows) {
+  return packagedPricingCatalogRevision(sourceRows) === PACKAGED_CONFIGURATION_REVISION;
+}
+
+function packagedPricingCatalogRevision(sourceRows) {
+  const signature = pricingCatalogSignature(sourceRows);
+  if (signature === LEGACY_PACKAGED_3_CATALOG_SIGNATURE ||
+      signature === LEGACY_PACKAGED_3_CLICKHOUSE_CATALOG_SIGNATURE) {
+    return LEGACY_PACKAGED_CONFIGURATION_REVISION;
+  }
+  if (signature === PACKAGED_4_CATALOG_SIGNATURE || signature === PACKAGED_4_CLICKHOUSE_CATALOG_SIGNATURE) {
+    return "packaged-4";
+  }
+  return "";
 }
 
 function normalizeConfiguration(source = {}) {
@@ -383,12 +398,13 @@ module.exports = {
   PACKAGED_CONFIGURATION_REVISION,
   PRICE_FIELDS,
   defaultConfiguration,
+  isCurrentPackagedPricingCatalog,
   isDerivedPackagedPricingRevision,
   isLegacyPackagedPricingCatalog,
   isManagedPackagedPricingRevision,
-  managedPackagedPricingRevision,
   normalizeConfiguration,
   normalizeUsageProfile,
+  packagedPricingCatalogRevision,
   packagedPricingRows,
   pricingOptionsFromConfiguration,
   pricingConfigurationSignature,

--- a/lib/storage/clickhouse.js
+++ b/lib/storage/clickhouse.js
@@ -22,11 +22,11 @@ const { sameSourceFingerprint, sourceFingerprint } = require("../core/derivation
 const {
   defaultConfiguration,
   LEGACY_PACKAGED_CONFIGURATION_REVISION,
+  PACKAGED_CONFIGURATION_REVISION,
   isDerivedPackagedPricingRevision,
-  isLegacyPackagedPricingCatalog,
   isManagedPackagedPricingRevision,
-  managedPackagedPricingRevision,
   normalizeConfiguration,
+  packagedPricingCatalogRevision,
   pricingConfigurationSignature,
   pricingOptionsFromConfiguration,
 } = require("../core/configuration");
@@ -43,6 +43,7 @@ const DEFAULT_CLICKHOUSE_DATABASE = "tokenomics";
 const DEFAULT_CLICKHOUSE_INSERT_BATCH_ROWS = 100_000;
 const DEFAULT_CLICKHOUSE_INSERT_BATCH_BYTES = 32 * 1024 * 1024;
 const CLICKHOUSE_SOURCE_TABLES = ["telemetry_events", "rate_limit_samples", "output_char_metrics", "usage_events", "sessions", "codex_sessions"];
+const CLICKHOUSE_PRICING_PROJECTION_REVISION = "2";
 
 function parseByteSize(value, flagName) {
   const text = String(value ?? "").trim();
@@ -384,6 +385,16 @@ function createClickHouseBackend(dependencies = {}) {
       ORDER BY (committed_at_ms, revision)
     `);
     await clickHouseRequest(client, `
+      CREATE TABLE IF NOT EXISTS configuration_metadata (
+        revision String CODEC(ZSTD(3)),
+        written_at_ms UInt64 CODEC(Delta, ZSTD(1)),
+        managed_pricing UInt8 CODEC(T64, ZSTD(1)),
+        packaged_revision String CODEC(ZSTD(1)),
+        pricing_projection_revision String CODEC(ZSTD(1))
+      ) ENGINE = MergeTree
+      ORDER BY (revision, written_at_ms)
+    `);
+    await clickHouseRequest(client, `
       CREATE TABLE IF NOT EXISTS analytics_settings (
         revision String CODEC(ZSTD(3)),
         key LowCardinality(String) CODEC(ZSTD(1)),
@@ -468,6 +479,7 @@ function createClickHouseBackend(dependencies = {}) {
       "import_generations",
       "import_generation_sources",
       "configuration_revisions",
+      "configuration_metadata",
       "analytics_settings",
       "pricing_catalog",
       "usage_event_costs",
@@ -546,10 +558,23 @@ function createClickHouseBackend(dependencies = {}) {
       WHERE revision = {revision:String}
       ORDER BY provider, model, variant, row_id
     `, { params: { revision } });
+    const metadataRows = await clickHouseJsonEachRow(client, `
+      SELECT managed_pricing, packaged_revision, pricing_projection_revision
+      FROM configuration_metadata
+      WHERE revision = {revision:String}
+      ORDER BY written_at_ms DESC
+      LIMIT 1
+    `, { params: { revision } });
+    const metadata = metadataRows[0] || {};
     return {
       revision,
       settings: Object.fromEntries(settingsRows.map((row) => [row.key, JSON.parse(row.value_json)])),
       prices: priceRows.map(clickHousePricingRow),
+      clickHouseMetadata: {
+        managedPricing: number(metadata.managed_pricing) === 1,
+        packagedRevision: String(metadata.packaged_revision || ""),
+        pricingProjectionRevision: String(metadata.pricing_projection_revision || ""),
+      },
     };
   }
 
@@ -557,8 +582,20 @@ function createClickHouseBackend(dependencies = {}) {
     return normalizeConfiguration(await clickHouseConfigurationSourceAtRevision(client, revision));
   }
 
-  async function insertClickHouseConfigurationData(client, configuration, options = {}) {
+  async function insertClickHouseConfigurationData(client, configuration, options = {}, metadata = {}) {
     const normalized = normalizeConfiguration(configuration);
+    const managedPricing = metadata.managedPricing ?? /^packaged-\d+$/.test(normalized.settings.pricingRevision);
+    await clickHouseInsertRows(client, "configuration_metadata", [{
+      revision: normalized.revision,
+      written_at_ms: Date.now(),
+      managed_pricing: managedPricing ? 1 : 0,
+      packaged_revision: managedPricing
+        ? String(metadata.packagedRevision || PACKAGED_CONFIGURATION_REVISION)
+        : "",
+      pricing_projection_revision: String(
+        metadata.pricingProjectionRevision || CLICKHOUSE_PRICING_PROJECTION_REVISION,
+      ),
+    }], options);
     await clickHouseInsertRows(client, "analytics_settings", Object.entries(normalized.settings).map(([key, value]) => ({
       revision: normalized.revision,
       key,
@@ -607,27 +644,78 @@ function createClickHouseBackend(dependencies = {}) {
     const storedPricingRevision = String(
       source.settings?.pricingRevision || source.revision || "",
     ).trim();
-    const legacyManagedPricing = source.settings?.pricingBasis === "standard" &&
-      isDerivedPackagedPricingRevision(storedPricingRevision) &&
-      isLegacyPackagedPricingCatalog(source.prices);
-    const configuration = normalizeConfiguration(legacyManagedPricing
-      ? {
+    const currentPackagedVersion = Number(PACKAGED_CONFIGURATION_REVISION.replace("packaged-", ""));
+    const storedPublicPackagedMatch = storedPricingRevision.match(
+      /^packaged-(\d+)(?::(?:managed:)?[0-9a-f]{32})?$/,
+    );
+    if (source.settings?.pricingBasis === "standard" && storedPublicPackagedMatch &&
+        Number(storedPublicPackagedMatch[1]) > currentPackagedVersion) {
+      throw new Error(
+        `stored packaged pricing revision ${storedPricingRevision} is newer than ${PACKAGED_CONFIGURATION_REVISION}`,
+      );
+    }
+    const inferredPackagedRevision = source.settings?.pricingBasis === "standard" &&
+      isDerivedPackagedPricingRevision(storedPricingRevision)
+      ? packagedPricingCatalogRevision(source.prices)
+      : "";
+    const legacyManagedPricing = inferredPackagedRevision === LEGACY_PACKAGED_CONFIGURATION_REVISION;
+    const metadataManagedPricing = source.clickHouseMetadata.managedPricing;
+    const storedPackagedMatch = source.clickHouseMetadata.packagedRevision.match(/^packaged-(\d+)$/);
+    if (metadataManagedPricing && storedPackagedMatch && Number(storedPackagedMatch[1]) > currentPackagedVersion) {
+      throw new Error(
+        `ClickHouse packaged pricing revision ${source.clickHouseMetadata.packagedRevision} is newer than ${PACKAGED_CONFIGURATION_REVISION}`,
+      );
+    }
+    const packagedMetadataStale = metadataManagedPricing &&
+      source.clickHouseMetadata.packagedRevision !== PACKAGED_CONFIGURATION_REVISION;
+    const inferredPackagedStale = inferredPackagedRevision &&
+      inferredPackagedRevision !== PACKAGED_CONFIGURATION_REVISION;
+    let normalizationSource = source;
+    if (legacyManagedPricing) {
+      normalizationSource = {
         ...source,
         settings: {
           ...source.settings,
           pricingRevision: LEGACY_PACKAGED_CONFIGURATION_REVISION,
         },
-      }
-      : source);
-    const managedPricing = legacyManagedPricing || isManagedPackagedPricingRevision(storedPricingRevision) ||
+      };
+    } else if (packagedMetadataStale) {
+      normalizationSource = {
+        ...source,
+        settings: {
+          ...source.settings,
+          pricingRevision: source.clickHouseMetadata.packagedRevision || PACKAGED_CONFIGURATION_REVISION,
+        },
+      };
+    } else if (inferredPackagedStale) {
+      normalizationSource = {
+        ...source,
+        settings: {
+          ...source.settings,
+          pricingRevision: inferredPackagedRevision,
+        },
+      };
+    }
+    const configuration = normalizeConfiguration(normalizationSource);
+    const managedPricing = metadataManagedPricing || Boolean(inferredPackagedRevision) ||
+      isManagedPackagedPricingRevision(storedPricingRevision) ||
       /^packaged-\d+$/.test(storedPricingRevision);
-    if (storedPricingRevision === configuration.settings.pricingRevision) return configuration;
+    const storedProjectionRevision = source.clickHouseMetadata.pricingProjectionRevision;
+    const storedProjectionNumber = /^\d+$/.test(storedProjectionRevision)
+      ? Number(storedProjectionRevision)
+      : null;
+    if (storedProjectionNumber !== null && storedProjectionNumber > Number(CLICKHOUSE_PRICING_PROJECTION_REVISION)) {
+      throw new Error(
+        `ClickHouse pricing projection revision ${storedProjectionRevision} is newer than ${CLICKHOUSE_PRICING_PROJECTION_REVISION}`,
+      );
+    }
+    const projectionStale = storedProjectionRevision !== CLICKHOUSE_PRICING_PROJECTION_REVISION;
+    if (storedPricingRevision === configuration.settings.pricingRevision && !projectionStale) return configuration;
 
-    // A packaged pricing-engine revision changed. Publish the normalized
-    // catalog and its repricing overlays under a fresh append-only
-    // configuration revision, then expose the marker last. This makes newly
-    // supported models visible for already-imported usage without reopening
-    // source transcripts.
+    // A catalog or ClickHouse projection revision changed. Publish the
+    // normalized catalog and its repricing overlays under a fresh append-only
+    // configuration revision, then expose the marker last. This makes pricing
+    // changes visible for already-imported usage without reopening transcripts.
     const upgradeRevision = randomUUID();
     const upgraded = normalizeConfiguration({
       ...configuration,
@@ -638,12 +726,13 @@ function createClickHouseBackend(dependencies = {}) {
         // Retries and concurrent starters then write disjoint overlay keys.
         // Preserve managed provenance without claiming derived catalogs are
         // safe to replace during a later packaged upgrade.
-        pricingRevision: managedPricing
-          ? managedPackagedPricingRevision(upgradeRevision)
-          : upgradeRevision,
+        pricingRevision: upgradeRevision,
       },
     });
-    await insertClickHouseConfigurationData(client, upgraded, options);
+    await insertClickHouseConfigurationData(client, upgraded, options, {
+      managedPricing,
+      packagedRevision: managedPricing ? PACKAGED_CONFIGURATION_REVISION : "",
+    });
     const generation = await ensureClickHouseBaselineGeneration(client, options);
     await insertClickHousePricingOverlays(client, upgraded, generation?.generation_id || "");
     return commitClickHouseConfiguration(
@@ -665,13 +754,15 @@ function createClickHouseBackend(dependencies = {}) {
     const candidate = normalizeConfiguration(source);
     const client = clickHouseClient(options);
     await initializeClickHouseDatabase(client);
+    await ensureClickHouseConfiguration(client, options);
     const current = await latestClickHouseConfigurationRevision(client);
     if (!current || current.revision !== candidate.revision) {
       const error = new Error("configuration revision conflict");
       error.statusCode = 409;
       throw error;
     }
-    const currentConfiguration = await configurationAtClickHouseRevision(client, current.revision);
+    const currentSource = await clickHouseConfigurationSourceAtRevision(client, current.revision);
+    const currentConfiguration = normalizeConfiguration(currentSource);
     const nextRevision = randomUUID();
     const pricingChanged = pricingConfigurationSignature(currentConfiguration) !== pricingConfigurationSignature(candidate);
     const next = normalizeConfiguration({
@@ -682,7 +773,10 @@ function createClickHouseBackend(dependencies = {}) {
         pricingRevision: pricingChanged ? nextRevision : currentConfiguration.settings.pricingRevision,
       },
     });
-    await insertClickHouseConfigurationData(client, next, options);
+    await insertClickHouseConfigurationData(client, next, options, {
+      managedPricing: !pricingChanged && currentSource.clickHouseMetadata.managedPricing,
+      packagedRevision: !pricingChanged ? currentSource.clickHouseMetadata.packagedRevision : "",
+    });
     if (pricingChanged) {
       const generation = await ensureClickHouseBaselineGeneration(client, options);
       await insertClickHousePricingOverlays(client, next, generation?.generation_id || "");
@@ -1214,7 +1308,9 @@ function createClickHouseBackend(dependencies = {}) {
   }
 
   async function insertClickHousePricingOverlays(client, configuration, generationId) {
-    const usageDefinitions = clickHouseRepricedDefinitions("usage_events", "repriced_usage_events", configuration);
+    const usageDefinitions = clickHouseRepricedDefinitions("usage_events", "repriced_usage_events", configuration, {
+      timestamp: "raw.timestamp",
+    });
     await clickHouseRequest(client, `
       INSERT INTO usage_event_costs (
         pricing_revision, source_path, import_id, line_no, priced, cost_usd,

--- a/test/clickhouse.test.js
+++ b/test/clickhouse.test.js
@@ -185,6 +185,17 @@ function createClickHouseServer({ failureStatus = null, failureBody = "", failur
         return;
       }
 
+      if (query.includes("FROM configuration_metadata") && query.includes("pricing_projection_revision")) {
+        const revision = url.searchParams.get("param_revision");
+        const rows = (activeRows.configuration_metadata || [])
+          .filter((row) => row.revision === revision)
+          .sort((a, b) => Number(b.written_at_ms) - Number(a.written_at_ms))
+          .slice(0, 1);
+        response.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
+        response.end(rows.map((row) => JSON.stringify(row)).join("\n") + (rows.length ? "\n" : ""));
+        return;
+      }
+
       if (query.includes("FROM pricing_catalog") && query.includes("ORDER BY provider")) {
         const revision = url.searchParams.get("param_revision");
         const rows = (activeRows.pricing_catalog || []).filter((row) => row.revision === revision);
@@ -307,6 +318,8 @@ test("ClickHouse configuration revisions publish marker-last and reject stale wr
     const markerInsert = mock.requests.findLastIndex((request) => request.query.startsWith("INSERT INTO configuration_revisions"));
     assert.ok(settingsInsert >= 0 && pricingInsert > settingsInsert);
     assert.ok(usageOverlay > pricingInsert && rateLimitOverlay > usageOverlay && markerInsert > rateLimitOverlay);
+    const usageOverlayQuery = mock.requests[usageOverlay].query;
+    assert.match(usageOverlayQuery, /parseDateTime64BestEffortOrNull\(toString\(raw\.timestamp\)\)/);
     const rateLimitOverlayQuery = mock.requests[rateLimitOverlay].query;
     assert.doesNotMatch(rateLimitOverlayQuery, /raw\.service_mode/);
     assert.match(rateLimitOverlayQuery, /'unknown' = 'fast'/);
@@ -336,7 +349,7 @@ test("ClickHouse packaged pricing upgrade publishes Opus 5 overlays before the r
     const requests = mock.requests.slice(before);
 
     assert.notEqual(upgraded.revision, legacyRevision);
-    assert.match(upgraded.settings.pricingRevision, /^packaged-4:managed:[0-9a-f]{32}$/);
+    assert.match(upgraded.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
     assert.ok(upgraded.prices.some((row) => row.provider === "anthropic" && row.model === "claude-opus-5"));
     const usageOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO usage_event_costs"));
     const rateLimitOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO rate_limit_sample_costs"));
@@ -393,7 +406,7 @@ test("ClickHouse packaged-3 migration materializes temporal Luna and Terra rows 
     const requests = mock.requests.slice(before);
 
     assert.notEqual(upgraded.revision, legacyRevision);
-    assert.match(upgraded.settings.pricingRevision, /^packaged-4:managed:[0-9a-f]{32}$/);
+    assert.match(upgraded.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
     assert.ok(upgraded.prices.some((row) => row.provider === "anthropic" && row.model === "claude-opus-5"));
     const temporalRows = upgraded.prices.filter((row) => temporalModels.has(row.model));
     assert.equal(temporalRows.length, 8);
@@ -467,7 +480,170 @@ test("ClickHouse repairs a chained derived packaged migration only for an unchan
     assert.equal(requests.some((request) => request.query.startsWith("INSERT INTO sources")), false);
     assert.ok(requests.some((request) => request.query.trimStart().startsWith("INSERT INTO usage_event_costs")));
     assert.ok(requests.some((request) => request.query.trimStart().startsWith("INSERT INTO rate_limit_sample_costs")));
-    assert.match(upgraded.settings.pricingRevision, /^packaged-4:managed:[0-9a-f]{32}$/);
+    assert.match(upgraded.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
+
+    const stableStart = mock.requests.length;
+    assert.equal((await loadConfiguration(options)).revision, upgraded.revision);
+    assert.equal(mock.requests.slice(stableStart).some((request) => request.query.trimStart().startsWith("INSERT INTO")), false);
+
+    const futureMetadata = mock.activeRows.configuration_metadata.find((row) => row.revision === upgraded.revision);
+    futureMetadata.pricing_projection_revision = "3";
+    const futureProjectionStart = mock.requests.length;
+    await assert.rejects(loadConfiguration(options), /projection revision 3 is newer than 2/);
+    assert.equal(mock.requests.slice(futureProjectionStart).some((request) => request.query.trimStart().startsWith("INSERT INTO")), false);
+
+    futureMetadata.pricing_projection_revision = "2";
+    futureMetadata.packaged_revision = "packaged-5";
+    const futurePackageStart = mock.requests.length;
+    await assert.rejects(loadConfiguration(options), /packaged pricing revision packaged-5 is newer than packaged-4/);
+    assert.equal(mock.requests.slice(futurePackageStart).some((request) => request.query.trimStart().startsWith("INSERT INTO")), false);
+
+    mock.activeRows.configuration_metadata = mock.activeRows.configuration_metadata
+      .filter((row) => row.revision !== upgraded.revision);
+    mock.activeRows.analytics_settings.find((row) => (
+      row.revision === upgraded.revision && row.key === "pricingRevision"
+    )).value_json = JSON.stringify(`packaged-5:${"e".repeat(32)}`);
+    const futurePublicStart = mock.requests.length;
+    await assert.rejects(loadConfiguration(options), /stored packaged pricing revision packaged-5:.* is newer than packaged-4/);
+    assert.equal(mock.requests.slice(futurePublicStart).some((request) => request.query.trimStart().startsWith("INSERT INTO")), false);
+  });
+});
+
+test("ClickHouse rebuilds managed overlays when projection metadata is stale", async () => {
+  const mock = createClickHouseServer();
+  await withServer(mock, async (clickhouseUrl) => {
+    const options = defaultOptions({ dbEngine: "clickhouse", clickhouseUrl, clickhouseDatabase: "tokenomics_managed_overlay_rebuild_test" });
+    await loadConfiguration(options);
+
+    const legacyRevision = "legacy-managed-packaged-4";
+    const legacyPricingRevision = `packaged-4:managed:${"c".repeat(32)}`;
+    mock.activeRows.configuration_revisions[0].revision = legacyRevision;
+    for (const row of mock.activeRows.analytics_settings) {
+      row.revision = legacyRevision;
+      if (row.key === "pricingRevision") row.value_json = JSON.stringify(legacyPricingRevision);
+    }
+    for (const row of mock.activeRows.configuration_metadata) {
+      row.revision = legacyRevision;
+      row.managed_pricing = 1;
+      row.packaged_revision = "packaged-4";
+      row.pricing_projection_revision = "stale";
+    }
+    mock.activeRows.pricing_catalog = mock.activeRows.pricing_catalog
+      .map((row) => ({ ...row, revision: legacyRevision }));
+
+    const before = mock.requests.length;
+    const upgraded = await loadConfiguration(options);
+    const requests = mock.requests.slice(before);
+
+    assert.notEqual(upgraded.revision, legacyRevision);
+    assert.match(upgraded.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
+    assert.equal(requests.some((request) => request.query.startsWith("INSERT INTO sources")), false);
+    const usageOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO usage_event_costs"));
+    const rateLimitOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO rate_limit_sample_costs"));
+    const marker = requests.findIndex((request) => request.query.startsWith("INSERT INTO configuration_revisions"));
+    assert.ok(usageOverlay >= 0 && rateLimitOverlay > usageOverlay && marker > rateLimitOverlay);
+    assert.match(requests[usageOverlay].query, /parseDateTime64BestEffortOrNull\(toString\(raw\.timestamp\)\)/);
+
+    const stableStart = mock.requests.length;
+    assert.equal((await loadConfiguration(options)).revision, upgraded.revision);
+    assert.equal(mock.requests.slice(stableStart).some((request) => request.query.trimStart().startsWith("INSERT INTO")), false);
+  });
+});
+
+test("ClickHouse restores managed provenance after an old profile-only writer", async () => {
+  const mock = createClickHouseServer();
+  await withServer(mock, async (clickhouseUrl) => {
+    const options = defaultOptions({ dbEngine: "clickhouse", clickhouseUrl, clickhouseDatabase: "tokenomics_old_profile_writer_test" });
+    await loadConfiguration(options);
+
+    const legacyRevision = "old-compatible-profile-write";
+    const legacyPricingRevision = `packaged-4:${"d".repeat(32)}`;
+    mock.activeRows.configuration_revisions[0].revision = legacyRevision;
+    for (const row of mock.activeRows.analytics_settings) {
+      row.revision = legacyRevision;
+      if (row.key === "pricingRevision") row.value_json = JSON.stringify(legacyPricingRevision);
+      if (row.key === "monthlyCostLimitUsd") row.value_json = JSON.stringify(321);
+    }
+    mock.activeRows.configuration_metadata = [];
+    mock.activeRows.pricing_catalog = mock.activeRows.pricing_catalog
+      .map((row) => ({ ...row, revision: legacyRevision }));
+
+    const before = mock.requests.length;
+    const upgraded = await loadConfiguration(options);
+    const requests = mock.requests.slice(before);
+
+    assert.notEqual(upgraded.revision, legacyRevision);
+    assert.match(upgraded.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
+    assert.equal(upgraded.settings.monthlyCostLimitUsd, 321);
+    assert.equal(requests.some((request) => request.query.startsWith("INSERT INTO sources")), false);
+    const usageOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO usage_event_costs"));
+    const marker = requests.findIndex((request) => request.query.startsWith("INSERT INTO configuration_revisions"));
+    assert.ok(usageOverlay >= 0 && marker > usageOverlay);
+    assert.match(requests[usageOverlay].query, /parseDateTime64BestEffortOrNull\(toString\(raw\.timestamp\)\)/);
+    assert.ok(mock.activeRows.configuration_metadata.some((row) => (
+      row.revision === upgraded.revision && row.managed_pricing === 1 &&
+      row.packaged_revision === "packaged-4" && row.pricing_projection_revision === "2"
+    )));
+
+    const stableStart = mock.requests.length;
+    assert.equal((await loadConfiguration(options)).revision, upgraded.revision);
+    assert.equal(mock.requests.slice(stableStart).some((request) => request.query.trimStart().startsWith("INSERT INTO")), false);
+  });
+});
+
+test("ClickHouse projection revisions invalidate custom pricing overlays", async () => {
+  const mock = createClickHouseServer();
+  await withServer(mock, async (clickhouseUrl) => {
+    const options = defaultOptions({ dbEngine: "clickhouse", clickhouseUrl, clickhouseDatabase: "tokenomics_custom_overlay_rebuild_test" });
+    const initial = await loadConfiguration(options);
+
+    const legacyRevision = "legacy-custom-projection";
+    const legacyPricingRevision = "custom-temporal-prices";
+    for (const row of mock.activeRows.configuration_revisions) row.revision = legacyRevision;
+    for (const row of mock.activeRows.analytics_settings) {
+      row.revision = legacyRevision;
+      if (row.key === "pricingBasis") row.value_json = JSON.stringify("custom");
+      if (row.key === "pricingRevision") row.value_json = JSON.stringify(legacyPricingRevision);
+    }
+    mock.activeRows.configuration_metadata = [];
+    mock.activeRows.pricing_catalog = mock.activeRows.pricing_catalog.map((row) => ({
+      ...row,
+      revision: legacyRevision,
+      input: row.model === "gpt-5.6-luna" && row.variant === "short" && row.effective_until
+        ? 7
+        : row.input,
+    }));
+
+    const staleWrite = structuredClone(initial);
+    staleWrite.revision = legacyRevision;
+    staleWrite.settings.pricingBasis = "custom";
+    staleWrite.settings.pricingRevision = legacyPricingRevision;
+    staleWrite.settings.monthlyCostLimitUsd = 123;
+    staleWrite.prices.find((row) => (
+      row.model === "gpt-5.6-luna" && row.variant === "short" && row.effectiveUntil
+    )).input = 7;
+    const before = mock.requests.length;
+    await assert.rejects(saveConfiguration(options, staleWrite), /configuration revision conflict/);
+    const upgraded = await loadConfiguration(options);
+    const requests = mock.requests.slice(before);
+    const historicalLuna = upgraded.prices.find((row) => (
+      row.model === "gpt-5.6-luna" && row.variant === "short" && row.effectiveUntil
+    ));
+
+    assert.notEqual(upgraded.revision, legacyRevision);
+    assert.equal(upgraded.settings.pricingBasis, "custom");
+    assert.notEqual(upgraded.settings.pricingRevision, legacyPricingRevision);
+    assert.equal(upgraded.settings.monthlyCostLimitUsd, null);
+    assert.equal(historicalLuna.input, 7);
+    const usageOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO usage_event_costs"));
+    const rateLimitOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO rate_limit_sample_costs"));
+    const marker = requests.findIndex((request) => request.query.startsWith("INSERT INTO configuration_revisions"));
+    assert.ok(usageOverlay >= 0 && rateLimitOverlay > usageOverlay && marker > rateLimitOverlay);
+    assert.match(requests[usageOverlay].query, /parseDateTime64BestEffortOrNull\(toString\(raw\.timestamp\)\)/);
+    assert.ok(mock.activeRows.configuration_metadata.some((row) => (
+      row.revision === upgraded.revision && row.managed_pricing === 0 &&
+      row.pricing_projection_revision === "2"
+    )));
 
     const stableStart = mock.requests.length;
     assert.equal((await loadConfiguration(options)).revision, upgraded.revision);
@@ -489,6 +665,12 @@ test("ClickHouse preserves edited standard rows while rebasing only older derive
     for (const row of mock.activeRows.analytics_settings) {
       row.revision = legacyRevision;
       if (row.key === "pricingRevision") row.value_json = JSON.stringify(legacyPricingRevision);
+    }
+    for (const row of mock.activeRows.configuration_metadata) {
+      row.revision = legacyRevision;
+      row.managed_pricing = 0;
+      row.packaged_revision = "";
+      row.pricing_projection_revision = "2";
     }
     mock.activeRows.pricing_catalog = mock.activeRows.pricing_catalog.flatMap((row) => {
       if (!temporalModels.has(row.model)) return [{ ...row, revision: legacyRevision }];

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -7,8 +7,10 @@ const Path = require("node:path");
 const test = require("node:test");
 const {
   defaultConfiguration,
+  isCurrentPackagedPricingCatalog,
   isLegacyPackagedPricingCatalog,
   normalizeConfiguration,
+  packagedPricingCatalogRevision,
 } = require("../lib/core/configuration");
 const { calculateCost } = require("../lib/core/pricing");
 const { loadConfiguration, saveConfiguration } = require("../app");
@@ -118,8 +120,20 @@ test("legacy packaged catalog recognition rejects even tiny tariff edits", () =>
   });
 
   assert.equal(isLegacyPackagedPricingCatalog(legacy), true);
+  assert.equal(packagedPricingCatalogRevision(legacy), "packaged-3");
   legacy.find((row) => row.model === "gpt-5.6-luna" && row.variant === "short").input = 1.000000000000001;
   assert.equal(isLegacyPackagedPricingCatalog(legacy), false);
+  assert.equal(packagedPricingCatalogRevision(legacy), "");
+});
+
+test("current packaged catalog recognition rejects even tiny tariff edits", () => {
+  const current = defaultConfiguration().prices;
+
+  assert.equal(isCurrentPackagedPricingCatalog(current), true);
+  assert.equal(packagedPricingCatalogRevision(current), "packaged-4");
+  current.find((row) => row.model === "gpt-5.6-luna" && row.variant === "short" && row.effectiveFrom).input += Number.EPSILON;
+  assert.equal(isCurrentPackagedPricingCatalog(current), false);
+  assert.equal(packagedPricingCatalogRevision(current), "");
 });
 
 test("packaged-2 pricing is upgraded with Opus 5 without replacing persisted rows", () => {


### PR DESCRIPTION
## Summary

Follow-up to #7, which merged before runtime validation completed.

- evaluate temporal ClickHouse pricing rows using each usage event timestamp instead of startup time
- version persisted overlay projection semantics and rebuild stale managed, derived, and custom overlays exactly once
- retain packaged provenance in a separate metadata table while keeping the public pricing revision compatible with older readers
- recover provenance after an old profile-only writer only for exact known packaged snapshots
- fail closed on future public, packaged-metadata, or projection revisions

## Runtime falsifier

After #7 repaired the 63-row catalog to 67 temporal rows, the active ClickHouse catalog was correct but historical Luna overlays were not:

- actual historical Luna: $83.08875936
- independent expected historical Luna: $415.44379680
- current/post-boundary Luna matched exactly: $14.81187788

The overlay SQL used `now64(3)` because `raw.timestamp` was not passed to the pricing projection.

## Verification

- `npm test`: 259 passed, 0 failed
- focused configuration/pricing/ClickHouse/SQLite tests: 61 passed, 0 failed
- syntax and `git diff --check`: passed
- exact nominal and observed ClickHouse catalog signatures reject tiny tariff edits
- independent hostile review: APPROVE, no blocker/major findings
- follow-up branch tree is identical to the reviewed corrective tree

## Compatibility and safety

Metadata is stored outside `analytics_settings`, so older readers do not reject an unknown setting. Public revisions keep the compatible `packaged-N:<hash>` form. Overlay and metadata rows are append-only and published before the configuration marker. Missing or stale metadata rebuilds; future revisions abort without INSERT. Source transcripts are not reimported.

Residual risk: future packaged snapshots must remain registered for mixed-version provenance recovery; an actual future-binary rolling test is not available locally.
