### PR TITLE
Add automatic macOS launcher and quota cockpit

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Verify the Node to Swift contract fixture
         run: |
           node scripts/generate-macos-summary-fixture.js
-          git diff --exit-code -- mac/Tests/TokenomicsMenubarTests/Fixtures/summary-v1.json
+          git diff --exit-code -- mac/Tests/TokenomicsMenubarTests/Fixtures
           node --test test/macos-contract.test.js
       - name: Run tests
         run: swift test -Xswiftc -warnings-as-errors

--- a/mac/README.md
+++ b/mac/README.md
@@ -1,8 +1,9 @@
 # Native macOS menu bar client
 
 This is a small macOS 14+ companion for the local Tokenomics service. It shows
-today's and month-to-date usage in the menu bar, with a compact provider
-breakdown and daily chart.
+today's and month-to-date usage in the menu bar, with subscription quota
+windows, a compact provider breakdown, and a daily chart. The menu-bar label
+can show today's usage, shortest-window quota use, or its reset countdown.
 
 The native client is a renderer and lifecycle companion, not a second analytics
 engine. The local Node service owns ClickHouse access, sync, calendar, and
@@ -15,8 +16,11 @@ budget policy; the Swift app consumes its versioned summary contract.
 Run the repository's one-line installer first. On macOS it atomically writes
 `~/Library/Application Support/Tokenomics Viewer/tokenomics-launch.json`, so
 the app can start the installed `tokenomics-launch` wrapper when the configured
-loopback service is offline. A source-only setup can select an executable
-wrapper in **Settings → Launcher fallback**.
+loopback service is offline. On launch, wake, and refresh, the app probes that
+exact endpoint and starts the wrapper with `--no-open` only when no Tokenomics
+service answers. It does not replace an unrelated service occupying the port,
+and only **Open Dashboard** opens a browser. A source-only setup can select an
+executable wrapper in **Settings → Launcher fallback**.
 
 ```sh
 cd mac

--- a/mac/Sources/TokenomicsMenubar/ConnectionCoordinator.swift
+++ b/mac/Sources/TokenomicsMenubar/ConnectionCoordinator.swift
@@ -114,29 +114,28 @@ public final class ConnectionCoordinator: ObservableObject {
     /// A user-initiated refresh always asks the backend to coalesce a sync,
     /// even when automatic sync is disabled.
     public func refresh(triggerSync: Bool = true) {
-        refresh(triggerSync: triggerSync, allowLaunch: false)
+        scheduleRefresh(triggerSync: triggerSync)
     }
 
     public func startTokenomics() {
         guard canStartTokenomics, !isRefreshing else { return }
         launcherProcess?.stop()
         launcherProcess = nil
-        refresh(triggerSync: true, allowLaunch: true)
+        scheduleRefresh(triggerSync: true)
     }
 
     public var canStartTokenomics: Bool {
         launcherConfiguration() != nil
     }
 
-    private func refresh(triggerSync: Bool, allowLaunch: Bool) {
+    private func scheduleRefresh(triggerSync: Bool) {
         operationTask?.cancel()
         operationGeneration += 1
         let generation = operationGeneration
         operationTask = Task { @MainActor [weak self] in
             await self?.runRefresh(
                 generation: generation,
-                triggerSync: triggerSync,
-                allowLaunch: allowLaunch
+                triggerSync: triggerSync
             )
         }
     }
@@ -152,9 +151,9 @@ public final class ConnectionCoordinator: ObservableObject {
     public func wake() {
         guard automaticStarted else { return }
         if preferences.automaticSyncEnabled {
-            refresh(triggerSync: true)
+            scheduleRefresh(triggerSync: true)
         } else {
-            refresh(triggerSync: false)
+            scheduleRefresh(triggerSync: false)
         }
     }
 
@@ -173,21 +172,18 @@ public final class ConnectionCoordinator: ObservableObject {
             seenUTCDate = today
             guard preferences.automaticSyncEnabled || rolledOver else { continue }
             if isRefreshing { continue }
-            refresh(triggerSync: preferences.automaticSyncEnabled)
+            scheduleRefresh(triggerSync: preferences.automaticSyncEnabled)
         }
     }
 
-    private func runRefresh(generation: Int, triggerSync: Bool, allowLaunch: Bool) async {
+    private func runRefresh(generation: Int, triggerSync: Bool) async {
         isRefreshing = true
         defer {
             if generation == operationGeneration { isRefreshing = false }
         }
         state = .finding
         do {
-            let discovery = try await findOrStartEndpoint(
-                generation: generation,
-                allowLaunch: allowLaunch
-            )
+            let discovery = try await findOrStartEndpoint(generation: generation)
             guard isCurrent(generation) else { return }
             let selected = discovery.endpoint
             endpoint = selected
@@ -239,10 +235,7 @@ public final class ConnectionCoordinator: ObservableObject {
         }
     }
 
-    private func findOrStartEndpoint(
-        generation: Int,
-        allowLaunch: Bool
-    ) async throws -> (endpoint: Endpoint, launched: Bool) {
+    private func findOrStartEndpoint(generation: Int) async throws -> (endpoint: Endpoint, launched: Bool) {
         let ordered = PortDiscovery.orderedEndpoints(preferred: preferences.preferredPort, active: preferences.activeEndpoint)
         guard let candidate = ordered.first else {
             throw EndpointError.network("The configured Tokenomics port is invalid.")
@@ -261,9 +254,15 @@ public final class ConnectionCoordinator: ObservableObject {
         } catch is CancellationError {
             throw CancellationError()
         } catch {
-            guard allowLaunch else {
-                throw EndpointError.network("Tokenomics is unavailable on port \(candidate.port).")
+            // No Tokenomics service answered on the exact configured endpoint;
+            // fall through to the configured launcher.
+        }
+
+        if let launcherProcess {
+            guard !launcherProcess.isRunning else {
+                throw EndpointError.network("The Tokenomics launcher is running, but its service is not ready on port \(candidate.port).")
             }
+            self.launcherProcess = nil
         }
 
         guard let launchConfiguration = launcherConfiguration() else {

--- a/mac/Sources/TokenomicsMenubar/Models.swift
+++ b/mac/Sources/TokenomicsMenubar/Models.swift
@@ -228,6 +228,81 @@ public struct UsageProfile: Decodable, Equatable, Sendable {
     private enum CodingKeys: String, CodingKey { case id, name, mode }
 }
 
+public struct SubscriptionWindow: Decodable, Equatable, Sendable, Identifiable {
+    public var key: String
+    public var provider: String?
+    public var limitID: String?
+    public var kind: String?
+    public var planType: String?
+    public var windowMinutes: Int
+    public var usedPercent: Double?
+    public var remainingPercent: Double?
+    public var latestAt: Date?
+    public var resetAt: Date?
+    public var apiEquivalentCostUSD: Double?
+    public var projectedFullWindowApiEquivalentUSD: Double?
+
+    public var id: String { key }
+
+    public init(
+        key: String,
+        provider: String? = nil,
+        limitID: String? = nil,
+        kind: String? = nil,
+        planType: String? = nil,
+        windowMinutes: Int,
+        usedPercent: Double? = nil,
+        remainingPercent: Double? = nil,
+        latestAt: Date? = nil,
+        resetAt: Date? = nil,
+        apiEquivalentCostUSD: Double? = nil,
+        projectedFullWindowApiEquivalentUSD: Double? = nil
+    ) {
+        self.key = key
+        self.provider = provider
+        self.limitID = limitID
+        self.kind = kind
+        self.planType = planType
+        self.windowMinutes = windowMinutes
+        self.usedPercent = usedPercent
+        self.remainingPercent = remainingPercent
+        self.latestAt = latestAt
+        self.resetAt = resetAt
+        self.apiEquivalentCostUSD = apiEquivalentCostUSD
+        self.projectedFullWindowApiEquivalentUSD = projectedFullWindowApiEquivalentUSD
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case key, provider, kind, planType, windowMinutes, usedPercent, remainingPercent
+        case limitID = "limitId"
+        case latestAt, resetAt
+        case apiEquivalentCostUSD = "apiEquivalentCostUsd"
+        case projectedFullWindowApiEquivalentUSD = "projectedFullWindowApiEquivalentUsd"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        key = try values.decode(String.self, forKey: .key)
+        provider = try values.decodeIfPresent(String.self, forKey: .provider)
+        limitID = try values.decodeIfPresent(String.self, forKey: .limitID)
+        kind = try values.decodeIfPresent(String.self, forKey: .kind)
+        planType = try values.decodeIfPresent(String.self, forKey: .planType)
+        windowMinutes = try values.decode(Int.self, forKey: .windowMinutes)
+        usedPercent = try values.decodeIfPresent(Double.self, forKey: .usedPercent)
+        remainingPercent = try values.decodeIfPresent(Double.self, forKey: .remainingPercent)
+        latestAt = try values.decodeIfPresent(String.self, forKey: .latestAt).flatMap(Self.parseDate)
+        resetAt = try values.decodeIfPresent(String.self, forKey: .resetAt).flatMap(Self.parseDate)
+        apiEquivalentCostUSD = try values.decodeIfPresent(Double.self, forKey: .apiEquivalentCostUSD)
+        projectedFullWindowApiEquivalentUSD = try values.decodeIfPresent(Double.self, forKey: .projectedFullWindowApiEquivalentUSD)
+    }
+
+    private static func parseDate(_ value: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: value) ?? ISO8601DateFormatter().date(from: value)
+    }
+}
+
 public struct SummaryResponse: Decodable, Equatable, Sendable {
     public var contractVersion: Int
     public var calendarTimeZone: String?
@@ -236,6 +311,7 @@ public struct SummaryResponse: Decodable, Equatable, Sendable {
     public var generatedAt: Date?
     public var apiEquivalentCostUSD: Double?
     public var billedCostUSD: Double?
+    public var subscriptionWindows: [SubscriptionWindow]
     public var total: UsagePeriod?
     public var currentMonth: UsagePeriod?
     public var daily: [DailySpendPoint]
@@ -310,6 +386,7 @@ public struct SummaryResponse: Decodable, Equatable, Sendable {
         generatedAt: Date? = nil,
         apiEquivalentCostUSD: Double? = nil,
         billedCostUSD: Double? = nil,
+        subscriptionWindows: [SubscriptionWindow] = [],
         total: UsagePeriod? = nil,
         currentMonth: UsagePeriod? = nil,
         daily: [DailySpendPoint] = [],
@@ -327,6 +404,7 @@ public struct SummaryResponse: Decodable, Equatable, Sendable {
         self.generatedAt = generatedAt
         self.apiEquivalentCostUSD = apiEquivalentCostUSD
         self.billedCostUSD = billedCostUSD
+        self.subscriptionWindows = subscriptionWindows
         self.total = total
         self.currentMonth = currentMonth
         self.daily = daily
@@ -341,7 +419,7 @@ public struct SummaryResponse: Decodable, Equatable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case contractVersion
         case generatedAt, calendarTimeZone, usageProfile, costSemantics
-        case apiEquivalentCostUsd, billedCostUsd, total, currentMonth, daily
+        case apiEquivalentCostUsd, billedCostUsd, subscriptionWindows, total, currentMonth, daily
         case budget
         case providerModelEffortDaily
         case configurationRevision, pricingBasis, pricingStale
@@ -363,6 +441,7 @@ public struct SummaryResponse: Decodable, Equatable, Sendable {
         costSemantics = try values.decodeIfPresent(String.self, forKey: .costSemantics)
         apiEquivalentCostUSD = try values.decodeIfPresent(Double.self, forKey: .apiEquivalentCostUsd)
         billedCostUSD = try values.decodeIfPresent(Double.self, forKey: .billedCostUsd)
+        subscriptionWindows = try values.decodeIfPresent([SubscriptionWindow].self, forKey: .subscriptionWindows) ?? []
         total = try values.decodeIfPresent(UsagePeriod.self, forKey: .total)
         currentMonth = try values.decodeIfPresent(UsagePeriod.self, forKey: .currentMonth)
         daily = try values.decodeIfPresent([DailySpendPoint].self, forKey: .daily) ?? []

--- a/mac/Sources/TokenomicsMenubar/Preferences.swift
+++ b/mac/Sources/TokenomicsMenubar/Preferences.swift
@@ -1,6 +1,22 @@
 import Foundation
 import Combine
 
+public enum MenuBarLabelMode: String, CaseIterable, Identifiable, Sendable {
+    case today
+    case quotaUsed = "quota-used"
+    case quotaReset = "quota-reset"
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .today: return "Today's usage"
+        case .quotaUsed: return "Shortest quota used"
+        case .quotaReset: return "Shortest quota reset"
+        }
+    }
+}
+
 public struct RuntimePreferences: Equatable, Sendable {
     public static let defaultPort = 8787
     public static let defaultAutomaticSyncInterval: TimeInterval = 20
@@ -12,19 +28,22 @@ public struct RuntimePreferences: Equatable, Sendable {
     public var launcherPath: String?
     public var automaticSyncEnabled: Bool
     public var automaticSyncInterval: TimeInterval
+    public var menuBarLabelMode: MenuBarLabelMode
 
     public init(
         preferredPort: Int = RuntimePreferences.defaultPort,
         activeEndpoint: Endpoint? = nil,
         launcherPath: String? = nil,
         automaticSyncEnabled: Bool = true,
-        automaticSyncInterval: TimeInterval = RuntimePreferences.defaultAutomaticSyncInterval
+        automaticSyncInterval: TimeInterval = RuntimePreferences.defaultAutomaticSyncInterval,
+        menuBarLabelMode: MenuBarLabelMode = .today
     ) {
         self.preferredPort = Self.validPort(preferredPort) ? preferredPort : Self.defaultPort
         self.activeEndpoint = activeEndpoint
         self.launcherPath = Self.validAbsolutePath(launcherPath) ? launcherPath : nil
         self.automaticSyncEnabled = automaticSyncEnabled
         self.automaticSyncInterval = Self.validInterval(automaticSyncInterval) ? automaticSyncInterval : Self.defaultAutomaticSyncInterval
+        self.menuBarLabelMode = menuBarLabelMode
     }
 
     public init(defaults: UserDefaults) {
@@ -33,12 +52,14 @@ public struct RuntimePreferences: Equatable, Sendable {
         let launcher = defaults.string(forKey: Keys.launcherPath)
         let enabled = defaults.object(forKey: Keys.automaticSyncEnabled) as? Bool ?? true
         let interval = defaults.object(forKey: Keys.automaticSyncInterval) as? Double ?? Self.defaultAutomaticSyncInterval
+        let labelMode = defaults.string(forKey: Keys.menuBarLabelMode).flatMap(MenuBarLabelMode.init(rawValue:)) ?? .today
         self.init(
             preferredPort: storedPort,
             activeEndpoint: active,
             launcherPath: launcher,
             automaticSyncEnabled: enabled,
-            automaticSyncInterval: interval
+            automaticSyncInterval: interval,
+            menuBarLabelMode: labelMode
         )
     }
 
@@ -56,6 +77,7 @@ public struct RuntimePreferences: Equatable, Sendable {
         }
         defaults.set(automaticSyncEnabled, forKey: Keys.automaticSyncEnabled)
         defaults.set(automaticSyncInterval, forKey: Keys.automaticSyncInterval)
+        defaults.set(menuBarLabelMode.rawValue, forKey: Keys.menuBarLabelMode)
     }
 
     public static func validPort(_ port: Int) -> Bool { (1...65_535).contains(port) }
@@ -83,6 +105,7 @@ public struct RuntimePreferences: Equatable, Sendable {
         static let launcherPath = "tokenomics.launcherPath"
         static let automaticSyncEnabled = "tokenomics.automaticSyncEnabled"
         static let automaticSyncInterval = "tokenomics.automaticSyncInterval"
+        static let menuBarLabelMode = "tokenomics.menuBarLabelMode"
     }
 }
 
@@ -119,6 +142,7 @@ public final class PreferencesStore: ObservableObject {
             persist()
         }
     }
+    @Published public var menuBarLabelMode: MenuBarLabelMode { didSet { persist() } }
 
     public private(set) var activeEndpoint: Endpoint? {
         didSet { persist() }
@@ -134,6 +158,7 @@ public final class PreferencesStore: ObservableObject {
         launcherPath = values.launcherPath ?? ""
         automaticSyncEnabled = values.automaticSyncEnabled
         automaticSyncInterval = values.automaticSyncInterval
+        menuBarLabelMode = values.menuBarLabelMode
         activeEndpoint = values.activeEndpoint
         isLoading = false
     }
@@ -164,7 +189,8 @@ public final class PreferencesStore: ObservableObject {
             activeEndpoint: activeEndpoint,
             launcherPath: launcherPath.isEmpty ? nil : launcherPath,
             automaticSyncEnabled: automaticSyncEnabled,
-            automaticSyncInterval: normalizedInterval()
+            automaticSyncInterval: normalizedInterval(),
+            menuBarLabelMode: menuBarLabelMode
         )
         values.save(to: defaults)
     }

--- a/mac/Sources/TokenomicsMenubar/Views.swift
+++ b/mac/Sources/TokenomicsMenubar/Views.swift
@@ -24,59 +24,158 @@ enum BudgetUsageLevel: Equatable {
     }
 }
 
+enum QuotaPresentation {
+    static func orderedWindows(_ windows: [SubscriptionWindow]) -> [SubscriptionWindow] {
+        windows
+            .filter { $0.windowMinutes > 0 }
+            .sorted { lhs, rhs in
+                lhs.windowMinutes < rhs.windowMinutes
+                    || (lhs.windowMinutes == rhs.windowMinutes && lhs.key < rhs.key)
+            }
+    }
+
+    static func shortestWindow(
+        _ windows: [SubscriptionWindow],
+        requiringReset: Bool = false
+    ) -> SubscriptionWindow? {
+        orderedWindows(windows).first { window in
+            if requiringReset { return window.resetAt != nil }
+            return normalizedPercent(window.usedPercent) != nil
+        }
+    }
+
+    static func windowLabel(minutes: Int) -> String {
+        switch minutes {
+        case 300: return "5-hour"
+        case 10_080: return "Weekly"
+        case let value where value % 1_440 == 0: return "\(value / 1_440)-day"
+        case let value where value % 60 == 0: return "\(value / 60)-hour"
+        default: return "\(minutes)-minute"
+        }
+    }
+
+    static func compactWindowLabel(minutes: Int) -> String {
+        switch minutes {
+        case 10_080: return "1w"
+        case let value where value % 1_440 == 0: return "\(value / 1_440)d"
+        case let value where value % 60 == 0: return "\(value / 60)h"
+        default: return "\(minutes)m"
+        }
+    }
+
+    static func windowTitle(_ window: SubscriptionWindow) -> String {
+        let provider: String?
+        switch window.provider?.lowercased() {
+        case "openai": provider = "OpenAI"
+        case "anthropic": provider = "Anthropic"
+        case let value?: provider = value.localizedCapitalized
+        case nil: provider = nil
+        }
+        return [provider, windowLabel(minutes: window.windowMinutes)]
+            .compactMap { $0 }
+            .joined(separator: " · ")
+    }
+
+    static func normalizedPercent(_ value: Double?) -> Double? {
+        guard let value, value.isFinite else { return nil }
+        return min(100, max(0, value))
+    }
+
+    static func percentText(_ value: Double?) -> String? {
+        normalizedPercent(value).map { String(format: "%.0f%%", $0) }
+    }
+
+    static func resetCountdown(resetAt: Date?, now: Date) -> String? {
+        guard let resetAt else { return nil }
+        let seconds = resetAt.timeIntervalSince(now)
+        guard seconds > 0 else { return "Reset pending" }
+        let minutes = max(1, Int(ceil(seconds / 60)))
+        if minutes < 60 { return "Resets in \(minutes)m" }
+        let hours = minutes / 60
+        let remainingMinutes = minutes % 60
+        if hours < 24 {
+            return remainingMinutes == 0 ? "Resets in \(hours)h" : "Resets in \(hours)h \(remainingMinutes)m"
+        }
+        let days = hours / 24
+        let remainingHours = hours % 24
+        return remainingHours == 0 ? "Resets in \(days)d" : "Resets in \(days)d \(remainingHours)h"
+    }
+}
+
+enum MenuBarPresentation {
+    static func labelText(
+        payload: SummaryResponse,
+        mode: MenuBarLabelMode,
+        now: Date
+    ) -> String? {
+        switch mode {
+        case .today:
+            guard payload.hasAnyUsageValue, let today = payload.currentDay(on: now)?.amountUSD else { return nil }
+            let prefix = payload.costSemantics == "api-equivalent" ? "Today eq." : "Today"
+            let denominator = todayDenominator(payload)
+            if let denominator {
+                return "\(prefix) \(Presentation.compactCurrency(today))/\(Presentation.compactCurrency(denominator))"
+            }
+            return "\(prefix) \(Presentation.compactCurrency(today))"
+        case .quotaUsed:
+            guard let window = QuotaPresentation.shortestWindow(payload.subscriptionWindows),
+                  let used = QuotaPresentation.percentText(window.usedPercent)
+            else { return nil }
+            return "\(QuotaPresentation.compactWindowLabel(minutes: window.windowMinutes)) \(used)"
+        case .quotaReset:
+            guard let window = QuotaPresentation.shortestWindow(payload.subscriptionWindows, requiringReset: true),
+                  let reset = QuotaPresentation.resetCountdown(resetAt: window.resetAt, now: now)
+            else { return nil }
+            return "\(QuotaPresentation.compactWindowLabel(minutes: window.windowMinutes)) \(reset.replacingOccurrences(of: "Resets in ", with: ""))"
+        }
+    }
+
+    private static func todayDenominator(_ payload: SummaryResponse) -> Double? {
+        guard payload.budget.todayScheduled ?? true else { return nil }
+        let profileMode = payload.usageProfile?.mode?.lowercased() ?? ""
+        let budgetStatus = payload.budget.status?.lowercased() ?? ""
+        let noLimit = profileMode.contains("subscription")
+            || profileMode.contains("no-limit")
+            || profileMode.contains("unlimited")
+            || budgetStatus.contains("subscription")
+            || budgetStatus.contains("no-limit")
+            || budgetStatus.contains("unlimited")
+        return noLimit ? nil : payload.budget.todayAllowanceUSD
+    }
+}
+
 public struct MenuBarLabelView: View {
     @ObservedObject var coordinator: ConnectionCoordinator
+    @ObservedObject private var preferences: PreferencesStore
 
     public init(coordinator: ConnectionCoordinator) {
         self.coordinator = coordinator
+        _preferences = ObservedObject(wrappedValue: coordinator.preferences)
     }
 
     public var body: some View {
-        HStack(spacing: 4) {
-            if let text = labelText {
-                if coordinator.state.isUsable == false { Image(systemName: iconName).accessibilityHidden(true) }
-                Text(text)
-            } else {
-                Image(systemName: iconName).accessibilityHidden(true)
-                Text(stateLabel)
+        TimelineView(.periodic(from: .now, by: 60)) { context in
+            HStack(spacing: 4) {
+                if let text = labelText(now: context.date) {
+                    if coordinator.state.isUsable == false { Image(systemName: iconName).accessibilityHidden(true) }
+                    Text(text)
+                } else {
+                    Image(systemName: iconName).accessibilityHidden(true)
+                    Text(stateLabel)
+                }
             }
+            .accessibilityLabel(accessibilityText(now: context.date))
+            .help(accessibilityText(now: context.date))
         }
         .font(.system(size: 12, weight: .medium, design: .rounded))
         .monospacedDigit()
         .foregroundStyle(labelColor)
-        .accessibilityLabel(accessibilityText)
-        .help(accessibilityText)
         .task { coordinator.start() }
     }
 
-    private var labelText: String? {
+    private func labelText(now: Date) -> String? {
         guard let payload = coordinator.payload ?? coordinator.lastGoodPayload else { return nil }
-        guard payload.hasAnyUsageValue else { return nil }
-        if let today = payload.today?.amountUSD {
-            return "Today \(Self.amount(today, denominator: todayDenominator(payload)))"
-        }
-        return nil
-    }
-
-    private func todayDenominator(_ payload: SummaryResponse) -> Double? {
-        guard isScheduled(payload) else { return nil }
-        if isNoLimit(payload) { return nil }
-        return payload.budget.todayAllowanceUSD
-    }
-
-    private func isScheduled(_ payload: SummaryResponse) -> Bool {
-        payload.budget.todayScheduled ?? true
-    }
-
-    private func isNoLimit(_ payload: SummaryResponse) -> Bool {
-        let profileMode = payload.usageProfile?.mode?.lowercased() ?? ""
-        let budgetStatus = payload.budget.status?.lowercased() ?? ""
-        return profileMode.contains("subscription") || profileMode.contains("no-limit") || profileMode.contains("unlimited") || budgetStatus.contains("subscription") || budgetStatus.contains("no-limit") || budgetStatus.contains("unlimited")
-    }
-
-    private static func amount(_ value: Double, denominator: Double?) -> String {
-        if let denominator { return "\(Presentation.compactCurrency(value))/\(Presentation.compactCurrency(denominator))" }
-        return Presentation.compactCurrency(value)
+        return MenuBarPresentation.labelText(payload: payload, mode: preferences.menuBarLabelMode, now: now)
     }
 
     private var iconName: String {
@@ -111,9 +210,9 @@ public struct MenuBarLabelView: View {
         }
     }
 
-    private var accessibilityText: String {
+    private func accessibilityText(now: Date) -> String {
         if let payload = coordinator.payload ?? coordinator.lastGoodPayload {
-            let today = payload.today?.amountUSD.map(Presentation.currency) ?? "No data"
+            let today = payload.currentDay(on: now)?.amountUSD.map(Presentation.currency) ?? "No data"
             let month = payload.monthToDate?.amountUSD.map(Presentation.currency) ?? "No data"
             return "Tokenomics. Today \(today). Month to date \(month). State \(stateLabel)."
         }
@@ -138,6 +237,7 @@ public struct PopoverView: View {
         VStack(alignment: .leading, spacing: 14) {
             header
             stateBanner
+            quotaSection
             todaySection
             Divider()
             monthSection
@@ -215,10 +315,28 @@ public struct PopoverView: View {
         }
     }
 
+    @ViewBuilder
+    private var quotaSection: some View {
+        let windows = QuotaPresentation.orderedWindows(payload?.subscriptionWindows ?? [])
+        if !windows.isEmpty {
+            TimelineView(.periodic(from: .now, by: 60)) { context in
+                if windows.count > 4 {
+                    ScrollView {
+                        QuotaCockpitView(windows: windows, now: context.date)
+                    }
+                    .frame(maxHeight: 180)
+                } else {
+                    QuotaCockpitView(windows: windows, now: context.date)
+                }
+            }
+            Divider()
+        }
+    }
+
     private var todaySection: some View {
         VStack(alignment: .leading, spacing: 5) {
             HStack {
-                Text("Today").foregroundStyle(.secondary)
+                Text(todayTitle).foregroundStyle(.secondary)
                 Spacer()
                 Text(todayAmount).font(.title3.weight(.semibold))
             }
@@ -240,7 +358,7 @@ public struct PopoverView: View {
     private var monthSection: some View {
         VStack(alignment: .leading, spacing: 5) {
             HStack {
-                Text("Month to date").foregroundStyle(.secondary)
+                Text(monthTitle).foregroundStyle(.secondary)
                 Spacer()
                 Text(monthAmount).font(.title3.weight(.semibold))
             }
@@ -320,6 +438,9 @@ public struct PopoverView: View {
     private var monthValue: Double { payload?.monthToDate?.amountUSD ?? 0 }
     private var todayAmount: String { payload?.today?.amountUSD.map(Presentation.currency) ?? "No data yet" }
     private var monthAmount: String { payload?.monthToDate?.amountUSD.map(Presentation.currency) ?? "No data yet" }
+    private var todayTitle: String { isApiEquivalent ? "Today · API equivalent" : "Today" }
+    private var monthTitle: String { isApiEquivalent ? "Month · API equivalent" : "Month to date" }
+    private var isApiEquivalent: Bool { payload?.costSemantics == "api-equivalent" }
     private var todayProviderSpend: [ProviderSpend] { payload?.providerSpendToday(on: Date()) ?? [] }
     private var monthProviderSpend: [ProviderSpend] { payload?.providerSpendMonthToDate(on: Date()) ?? [] }
     private var scheduledToday: Bool { payload?.budget.todayScheduled ?? true }
@@ -414,6 +535,47 @@ public struct PopoverView: View {
         return "No launcher output was captured."
     }
 
+}
+
+private struct QuotaCockpitView: View {
+    let windows: [SubscriptionWindow]
+    let now: Date
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Quota").font(.subheadline.weight(.medium))
+            ForEach(windows) { window in
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack {
+                        Text(QuotaPresentation.windowTitle(window))
+                            .help(window.key)
+                        Spacer()
+                        Text(QuotaPresentation.percentText(window.usedPercent).map { "\($0) used" } ?? "Usage unavailable")
+                            .monospacedDigit()
+                    }
+                    .font(.caption)
+                    if let used = QuotaPresentation.normalizedPercent(window.usedPercent) {
+                        ProgressView(value: used, total: 100)
+                            .tint(BudgetUsageLevel(amount: used, limit: 100).color)
+                            .accessibilityLabel("\(QuotaPresentation.windowTitle(window)) quota")
+                            .accessibilityValue("\(QuotaPresentation.percentText(used) ?? "Unknown") used")
+                    }
+                    HStack {
+                        if let remaining = QuotaPresentation.percentText(window.remainingPercent) {
+                            Text("\(remaining) remaining")
+                        }
+                        Spacer()
+                        if let reset = QuotaPresentation.resetCountdown(resetAt: window.resetAt, now: now) {
+                            Text(reset)
+                                .help(window.resetAt?.formatted(date: .abbreviated, time: .shortened) ?? reset)
+                        }
+                    }
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
 }
 
 private struct ProviderBreakdownView: View {
@@ -624,6 +786,13 @@ public struct SettingsView: View {
                             intervalText = String(Int(preferences.normalizedInterval()))
                         }
                     }
+            }
+            Section("Menu bar") {
+                Picker("Label", selection: $preferences.menuBarLabelMode) {
+                    ForEach(MenuBarLabelMode.allCases) { mode in
+                        Text(mode.title).tag(mode)
+                    }
+                }
             }
             HStack {
                 Spacer()

--- a/mac/Tests/TokenomicsMenubarTests/Fixtures/summary-v1-subscription.json
+++ b/mac/Tests/TokenomicsMenubarTests/Fixtures/summary-v1-subscription.json
@@ -1,0 +1,406 @@
+{
+  "contractVersion": 1,
+  "generatedAt": "2026-08-03T12:00:00.000Z",
+  "calendarTimeZone": "UTC",
+  "usageProfile": {
+    "id": "pro",
+    "name": "ChatGPT Pro",
+    "mode": "subscription"
+  },
+  "costSemantics": "api-equivalent",
+  "apiEquivalentCostUsd": 18.42,
+  "billedCostUsd": null,
+  "subscriptionWindows": [
+    {
+      "key": "codex/codex:primary_300m",
+      "provider": "openai",
+      "limitId": "codex",
+      "kind": "primary",
+      "planType": "pro",
+      "windowMinutes": 300,
+      "usedPercent": 68,
+      "remainingPercent": 32,
+      "latestAt": "2026-08-03T12:00:00.000Z",
+      "resetAt": "2026-08-03T13:24:00.000Z",
+      "observedFrom": "2026-08-03T11:45:00.000Z",
+      "apiEquivalentCostUsd": 18.42,
+      "apiEquivalentPerQuotaPointUsd": null,
+      "projectedFullWindowApiEquivalentUsd": null,
+      "requests": 8,
+      "pricedRequests": 8,
+      "pricingCoverage": 1,
+      "timeCoverage": 0.06944444444444445,
+      "localTokens": {
+        "input": 1000,
+        "cacheCreate": 0,
+        "cacheRead": 2000,
+        "output": 300,
+        "total": 3300
+      },
+      "models": [
+        {
+          "name": "openai/gpt-5.6-sol",
+          "provider": "openai",
+          "model": "gpt-5.6-sol",
+          "requests": 8,
+          "pricedRequests": 8,
+          "costUsd": 18.42
+        }
+      ]
+    },
+    {
+      "key": "codex/codex:secondary_10080m",
+      "provider": "openai",
+      "limitId": "codex",
+      "kind": "secondary",
+      "planType": "pro",
+      "windowMinutes": 10080,
+      "usedPercent": 41,
+      "remainingPercent": 59,
+      "latestAt": "2026-08-03T12:00:00.000Z",
+      "resetAt": "2026-08-10T12:00:00.000Z",
+      "observedFrom": "2026-08-03T12:00:00.000Z",
+      "apiEquivalentCostUsd": 0,
+      "apiEquivalentPerQuotaPointUsd": null,
+      "projectedFullWindowApiEquivalentUsd": null,
+      "requests": 0,
+      "pricedRequests": 0,
+      "pricingCoverage": null,
+      "timeCoverage": 0,
+      "localTokens": {
+        "input": 0,
+        "cacheCreate": 0,
+        "cacheRead": 0,
+        "output": 0,
+        "total": 0
+      },
+      "models": []
+    }
+  ],
+  "subscriptionPlans": [
+    {
+      "provider": "openai",
+      "providerLabel": "OpenAI",
+      "currentPlanId": "chatgpt-pro-200",
+      "currentPlanLabel": "ChatGPT Pro ($200)",
+      "currentMonthlyUsd": 200,
+      "capacityMultiple": 20,
+      "lastObservedPlanId": "chatgpt-pro-200",
+      "lastObservedPlanLabel": "ChatGPT Pro ($200)",
+      "source": "protocol",
+      "likelyPlanId": null,
+      "likelyPlanLabel": null,
+      "confidence": "medium",
+      "observedAt": "2026-08-03T12:00:00.000Z",
+      "observedPlanType": "pro",
+      "observedPlanTypes": [
+        "pro"
+      ],
+      "stale": false,
+      "conflict": false,
+      "evidence": [
+        {
+          "kind": "provider-plan-type",
+          "observedAt": "2026-08-03T12:00:00.000Z",
+          "planTypes": [
+            "pro"
+          ],
+          "samples": 16,
+          "limitIds": [
+            "codex"
+          ],
+          "windowMinutes": [
+            300,
+            10080
+          ]
+        }
+      ],
+      "history": [
+        {
+          "date": "2026-08-03",
+          "limitId": "codex",
+          "samples": 8,
+          "signals": [
+            {
+              "planType": "pro",
+              "planId": "chatgpt-pro-200",
+              "planLabel": "ChatGPT Pro ($200)",
+              "samples": 8,
+              "firstObservedAt": null,
+              "lastObservedAt": null,
+              "supported": true,
+              "share": 1
+            }
+          ],
+          "mixed": false
+        }
+      ],
+      "inference": null,
+      "caveat": "Codex plan_type is direct telemetry, but concurrent sessions can overlap around a plan change. Mixed days remain mixed instead of being forced into one tier."
+    },
+    {
+      "provider": "anthropic",
+      "providerLabel": "Anthropic",
+      "currentPlanId": null,
+      "currentPlanLabel": null,
+      "currentMonthlyUsd": null,
+      "capacityMultiple": null,
+      "lastObservedPlanId": null,
+      "lastObservedPlanLabel": null,
+      "source": "none",
+      "likelyPlanId": null,
+      "likelyPlanLabel": null,
+      "confidence": "none",
+      "observedAt": null,
+      "observedPlanType": null,
+      "observedPlanTypes": [],
+      "stale": false,
+      "conflict": false,
+      "evidence": [],
+      "history": [],
+      "inference": null,
+      "caveat": "Claude session telemetry records usage but does not expose subscription plan, account identity, or quota percentages. Heuristic floors aggregate local Claude activity; inactivity cannot identify a downgrade."
+    }
+  ],
+  "sources": {
+    "files": 0,
+    "zipFiles": 0,
+    "zipEntries": 0,
+    "parseErrors": 0,
+    "skippedFiles": 0,
+    "tokenCountSnapshots": 0,
+    "skippedTokenCountSnapshots": 0
+  },
+  "total": {
+    "requests": 8,
+    "input": 0,
+    "cacheCreate5m": 0,
+    "cacheCreate30m": 0,
+    "cacheCreate1h": 0,
+    "cacheRead": 0,
+    "output": 0,
+    "reasoningOutput": 0,
+    "costUsd": 18.42,
+    "reasoningCostUsd": 0,
+    "costsUsd": {
+      "input": 0,
+      "cacheCreate5m": 0,
+      "cacheCreate30m": 0,
+      "cacheCreate1h": 0,
+      "cacheRead": 0,
+      "output": 0
+    },
+    "pricedRequests": 8,
+    "unpricedRequests": 0,
+    "pricedInput": 0,
+    "pricedCacheCreate5m": 0,
+    "pricedCacheCreate30m": 0,
+    "pricedCacheCreate1h": 0,
+    "pricedCacheRead": 0,
+    "pricedOutput": 0,
+    "pricedReasoningOutput": 0,
+    "visibleInputChars": 0,
+    "visibleOutputChars": 0,
+    "visibleTotalChars": 0,
+    "visibleCharTokenSamples": 0,
+    "visibleCharsPerTokenSum": 0,
+    "visibleCharsPerTokenMin": null,
+    "visibleCharsPerTokenMax": null,
+    "visibleOutputTextChars": 0,
+    "visibleOutputTextTokens": 0,
+    "outputCharTokenSamples": 0,
+    "outputCharsPerTokenSum": 0,
+    "outputCharsPerTokenMin": null,
+    "outputCharsPerTokenMax": null,
+    "outputCharsPerTokenP10": null,
+    "outputCharsPerTokenP99": null,
+    "outputCharTokenOutliers": 0
+  },
+  "currentMonth": {
+    "name": "2026-08",
+    "through": "2026-08-03",
+    "startAt": "2026-08-01T00:00:00.000Z",
+    "endAt": "2026-08-04T00:00:00.000Z",
+    "costUsd": 18.42,
+    "costsUsd": {
+      "input": 0,
+      "cacheCreate5m": 0,
+      "cacheCreate30m": 0,
+      "cacheCreate1h": 0,
+      "cacheRead": 0,
+      "output": 0
+    },
+    "pricedInput": 0,
+    "pricedCacheCreate5m": 0,
+    "pricedCacheCreate30m": 0,
+    "pricedCacheCreate1h": 0,
+    "pricedCacheRead": 0,
+    "pricedOutput": 0,
+    "pricedReasoningOutput": 0,
+    "visibleInputChars": 0,
+    "visibleOutputChars": 0,
+    "visibleTotalChars": 0,
+    "visibleCharTokenSamples": 0,
+    "visibleCharsPerTokenSum": 0,
+    "visibleCharsPerTokenMin": null,
+    "visibleCharsPerTokenMax": null,
+    "visibleOutputTextChars": 0,
+    "visibleOutputTextTokens": 0,
+    "outputCharTokenSamples": 0,
+    "outputCharsPerTokenSum": 0,
+    "outputCharsPerTokenMin": null,
+    "outputCharsPerTokenMax": null,
+    "outputCharsPerTokenP10": null,
+    "outputCharsPerTokenP99": null,
+    "outputCharTokenOutliers": 0,
+    "limitUsd": null,
+    "remainingUsd": null,
+    "overageUsd": null,
+    "usedRatio": null
+  },
+  "budget": {
+    "todayScheduled": true,
+    "totalScheduledDays": 21,
+    "remainingScheduledDays": 21,
+    "limitUsd": null,
+    "spentUsd": 18.42,
+    "remainingUsd": null,
+    "overageUsd": null,
+    "usedRatio": null,
+    "baselineDailyTargetUsd": null,
+    "todayAllowanceUsd": null,
+    "todayRemainingUsd": null,
+    "allowanceBasis": "no_monthly_limit",
+    "status": "subscription"
+  },
+  "topModels": [],
+  "models": [],
+  "topProjects": [],
+  "topEfforts": [],
+  "serviceTiers": [],
+  "serviceModes": [],
+  "agents": [],
+  "observedHarnesses": [],
+  "daily": [
+    {
+      "name": "2026-08-03",
+      "costUsd": 18.42,
+      "costsUsd": {
+        "input": 0,
+        "cacheCreate5m": 0,
+        "cacheCreate30m": 0,
+        "cacheCreate1h": 0,
+        "cacheRead": 0,
+        "output": 0
+      },
+      "pricedInput": 0,
+      "pricedCacheCreate5m": 0,
+      "pricedCacheCreate30m": 0,
+      "pricedCacheCreate1h": 0,
+      "pricedCacheRead": 0,
+      "pricedOutput": 0,
+      "pricedReasoningOutput": 0,
+      "visibleInputChars": 0,
+      "visibleOutputChars": 0,
+      "visibleTotalChars": 0,
+      "visibleCharTokenSamples": 0,
+      "visibleCharsPerTokenSum": 0,
+      "visibleCharsPerTokenMin": null,
+      "visibleCharsPerTokenMax": null,
+      "visibleOutputTextChars": 0,
+      "visibleOutputTextTokens": 0,
+      "outputCharTokenSamples": 0,
+      "outputCharsPerTokenSum": 0,
+      "outputCharsPerTokenMin": null,
+      "outputCharsPerTokenMax": null,
+      "outputCharsPerTokenP10": null,
+      "outputCharsPerTokenP99": null,
+      "outputCharTokenOutliers": 0
+    }
+  ],
+  "weekly": [],
+  "monthly": [
+    {
+      "name": "2026-08",
+      "costUsd": 18.42,
+      "costsUsd": {
+        "input": 0,
+        "cacheCreate5m": 0,
+        "cacheCreate30m": 0,
+        "cacheCreate1h": 0,
+        "cacheRead": 0,
+        "output": 0
+      },
+      "pricedInput": 0,
+      "pricedCacheCreate5m": 0,
+      "pricedCacheCreate30m": 0,
+      "pricedCacheCreate1h": 0,
+      "pricedCacheRead": 0,
+      "pricedOutput": 0,
+      "pricedReasoningOutput": 0,
+      "visibleInputChars": 0,
+      "visibleOutputChars": 0,
+      "visibleTotalChars": 0,
+      "visibleCharTokenSamples": 0,
+      "visibleCharsPerTokenSum": 0,
+      "visibleCharsPerTokenMin": null,
+      "visibleCharsPerTokenMax": null,
+      "visibleOutputTextChars": 0,
+      "visibleOutputTextTokens": 0,
+      "outputCharTokenSamples": 0,
+      "outputCharsPerTokenSum": 0,
+      "outputCharsPerTokenMin": null,
+      "outputCharsPerTokenMax": null,
+      "outputCharsPerTokenP10": null,
+      "outputCharsPerTokenP99": null,
+      "outputCharTokenOutliers": 0
+    }
+  ],
+  "projectDaily": [],
+  "configurationRevision": null,
+  "pricingBasis": "standard",
+  "regionalMultiplier": 1,
+  "pricingStale": false,
+  "providerModelEffortDaily": [],
+  "rateLimits": {
+    "windows": {
+      "codex/codex:primary_300m": {
+        "agent": "codex",
+        "limitId": "codex",
+        "kind": "primary",
+        "windowMinutes": 300,
+        "planType": "pro",
+        "samples": 8,
+        "latestUsedPercent": 68,
+        "latestRemainingPercent": 32,
+        "latestAt": "2026-08-03T12:00:00.000Z",
+        "latestResetAt": 1785763440
+      },
+      "codex/codex:secondary_10080m": {
+        "agent": "codex",
+        "limitId": "codex",
+        "kind": "secondary",
+        "windowMinutes": 10080,
+        "planType": "pro",
+        "samples": 8,
+        "latestUsedPercent": 41,
+        "latestRemainingPercent": 59,
+        "latestAt": "2026-08-03T12:00:00.000Z",
+        "latestResetAt": 1786363200
+      }
+    },
+    "daily": {},
+    "weekly": {},
+    "planHistory": [
+      {
+        "date": "2026-08-03",
+        "agent": "codex",
+        "limitId": "codex",
+        "planType": "pro",
+        "samples": 8
+      }
+    ]
+  },
+  "unpricedModels": [],
+  "recommendations": []
+}

--- a/mac/Tests/TokenomicsMenubarTests/TokenomicsMenubarTests.swift
+++ b/mac/Tests/TokenomicsMenubarTests/TokenomicsMenubarTests.swift
@@ -15,6 +15,45 @@ final class BudgetUsageLevelTests: XCTestCase {
     }
 }
 
+final class QuotaPresentationTests: XCTestCase {
+    func testQuotaLabelsAndCountdownUseInjectedClock() {
+        let now = ISO8601DateFormatter().date(from: "2026-08-03T12:00:00Z")!
+        let reset = ISO8601DateFormatter().date(from: "2026-08-03T13:24:00Z")!
+        let window = SubscriptionWindow(
+            key: "codex/primary",
+            provider: "openai",
+            windowMinutes: 300,
+            usedPercent: 68,
+            remainingPercent: 32,
+            resetAt: reset
+        )
+
+        XCTAssertEqual(QuotaPresentation.windowLabel(minutes: 300), "5-hour")
+        XCTAssertEqual(QuotaPresentation.windowLabel(minutes: 10_080), "Weekly")
+        XCTAssertEqual(QuotaPresentation.windowTitle(window), "OpenAI · 5-hour")
+        XCTAssertEqual(QuotaPresentation.resetCountdown(resetAt: reset, now: now), "Resets in 1h 24m")
+        XCTAssertEqual(QuotaPresentation.resetCountdown(resetAt: reset, now: reset), "Reset pending")
+
+        let payload = SummaryResponse(
+            usageProfile: UsageProfile(name: "ChatGPT Pro", mode: "subscription"),
+            costSemantics: "api-equivalent",
+            subscriptionWindows: [window],
+            currentMonth: UsagePeriod(name: "2026-08", through: "2026-08-03", amountUSD: 18.42),
+            daily: [DailySpendPoint(date: "2026-08-03", amountUSD: 18.42)]
+        )
+        XCTAssertEqual(MenuBarPresentation.labelText(payload: payload, mode: .today, now: now), "Today eq. $18.42")
+        XCTAssertEqual(MenuBarPresentation.labelText(payload: payload, mode: .quotaUsed, now: now), "5h 68%")
+        XCTAssertEqual(MenuBarPresentation.labelText(payload: payload, mode: .quotaReset, now: now), "5h 1h 24m")
+    }
+
+    func testInvalidPercentIsNotPresentedAsQuota() {
+        let window = SubscriptionWindow(key: "invalid", windowMinutes: 300, usedPercent: .infinity)
+        XCTAssertNil(QuotaPresentation.shortestWindow([window]))
+        XCTAssertEqual(QuotaPresentation.normalizedPercent(-10), 0)
+        XCTAssertEqual(QuotaPresentation.normalizedPercent(120), 100)
+    }
+}
+
 @MainActor
 final class SettingsWindowControllerTests: XCTestCase {
     func testAppUsesAnActivatableAccessoryPolicy() {
@@ -153,6 +192,22 @@ final class DirectLauncherTests: XCTestCase {
         XCTAssertTrue(process.output.contains("starting initial sync"))
     }
 
+    func testAppendsNoOpenAndConfiguredPortToLauncherArguments() async throws {
+        let process = try await DirectTokenomicsLauncher().start(
+            executablePath: "/bin/sh",
+            port: 9123,
+            timeout: .seconds(2),
+            baseArguments: ["-c", "printf '%s\\n' \"$@\"; sleep 1", "sh"]
+        )
+        defer { process.stop() }
+
+        for _ in 0..<40 where !process.output.contains("9123") {
+            try await Task.sleep(for: .milliseconds(25))
+        }
+
+        XCTAssertEqual(process.output.split(separator: "\n").map(String.init), ["--no-open", "--port", "9123"])
+    }
+
     func testStopTerminatesTheLauncherProcessGroup() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -244,6 +299,19 @@ final class SummaryDecodingTests: XCTestCase {
         XCTAssertEqual(allowance, 70.0 / 21.0, accuracy: 1e-12)
         XCTAssertEqual(response.budget.todayRemainingUSD, 0)
         XCTAssertEqual(response.budget.allowanceBasis, "monthly_limit_minus_spend_through_yesterday_divided_by_remaining_weekdays_utc")
+    }
+
+    func testDecodesNodeGeneratedSubscriptionQuotaFixture() throws {
+        let url = try XCTUnwrap(Bundle.module.url(forResource: "summary-v1-subscription", withExtension: "json", subdirectory: "Fixtures"))
+        let response = try JSONDecoder().decode(SummaryResponse.self, from: Data(contentsOf: url))
+
+        XCTAssertEqual(response.usageProfile?.mode, "subscription")
+        XCTAssertEqual(response.costSemantics, "api-equivalent")
+        XCTAssertNil(response.billedCostUSD)
+        XCTAssertEqual(response.subscriptionWindows.map(\.windowMinutes), [300, 10_080])
+        XCTAssertEqual(response.subscriptionWindows.map(\.usedPercent), [68, 41])
+        XCTAssertEqual(response.subscriptionWindows.first?.resetAt, ISO8601DateFormatter().date(from: "2026-08-03T13:24:00Z"))
+        XCTAssertNil(response.subscriptionWindows.first?.projectedFullWindowApiEquivalentUSD)
     }
 
     func testDecodesExistingSummaryAndIgnoresAdditiveFields() throws {
@@ -450,10 +518,12 @@ final class PortAndPreferencesTests: XCTestCase {
         XCTAssertEqual(preferences.automaticSyncInterval, 20)
         preferences.automaticSyncEnabled = false
         preferences.automaticSyncInterval = 1
+        preferences.menuBarLabelMode = .quotaReset
         preferences.save(to: suite)
         let loaded = RuntimePreferences(defaults: suite)
         XCTAssertFalse(loaded.automaticSyncEnabled)
         XCTAssertEqual(loaded.automaticSyncInterval, 20)
+        XCTAssertEqual(loaded.menuBarLabelMode, .quotaReset)
     }
 
     @MainActor
@@ -539,7 +609,7 @@ final class CoordinatorSyncTests: XCTestCase {
         coordinator.stop()
     }
 
-    func testUnavailableDoesNotStartLauncherUntilExplicitRequest() async throws {
+    func testUnavailableStartsLauncherAutomatically() async throws {
         let suite = UserDefaults(suiteName: "TokenomicsMenubarTests.explicit-start")!
         suite.removePersistentDomain(forName: "TokenomicsMenubarTests.explicit-start")
         let preferences = PreferencesStore(defaults: suite)
@@ -551,18 +621,9 @@ final class CoordinatorSyncTests: XCTestCase {
 
         coordinator.start()
         await coordinator.waitForCurrentOperation()
-        XCTAssertEqual(launcher.startCount, 0)
-        XCTAssertTrue(coordinator.canStartTokenomics)
-        guard case .unavailable = coordinator.state else {
-            XCTFail("expected unavailable state")
-            return
-        }
-
-        coordinator.startTokenomics()
-        await coordinator.waitForCurrentOperation()
         XCTAssertEqual(launcher.startCount, 1)
+        XCTAssertTrue(coordinator.canStartTokenomics)
         XCTAssertEqual(coordinator.state, .connected)
-        coordinator.stop()
     }
 
     func testAlreadyRunningTokenomicsIsReusedWithoutTakingOwnership() async throws {
@@ -584,6 +645,27 @@ final class CoordinatorSyncTests: XCTestCase {
         coordinator.stop()
     }
 
+    func testWrongServiceIsNotReplacedByTheLauncher() async throws {
+        let suiteName = "TokenomicsMenubarTests.wrong-service"
+        let suite = UserDefaults(suiteName: suiteName)!
+        suite.removePersistentDomain(forName: suiteName)
+        let preferences = PreferencesStore(defaults: suite)
+        preferences.launcherPath = "/bin/sh"
+        let launcher = UnexpectedLauncher()
+        let coordinator = ConnectionCoordinator(
+            preferences: preferences,
+            client: WrongServiceClient(),
+            launcher: launcher
+        )
+        defer { coordinator.stop() }
+
+        coordinator.start()
+        await coordinator.waitForCurrentOperation()
+
+        XCTAssertEqual(launcher.startCount, 0)
+        XCTAssertEqual(coordinator.state, .notTokenomics(endpoint: Endpoint(port: 8787)))
+    }
+
     func testApplicationTerminationStopsTokenomicsStartedByTheApp() async throws {
         let suiteName = "TokenomicsMenubarTests.application-termination"
         let suite = UserDefaults(suiteName: suiteName)!
@@ -596,8 +678,6 @@ final class CoordinatorSyncTests: XCTestCase {
         defer { coordinator.stop() }
 
         coordinator.start()
-        await coordinator.waitForCurrentOperation()
-        coordinator.startTokenomics()
         await coordinator.waitForCurrentOperation()
         XCTAssertTrue(launcher.lastProcess?.isRunning == true)
 
@@ -619,11 +699,12 @@ final class CoordinatorSyncTests: XCTestCase {
             launcher: OutputLauncher(output: "[start] scanning local sessions\n")
         )
 
-        coordinator.start()
-        await coordinator.waitForCurrentOperation()
         let probe = expectation(description: "startup probes the configured endpoint")
-        client.onProbe = { probe.fulfill() }
-        coordinator.startTokenomics()
+        client.onProbe = {
+            client.onProbe = nil
+            probe.fulfill()
+        }
+        coordinator.start()
         await fulfillment(of: [probe], timeout: 1)
 
         guard case .starting = coordinator.state else {
@@ -635,38 +716,65 @@ final class CoordinatorSyncTests: XCTestCase {
         coordinator.stop()
     }
 
-    func testChangingPreferredPortRefreshesAndDropsThePreviousSummary() async throws {
+    func testOfflineOwnedProcessIsNotStartedTwice() async throws {
+        let suiteName = "TokenomicsMenubarTests.no-duplicate-launch"
+        let suite = UserDefaults(suiteName: suiteName)!
+        suite.removePersistentDomain(forName: suiteName)
+        let preferences = PreferencesStore(defaults: suite)
+        preferences.launcherPath = "/bin/sh"
+        let client = StartableClient()
+        let launcher = RecordingLauncher(client: client)
+        let coordinator = ConnectionCoordinator(preferences: preferences, client: client, launcher: launcher)
+        defer { coordinator.stop() }
+
+        coordinator.start()
+        await coordinator.waitForCurrentOperation()
+        XCTAssertEqual(coordinator.state, .connected)
+        XCTAssertEqual(launcher.startCount, 1)
+
+        client.started = false
+        coordinator.refresh(triggerSync: false)
+        await coordinator.waitForCurrentOperation()
+
+        XCTAssertEqual(launcher.startCount, 1)
+        guard case .unavailable(let message) = coordinator.state else {
+            XCTFail("expected unavailable state while the owned process is still running")
+            return
+        }
+        XCTAssertTrue(message.contains("launcher is running"))
+    }
+
+    func testChangingPreferredPortStartsLauncherForTheNewPort() async throws {
         let suite = UserDefaults(suiteName: "TokenomicsMenubarTests.port-switch")!
         suite.removePersistentDomain(forName: "TokenomicsMenubarTests.port-switch")
         let preferences = PreferencesStore(defaults: suite)
         preferences.preferredPort = 8787
         preferences.launcherPath = "/bin/sh"
         let client = PortSwitchClient(availablePorts: [8787])
-        let coordinator = ConnectionCoordinator(preferences: preferences, client: client, launcher: FailingLauncher())
+        let launcher = PortStartingLauncher(client: client)
+        let coordinator = ConnectionCoordinator(preferences: preferences, client: client, launcher: launcher)
 
         coordinator.start()
         await coordinator.waitForCurrentOperation()
         XCTAssertEqual(coordinator.state, .connected)
         XCTAssertNotNil(coordinator.payload)
+        XCTAssertEqual(launcher.startedPorts, [])
 
         preferences.preferredPort = 8788
         await Task.yield()
         await coordinator.waitForCurrentOperation()
 
         XCTAssertTrue(client.probedPorts.contains(8788))
-        XCTAssertNil(coordinator.payload)
-        XCTAssertNil(coordinator.lastGoodPayload)
-        XCTAssertNil(coordinator.endpoint)
+        XCTAssertEqual(launcher.startedPorts, [8788])
+        XCTAssertNotNil(coordinator.payload)
+        XCTAssertNotNil(coordinator.lastGoodPayload)
+        XCTAssertEqual(coordinator.endpoint, Endpoint(port: 8788))
         XCTAssertTrue(coordinator.canStartTokenomics)
-        guard case .unavailable = coordinator.state else {
-            XCTFail("expected unavailable state after switching to an offline port")
-            coordinator.stop()
-            return
-        }
+        XCTAssertEqual(coordinator.state, .connected)
         coordinator.stop()
     }
 
-    func testEndpointDisappearanceDropsCachedSummary() async throws {
+    func testEndpointDisappearanceClearsCacheWhenAutomaticRelaunchFails() async throws {
         let suite = UserDefaults(suiteName: "TokenomicsMenubarTests.endpoint-loss")!
         suite.removePersistentDomain(forName: "TokenomicsMenubarTests.endpoint-loss")
         let preferences = PreferencesStore(defaults: suite)
@@ -690,8 +798,8 @@ final class CoordinatorSyncTests: XCTestCase {
         XCTAssertNil(preferences.activeEndpoint)
         XCTAssertNil(coordinator.lastRefreshAt)
         XCTAssertTrue(coordinator.canStartTokenomics)
-        guard case .unavailable = coordinator.state else {
-            XCTFail("expected unavailable state after the endpoint disappeared")
+        guard case .startFailure = coordinator.state else {
+            XCTFail("expected start failure after automatic relaunch failed")
             coordinator.stop()
             return
         }
@@ -730,6 +838,30 @@ private final class RunningZeroClient: TokenomicsHTTPClient, @unchecked Sendable
 }
 
 @MainActor
+private final class UnexpectedLauncher: TokenomicsLauncher {
+    private(set) var startCount = 0
+
+    func start(executablePath: String, port: Int, timeout: Duration) async throws -> any TokenomicsProcessHandle {
+        startCount += 1
+        throw LauncherError.launchFailed("unexpected launch")
+    }
+}
+
+private final class WrongServiceClient: TokenomicsHTTPClient, @unchecked Sendable {
+    func probeSync(at endpoint: Endpoint) async throws -> SyncProbe {
+        throw EndpointError.notTokenomics
+    }
+
+    func fetchSummary(at endpoint: Endpoint) async throws -> SummaryResponse {
+        throw EndpointError.notTokenomics
+    }
+
+    func triggerSync(at endpoint: Endpoint) async throws {
+        throw EndpointError.notTokenomics
+    }
+}
+
+@MainActor
 private final class RecordingLauncher: TokenomicsLauncher {
     private let client: StartableClient
     private(set) var startCount = 0
@@ -745,6 +877,22 @@ private final class RecordingLauncher: TokenomicsLauncher {
         let process = RecordingProcess()
         lastProcess = process
         return process
+    }
+}
+
+@MainActor
+private final class PortStartingLauncher: TokenomicsLauncher {
+    private let client: PortSwitchClient
+    private(set) var startedPorts: [Int] = []
+
+    init(client: PortSwitchClient) {
+        self.client = client
+    }
+
+    func start(executablePath: String, port: Int, timeout: Duration) async throws -> any TokenomicsProcessHandle {
+        startedPorts.append(port)
+        client.availablePorts.insert(port)
+        return RecordingProcess()
     }
 }
 

--- a/scripts/generate-macos-summary-fixture.js
+++ b/scripts/generate-macos-summary-fixture.js
@@ -4,12 +4,11 @@
 const fs = require("node:fs");
 const Path = require("node:path");
 const { webSummary } = require("../lib/dashboard");
-const { newReport } = require("../lib/core/report-model");
+const { newReport, newStats } = require("../lib/core/report-model");
 
-const fixturePath = Path.resolve(
-  __dirname,
-  "../mac/Tests/TokenomicsMenubarTests/Fixtures/summary-v1.json",
-);
+const fixtureDirectory = Path.resolve(__dirname, "../mac/Tests/TokenomicsMenubarTests/Fixtures");
+const fixturePath = Path.join(fixtureDirectory, "summary-v1.json");
+const subscriptionFixturePath = Path.join(fixtureDirectory, "summary-v1-subscription.json");
 
 function buildMacOSSummaryFixture() {
   const report = newReport();
@@ -25,15 +24,77 @@ function buildMacOSSummaryFixture() {
   });
 }
 
+function buildMacOSSubscriptionSummaryFixture() {
+  const report = newReport();
+  report.usageProfile = { id: "pro", name: "ChatGPT Pro", mode: "subscription" };
+  report.total.costUsd = 18.42;
+  report.total.requests = 8;
+  report.total.pricedRequests = 8;
+  report.monthly["2026-08"] = { costUsd: 18.42 };
+  report.daily["2026-08-03"] = { costUsd: 18.42 };
+
+  const latestAt = "2026-08-03T12:00:00.000Z";
+  report.rateLimits.windows["codex/codex:primary_300m"] = {
+    agent: "codex",
+    limitId: "codex",
+    kind: "primary",
+    windowMinutes: 300,
+    planType: "pro",
+    samples: 8,
+    latestUsedPercent: 68,
+    latestRemainingPercent: 32,
+    latestAt,
+    latestResetAt: Date.parse("2026-08-03T13:24:00.000Z") / 1_000,
+  };
+  report.rateLimits.windows["codex/codex:secondary_10080m"] = {
+    agent: "codex",
+    limitId: "codex",
+    kind: "secondary",
+    windowMinutes: 10_080,
+    planType: "pro",
+    samples: 8,
+    latestUsedPercent: 41,
+    latestRemainingPercent: 59,
+    latestAt,
+    latestResetAt: Date.parse("2026-08-10T12:00:00.000Z") / 1_000,
+  };
+  report.rateLimits.planHistory = [
+    { date: "2026-08-03", agent: "codex", limitId: "codex", planType: "pro", samples: 8 },
+  ];
+
+  const period = "2026-08-03T11:45Z";
+  const modelStats = newStats();
+  Object.assign(modelStats, {
+    requests: 8,
+    pricedRequests: 8,
+    input: 1_000,
+    cacheRead: 2_000,
+    output: 300,
+    costUsd: 18.42,
+  });
+  report.quarterHourly[period] = modelStats;
+  report.quarterHourlyProviderModels[period] = {
+    openai: { "gpt-5.6-sol": modelStats },
+  };
+
+  return webSummary(report, {
+    now: new Date(latestAt),
+    top: 25,
+  });
+}
+
 function writeMacOSSummaryFixture() {
-  fs.mkdirSync(Path.dirname(fixturePath), { recursive: true });
+  fs.mkdirSync(fixtureDirectory, { recursive: true });
   fs.writeFileSync(fixturePath, `${JSON.stringify(buildMacOSSummaryFixture(), null, 2)}\n`);
+  fs.writeFileSync(subscriptionFixturePath, `${JSON.stringify(buildMacOSSubscriptionSummaryFixture(), null, 2)}\n`);
 }
 
 if (require.main === module) writeMacOSSummaryFixture();
 
 module.exports = {
   buildMacOSSummaryFixture,
+  buildMacOSSubscriptionSummaryFixture,
   fixturePath,
+  subscriptionFixturePath,
   writeMacOSSummaryFixture,
 };

--- a/test/macos-contract.test.js
+++ b/test/macos-contract.test.js
@@ -5,7 +5,9 @@ const fs = require("node:fs");
 const test = require("node:test");
 const {
   buildMacOSSummaryFixture,
+  buildMacOSSubscriptionSummaryFixture,
   fixturePath,
+  subscriptionFixturePath,
 } = require("../scripts/generate-macos-summary-fixture");
 
 test("checked-in macOS fixture matches the current Node summary contract", () => {
@@ -14,4 +16,20 @@ test("checked-in macOS fixture matches the current Node summary contract", () =>
   assert.deepEqual(checkedIn, buildMacOSSummaryFixture());
   assert.equal(checkedIn.contractVersion, 1);
   assert.equal(checkedIn.budget.allowanceBasis, "monthly_limit_minus_spend_through_yesterday_divided_by_remaining_weekdays_utc");
+});
+
+test("checked-in macOS subscription fixture exposes server-owned quota windows", () => {
+  const checkedIn = JSON.parse(fs.readFileSync(subscriptionFixturePath, "utf8"));
+
+  assert.deepEqual(checkedIn, buildMacOSSubscriptionSummaryFixture());
+  assert.equal(checkedIn.contractVersion, 1);
+  assert.equal(checkedIn.costSemantics, "api-equivalent");
+  assert.equal(checkedIn.billedCostUsd, null);
+  assert.deepEqual(
+    checkedIn.subscriptionWindows.map((window) => [window.windowMinutes, window.usedPercent, window.resetAt]),
+    [
+      [300, 68, "2026-08-03T13:24:00.000Z"],
+      [10_080, 41, "2026-08-10T12:00:00.000Z"],
+    ],
+  );
 });


### PR DESCRIPTION
## Summary

- Probe the exact configured Tokenomics endpoint on app launch, wake, refresh, and port changes.
- Start the persisted `tokenomics-launch` command automatically when the service is absent; the native launcher always appends `--no-open` and the configured port.
- Reuse an already-running Tokenomics service, never replace a different service on the port, and avoid duplicate launches while an app-owned process is still running.
- Add a native subscription quota cockpit backed by the existing versioned Node summary contract.
- Add configurable menu-bar labels for today's usage, shortest-window quota use, and quota reset countdown.

Node/ClickHouse remains the policy and analytics authority. Swift only decodes and presents `subscriptionWindows`, `costSemantics`, and `usageProfile`.

## Verification

- `node --test` — 262 passed
- Xcode 26.6: `swift test -Xswiftc -warnings-as-errors` — 37 passed
- Xcode 26.6: `swift build -c release -Xswiftc -warnings-as-errors` — passed
- Node-generated API and subscription fixtures are checked into CI and decoded by Swift tests
- `git diff --check` — passed

## Review boundary

The lifecycle tests cover exact-port reuse, automatic launch, `--no-open`, wrong-service refusal, process ownership, duplicate-launch prevention, port changes, and termination cleanup. The generic local ClickHouse review runner is not usable in this repository because its required ClickHouse review charter is absent; manual hostile diff review and executable gates were used instead.
