### PR TITLE
Add observed-only GitHub Copilot ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Tokenomics Viewer
 
 Local-first cost and token analytics for Codex, Claude Code, omp (oh-my-pi),
-Pi, Gemini CLI, Qwen Code, OpenCode, Cursor Agent, and Grok Build, powered by
-ClickHouse. Tokenomics reads local session logs, removes replayed parent traces
+Pi, Gemini CLI, Qwen Code, OpenCode, Cursor Agent, Grok Build, and GitHub
+Copilot CLI/VS Code, powered by ClickHouse. Tokenomics reads local session logs,
+removes replayed parent traces
 from forked Codex sessions, normalizes exact usage where the source proves its
 semantics, and estimates costs from an editable pricing catalog.
 
@@ -31,7 +32,7 @@ The installer does not use `sudo` or install npm packages. On the first run it:
 3. Installs a private Node.js 26 runtime when the system Node.js is too old.
 4. Installs `clickhousectl`, selects stable ClickHouse, and starts the named
    `tokenomics` server.
-5. Imports supported exact-usage sessions and observed-only Cursor/Grok
+5. Imports supported exact-usage sessions and observed-only Cursor/Grok/Copilot
    metadata into ClickHouse.
 6. Starts the dashboard on a loopback address and opens it in your browser.
 
@@ -71,8 +72,9 @@ command to use. It does not edit shell startup files.
 - Codex fast-mode credit-equivalent pricing when a session records its service
   tier.
 - Codex rate-limit consumption summaries when snapshots are present.
-- Observed Harness Coverage for Cursor Agent and Grok Build session metadata.
-  These sessions are explicitly `observed-only`: usage is unavailable and they
+- Observed Harness Coverage for Cursor Agent, Grok Build, and GitHub Copilot
+  CLI/VS Code session metadata. These sessions are explicitly `observed-only`:
+  usage is unavailable and they
   never change exact token, request, cost, agent, or service-mode totals.
 
 Cost estimates are analytical aids, not billing statements. Subscription usage,
@@ -104,11 +106,12 @@ tokenomics-launch -- --source gemini
 tokenomics-launch -- --source opencode
 tokenomics-launch -- --source cursor
 tokenomics-launch -- --source grok
+tokenomics-launch -- --source copilot
 ```
 
 The default `--source all` scans exact Claude Code, Codex, omp, Pi, Gemini,
-Qwen, and OpenCode sources together, plus observed-only Cursor Agent and Grok
-Build metadata.
+Qwen, and OpenCode sources together, plus observed-only Cursor Agent, Grok
+Build, and GitHub Copilot CLI/VS Code metadata.
 
 Serve the current ClickHouse database without scanning source files:
 
@@ -240,22 +243,34 @@ With no explicit paths, Tokenomics discovers:
   observed-only)
 - `~/.grok/sessions/<encoded-cwd>/<session-id>/updates.jsonl` (Grok Build,
   observed-only; reads sibling `summary.json` and optional `signals.json`)
+- `~/.copilot/session-state/<session-id>/events.jsonl` (GitHub Copilot CLI,
+  observed-only)
+- `~/Library/Application Support/Code/User/workspaceStorage/*/chatSessions/*.jsonl`
+  on macOS, with the equivalent `~/.config/Code/...` and
+  `~/AppData/Roaming/Code/...` roots on Linux and Windows (GitHub Copilot in
+  VS Code, observed-only)
 
 Use `--source claude`, `--source codex`, `--source omp`, `--source pi`,
 `--source gemini`, `--source qwen`, `--source opencode`, `--source cursor`,
-`--source grok`, `--archives`, or `--no-archives` to control default discovery.
+`--source grok`, `--source copilot`, `--archives`, or `--no-archives` to control
+default discovery.
 ZIP and Zstandard-compressed rollouts are read
 directly without extracting them. If both `.jsonl` and `.jsonl.zst` versions
 exist during a compression transition, the plain file is read once.
 
-Cursor and Grok Build records are metadata coverage, not token telemetry. The
+Cursor, Grok Build, and Copilot records are metadata coverage, not exact token
+telemetry. The
 ingester does not parse Cursor conversation content or Grok `updates.jsonl`
 events, and never turns file size, mtime, context snapshots, or running totals
 into usage or cost estimates. Cursor records use the transcript file mtime as
 explicit `fileModifiedAt` provenance and leave the model unknown unless a
 future source proves a session-level model. Grok records retain the model and
 project from `summary.json`, plus `contextTokensUsed` and
-`contextWindowTokens` snapshots from `signals.json` when present.
+`contextWindowTokens` snapshots from `signals.json` when present. Copilot CLI
+records retain completed turns, reported output tokens, premium requests, and
+AIU checkpoints. VS Code journals are replayed to final request metadata while
+conversation and tool-response payloads are discarded; their reported prompt,
+completion, credit, and tool-round counters remain observational only.
 
 Sync is incremental by source fingerprint. Unchanged sessions are skipped;
 changed files or archive entries replace their previous normalized data. Codex
@@ -290,17 +305,24 @@ honors its config-directory environment variables and includes nested Claude
 Desktop/Cowork project sessions. Missing or malformed explicit mode metadata
 always remains `unknown`.
 
-### Observed-only Cursor Agent and Grok Build
+### Observed-only Cursor Agent, Grok Build, and GitHub Copilot
 
-Cursor Agent and Grok Build are metadata-coverage adapters, not exact usage
-adapters. Cursor discovery uses `~/.cursor/projects/*/agent-transcripts/**/*.jsonl`
+Cursor Agent, Grok Build, and GitHub Copilot are metadata-coverage adapters, not
+exact usage adapters. Cursor discovery uses
+`~/.cursor/projects/*/agent-transcripts/**/*.jsonl`
 and records only the project path plus transcript file mtime (`fileModifiedAt`);
 conversation lines are not parsed and the model remains unknown. Grok Build
 discovery uses `~/.grok/sessions/<encoded-cwd>/<session-id>/updates.jsonl` and
 reads only sibling `summary.json` plus optional `signals.json` metadata. It
 retains summary model/project/timestamp fields and context-token snapshots when
-present. Neither adapter calls usage aggregation, creates service-mode rows,
-or contributes to exact token/cost totals. The dashboard labels this surface
+present. Copilot CLI discovery uses
+`~/.copilot/session-state/<session-id>/events.jsonl`; it retains the session
+model/project/timestamp, completed turns, assistant-reported output tokens, and
+the final `session.usage_checkpoint`. VS Code discovery filters
+`workspaceStorage/*/chatSessions/*.jsonl` to GitHub Copilot snapshots, replays
+the journal to its final request metadata, and ignores response-array content.
+None of these adapters calls usage aggregation, creates service-mode rows, or
+contributes to exact token/cost totals. The dashboard labels this surface
 “Observed Harness Coverage” and states that usage is unavailable.
 
 ### omp (oh-my-pi)

--- a/docs/HARNESS_FORMAT_FRONTIER.md
+++ b/docs/HARNESS_FORMAT_FRONTIER.md
@@ -44,10 +44,12 @@ dashboard breakdowns
   harness/agent identity.
 - Exact token counters may be normalized when their cache semantics are known
   and covered by a fixture.
-- Cursor Agent transcripts and Grok Build sessions are admitted as
+- Cursor Agent transcripts, Grok Build sessions, and GitHub Copilot CLI/VS Code
+  sessions are admitted as
   `observed-only` metadata coverage. They retain agent/provider/model/project
   identity and source-timestamp provenance; Grok may retain context-token
-  snapshots from `signals.json`.
+  snapshots from `signals.json`. Copilot may retain harness-native output,
+  request, credit, and checkpoint counters as explicitly non-exact metadata.
 
 ## Rejected Surface
 
@@ -58,13 +60,15 @@ dashboard breakdowns
   record its own tier.
 - Reporting character estimates, divided session totals, inferred costs, or
   embedded provider costs as exact request telemetry.
-- Treating Cursor file mtime, transcript content, Grok context snapshots, or
-  running update totals as exact usage or cost telemetry.
+- Treating Cursor file mtime, transcript content, Grok context snapshots,
+  Copilot VS Code request counters, or Copilot CLI output/checkpoint counters as
+  exact usage or cost telemetry.
 - Claiming parity with every upstream CodeBurn provider from a registry count.
 
 ## Guard-Only Future
 
-- Any future estimate or provider-reported cost for Cursor Agent, Kiro, or Grok
+- Any future estimate or provider-reported cost for Cursor Agent, Kiro, Grok,
+  or GitHub Copilot
   requires a separate measurement contract before it can join exact usage
   totals; observed-only metadata remains excluded from those totals.
 - Network and RPC sources require separate authority, privacy, retry, and

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -130,8 +130,8 @@ function parseArgs(argv, env = process.env) {
     }
   }
 
-  if (!["all", "claude", "codex", "omp", "pi", "gemini", "qwen", "opencode", "cursor", "grok"].includes(options.source)) {
-    throw new Error("--source must be all, claude, codex, omp, pi, gemini, qwen, opencode, cursor, or grok");
+  if (!["all", "claude", "codex", "omp", "pi", "gemini", "qwen", "opencode", "cursor", "grok", "copilot"].includes(options.source)) {
+    throw new Error("--source must be all, claude, codex, omp, pi, gemini, qwen, opencode, cursor, grok, or copilot");
   }
   if (!["auto", "short", "long"].includes(options.openaiContext)) {
     throw new Error("--openai-context must be auto, short, or long");
@@ -180,11 +180,11 @@ function helpText() {
   return `Usage: node app.js [options] [paths...]
 
 Scans exact local sessions from Claude Code, Codex, omp (oh-my-pi), Pi, Gemini CLI,
-Qwen Code, and OpenCode; Cursor Agent and Grok Build contribute observed-only
-metadata coverage and never token or cost usage.
+Qwen Code, and OpenCode; Cursor Agent, Grok Build, and GitHub Copilot CLI/VS Code
+contribute observed-only metadata coverage and never token or cost usage.
 
 Options:
-  --source all|claude|codex|omp|pi|gemini|qwen|opencode|cursor|grok   Source roots to scan when paths are omitted (default: all)
+  --source all|claude|codex|omp|pi|gemini|qwen|opencode|cursor|grok|copilot   Source roots to scan when paths are omitted (default: all)
   --archives / --no-archives      Include Codex archived_sessions rollouts and zip files (default: include)
   --home PATH                     Home directory for default roots (default: current user home)
   --codex-home PATH               Codex data directory (default: CODEX_HOME or ~/.codex)

--- a/lib/core/derivation.js
+++ b/lib/core/derivation.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // Bump these independently when their derived values can change for the same source bytes.
-const ANALYTICS_DERIVATION_VERSION = 7;
+const ANALYTICS_DERIVATION_VERSION = 8;
 
 function sourceFingerprint(parts, {
   analyticsDerivationVersion = ANALYTICS_DERIVATION_VERSION,

--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -403,10 +403,18 @@ function observedHarnessStats(report) {
         latestSourceTimestamp: null,
         contextTokens: null,
         contextWindowTokens: null,
+        requestCount: 0,
+        premiumRequests: 0,
+        aiUnits: 0,
+        reportedCopilotCredits: 0,
       };
       groups.set(key, row);
     }
     row.sessionCount += 1;
+    row.requestCount += Number.isFinite(observation.requestCount) ? observation.requestCount : 0;
+    row.premiumRequests += Number.isFinite(observation.premiumRequests) ? observation.premiumRequests : 0;
+    row.aiUnits += Number.isFinite(observation.aiUnits) ? observation.aiUnits : 0;
+    row.reportedCopilotCredits += Number.isFinite(observation.reportedCopilotCredits) ? observation.reportedCopilotCredits : 0;
     const project = observation.project || "(unknown project)";
     if (!row.projects.includes(project)) {
       row.projectCount += 1;

--- a/lib/ingest/copilot.js
+++ b/lib/ingest/copilot.js
@@ -1,0 +1,463 @@
+"use strict";
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const Path = require("node:path");
+const readline = require("node:readline");
+const { fileURLToPath } = require("node:url");
+const {
+  UNKNOWN_MODEL,
+  UNKNOWN_PROJECT,
+} = require("../core/report-model");
+const {
+  observationBase,
+  observedSourceError,
+} = require("./observed-harnesses");
+
+const MULTIPLE_MODELS = "(multiple models)";
+const COPILOT_VSCODE_FIELDS = new Set([
+  "completionTokens",
+  "copilotCredits",
+  "elapsedMs",
+  "modelId",
+  "promptTokens",
+  "requestId",
+  "responseId",
+  "responseTimestamp",
+  "timestamp",
+]);
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : null;
+}
+
+function nonNegativeNumber(value) {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function isoTimestamp(value) {
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : null;
+}
+
+function latestTimestamp(current, candidate) {
+  const parsed = isoTimestamp(candidate);
+  if (!parsed) return current;
+  if (!current || Date.parse(parsed) > Date.parse(current)) return parsed;
+  return current;
+}
+
+async function walkFiles(root, predicate, out = []) {
+  let entries;
+  try {
+    entries = await fsp.readdir(root, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const fullPath = Path.join(root, entry.name);
+    if (entry.isDirectory()) await walkFiles(fullPath, predicate, out);
+    else if (entry.isFile() && predicate(fullPath)) out.push(fullPath);
+  }
+  return out;
+}
+
+function copilotCliRoot(home) {
+  return Path.join(home, ".copilot", "session-state");
+}
+
+function copilotVscodeRoots(home) {
+  return [
+    Path.join(home, "Library", "Application Support", "Code", "User", "workspaceStorage"),
+    Path.join(home, ".config", "Code", "User", "workspaceStorage"),
+    Path.join(home, "AppData", "Roaming", "Code", "User", "workspaceStorage"),
+  ];
+}
+
+async function firstJsonRecord(filename) {
+  const stream = fs.createReadStream(filename, { encoding: "utf8" });
+  const lines = readline.createInterface({ input: stream, crlfDelay: Infinity });
+  try {
+    for await (const line of lines) {
+      if (line.trim() === "") continue;
+      return JSON.parse(line);
+    }
+  } catch {
+    return null;
+  } finally {
+    lines.close();
+    stream.destroy();
+  }
+  return null;
+}
+
+function isCopilotVscodeSnapshot(record) {
+  if (!record || record.kind !== 0 || !record.v || typeof record.v !== "object") return false;
+  const snapshot = record.v;
+  if (nonEmptyString(snapshot.responderUsername)?.toLowerCase() === "github copilot") return true;
+  const selectedModel = nonEmptyString(snapshot.inputState?.selectedModel?.identifier);
+  if (selectedModel?.toLowerCase().startsWith("copilot/")) return true;
+  const extension = nonEmptyString(snapshot.inputState?.selectedModel?.metadata?.extension?._lower) ||
+    nonEmptyString(snapshot.inputState?.selectedModel?.metadata?.extension?.value);
+  if (extension?.toLowerCase() === "github.copilot-chat") return true;
+  return Array.isArray(snapshot.requests) && snapshot.requests.some((request) =>
+    nonEmptyString(request?.modelId)?.toLowerCase().startsWith("copilot/"));
+}
+
+async function discoverCopilotCliInputs(home) {
+  const paths = await walkFiles(copilotCliRoot(home), (filename) => Path.basename(filename) === "events.jsonl");
+  return paths.map((path) => ({ kind: "jsonl", adapter: "copilot-cli", path }));
+}
+
+async function discoverCopilotVscodeInputs(home) {
+  const output = [];
+  for (const root of copilotVscodeRoots(home)) {
+    let workspaces;
+    try {
+      workspaces = await fsp.readdir(root, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const workspace of workspaces) {
+      if (!workspace.isDirectory()) continue;
+      const chatSessions = Path.join(root, workspace.name, "chatSessions");
+      let files;
+      try {
+        files = await fsp.readdir(chatSessions, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const file of files) {
+        if (!file.isFile() || !file.name.endsWith(".jsonl")) continue;
+        const sessionPath = Path.join(chatSessions, file.name);
+        if (isCopilotVscodeSnapshot(await firstJsonRecord(sessionPath))) {
+          output.push({ kind: "jsonl", adapter: "copilot-vscode", path: sessionPath });
+        }
+      }
+    }
+  }
+  return output;
+}
+
+async function discoverCopilotInputs(home) {
+  return [
+    ...await discoverCopilotCliInputs(home),
+    ...await discoverCopilotVscodeInputs(home),
+  ];
+}
+
+function adapterForCopilotPath(filename, hint = null) {
+  if (hint === "copilot-cli" || hint === "copilot-vscode") return hint;
+  const normalized = filename.replace(/\\/g, "/");
+  if (Path.basename(filename) === "events.jsonl" && normalized.includes("/.copilot/session-state/")) {
+    return "copilot-cli";
+  }
+  if (normalized.includes("/Code/User/workspaceStorage/") && normalized.includes("/chatSessions/") && filename.endsWith(".jsonl")) {
+    return "copilot-vscode";
+  }
+  return null;
+}
+
+async function processJsonlRecords(filename, report, options, session, callback) {
+  const stream = fs.createReadStream(filename, { encoding: "utf8" });
+  const lines = readline.createInterface({ input: stream, crlfDelay: Infinity });
+  let lineNo = 0;
+  try {
+    for await (const line of lines) {
+      lineNo += 1;
+      session.lines += 1;
+      if (line.trim() === "") continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch (error) {
+        observedSourceError(report, session, `${filename}:${lineNo}`, error, options);
+        continue;
+      }
+      session.records += 1;
+      try {
+        callback(record, lineNo);
+      } catch (error) {
+        observedSourceError(report, session, `${filename}:${lineNo}`, error, options);
+      }
+    }
+  } finally {
+    lines.close();
+    stream.destroy();
+  }
+}
+
+function modelSummary(models) {
+  const values = [...models].filter(Boolean).sort();
+  if (values.length === 0) return UNKNOWN_MODEL;
+  if (values.length === 1) return values[0];
+  return MULTIPLE_MODELS;
+}
+
+function normalizedCopilotModel(value) {
+  const model = nonEmptyString(value);
+  if (!model) return null;
+  return model.toLowerCase().startsWith("copilot/") ? model.slice("copilot/".length) : model;
+}
+
+async function processCopilotCli(filename, report, options, session) {
+  const state = {
+    completedTurns: new Set(),
+    copilotVersion: null,
+    models: new Set(),
+    outputTokens: 0,
+    outputTokensSeen: false,
+    producer: null,
+    project: UNKNOWN_PROJECT,
+    sessionId: Path.basename(Path.dirname(filename)),
+    sourceTimestamp: null,
+    startSeen: false,
+    totalNanoAiu: null,
+    totalPremiumRequests: null,
+  };
+
+  await processJsonlRecords(filename, report, options, session, (record, lineNo) => {
+    state.sourceTimestamp = latestTimestamp(state.sourceTimestamp, record.timestamp);
+    const data = record.data && typeof record.data === "object" ? record.data : {};
+    if (record.type === "session.start") {
+      state.startSeen = true;
+      state.sessionId = nonEmptyString(data.sessionId) || state.sessionId;
+      state.producer = nonEmptyString(data.producer);
+      state.copilotVersion = nonEmptyString(data.copilotVersion);
+      state.project = nonEmptyString(data.context?.cwd) || state.project;
+      state.sourceTimestamp = latestTimestamp(state.sourceTimestamp, data.startTime);
+    } else if (record.type === "session.model_change") {
+      const model = normalizedCopilotModel(data.newModel);
+      if (model) state.models.add(model);
+    } else if (record.type === "assistant.message") {
+      const model = normalizedCopilotModel(data.model);
+      if (model) state.models.add(model);
+      const outputTokens = nonNegativeNumber(data.outputTokens);
+      if (outputTokens !== null) {
+        state.outputTokens += outputTokens;
+        state.outputTokensSeen = true;
+      }
+      const turnId = nonEmptyString(data.turnId);
+      if (turnId) state.completedTurns.add(turnId);
+    } else if (record.type === "assistant.turn_end") {
+      state.completedTurns.add(nonEmptyString(data.turnId) || `line:${lineNo}`);
+    } else if (record.type === "session.usage_checkpoint") {
+      state.totalNanoAiu = nonNegativeNumber(data.totalNanoAiu);
+      state.totalPremiumRequests = nonNegativeNumber(data.totalPremiumRequests);
+    }
+  });
+
+  if (!state.startSeen || state.producer !== "copilot-agent") {
+    observedSourceError(report, session, filename, new Error("missing Copilot CLI session.start shape"), options);
+    return;
+  }
+
+  const observation = observationBase({
+    agent: "copilot-cli",
+    provider: "github",
+    model: modelSummary(state.models),
+    project: state.project,
+    sourceTimestamp: state.sourceTimestamp,
+    sourceTimestampProvenance: state.sourceTimestamp ? "event.timestamp" : "event.timestamp-unavailable",
+  });
+  observation.sessionId = state.sessionId;
+  observation.requestCount = state.completedTurns.size;
+  if (state.outputTokensSeen) observation.reportedOutputTokens = state.outputTokens;
+  observation.counterProvenance = "assistant.message.outputTokens + session.usage_checkpoint";
+  if (state.copilotVersion) observation.copilotVersion = state.copilotVersion;
+  if (state.totalPremiumRequests !== null) observation.premiumRequests = state.totalPremiumRequests;
+  if (state.totalNanoAiu !== null) {
+    observation.reportedNanoAiu = state.totalNanoAiu;
+    observation.aiUnits = state.totalNanoAiu / 1e9;
+  }
+  session.stats.observation = observation;
+}
+
+function sanitizeResultMetadata(result) {
+  const metadata = result?.metadata;
+  if (!metadata || typeof metadata !== "object") return null;
+  return {
+    outputTokens: nonNegativeNumber(metadata.outputTokens),
+    promptTokens: nonNegativeNumber(metadata.promptTokens),
+    resolvedModel: normalizedCopilotModel(metadata.resolvedModel),
+    toolCallRounds: Array.isArray(metadata.toolCallRounds) ? metadata.toolCallRounds.length : null,
+  };
+}
+
+function sanitizeVscodeRequest(request) {
+  if (!request || typeof request !== "object") return {};
+  const output = {};
+  for (const field of COPILOT_VSCODE_FIELDS) {
+    if (Object.hasOwn(request, field)) output[field] = request[field];
+  }
+  output.resultMetadata = sanitizeResultMetadata(request.result);
+  return output;
+}
+
+function snapshotMetadata(snapshot) {
+  return {
+    creationDate: snapshot.creationDate,
+    responderUsername: snapshot.responderUsername,
+    selectedModel: snapshot.inputState?.selectedModel?.identifier,
+    selectedModelExtension: snapshot.inputState?.selectedModel?.metadata?.extension?._lower ||
+      snapshot.inputState?.selectedModel?.metadata?.extension?.value,
+    sessionId: snapshot.sessionId,
+    version: snapshot.version,
+    requests: Array.isArray(snapshot.requests) ? snapshot.requests.map(sanitizeVscodeRequest) : [],
+  };
+}
+
+function applyVscodeJournalRecord(state, record) {
+  if (record.kind === 0) {
+    if (!record.v || typeof record.v !== "object") throw new Error("invalid VS Code snapshot");
+    return snapshotMetadata(record.v);
+  }
+  if (!state || !Array.isArray(record.k)) throw new Error("VS Code journal record precedes snapshot");
+  const [root, index, field] = record.k;
+  if (record.kind === 2) {
+    if (root === "requests" && record.k.length === 1) {
+      if (!Array.isArray(record.v)) throw new Error("VS Code request splice must contain an array");
+      const at = record.i == null ? state.requests.length : record.i;
+      if (!Number.isInteger(at) || at < 0 || at > state.requests.length) throw new Error("invalid VS Code request splice index");
+      state.requests.splice(at, 0, ...record.v.map(sanitizeVscodeRequest));
+    }
+    // Response-array splices carry conversation/tool content, not usage
+    // metadata, and are intentionally ignored.
+    return state;
+  }
+  if (record.kind !== 1) throw new Error(`unsupported VS Code journal kind ${record.kind}`);
+  if (root !== "requests") return state;
+  if (!Number.isInteger(index) || index < 0 || index >= state.requests.length) throw new Error("invalid VS Code request index");
+  if (record.k.length === 2) {
+    state.requests[index] = sanitizeVscodeRequest(record.v);
+  } else if (field === "result") {
+    state.requests[index].resultMetadata = sanitizeResultMetadata(record.v);
+  } else if (COPILOT_VSCODE_FIELDS.has(field)) {
+    state.requests[index][field] = record.v;
+  }
+  return state;
+}
+
+function isCopilotVscodeState(state) {
+  if (!state) return false;
+  if (nonEmptyString(state.responderUsername)?.toLowerCase() === "github copilot") return true;
+  if (nonEmptyString(state.selectedModel)?.toLowerCase().startsWith("copilot/")) return true;
+  if (nonEmptyString(state.selectedModelExtension)?.toLowerCase() === "github.copilot-chat") return true;
+  return state.requests.some((request) => nonEmptyString(request.modelId)?.toLowerCase().startsWith("copilot/"));
+}
+
+async function vscodeWorkspaceProject(filename) {
+  const workspaceFile = Path.join(Path.dirname(Path.dirname(filename)), "workspace.json");
+  let metadata;
+  try {
+    metadata = JSON.parse(await fsp.readFile(workspaceFile, "utf8"));
+  } catch {
+    return UNKNOWN_PROJECT;
+  }
+  const value = nonEmptyString(metadata.folder) || nonEmptyString(metadata.workspace);
+  if (!value) return UNKNOWN_PROJECT;
+  if (!value.startsWith("file:")) return value;
+  try {
+    const decoded = fileURLToPath(value);
+    return metadata.workspace ? Path.dirname(decoded) : decoded;
+  } catch {
+    return UNKNOWN_PROJECT;
+  }
+}
+
+async function processCopilotVscode(filename, report, options, session) {
+  let state = null;
+  await processJsonlRecords(filename, report, options, session, (record) => {
+    state = applyVscodeJournalRecord(state, record);
+  });
+  if (!isCopilotVscodeState(state)) {
+    observedSourceError(report, session, filename, new Error("missing GitHub Copilot VS Code session shape"), options);
+    return;
+  }
+
+  const models = new Set();
+  const selectedModel = normalizedCopilotModel(state.selectedModel);
+  if (selectedModel) models.add(selectedModel);
+  let sourceTimestamp = latestTimestamp(null, state.creationDate);
+  let sourceTimestampProvenance = sourceTimestamp ? "journal.creationDate" : "journal.timestamp-unavailable";
+  let reportedPromptTokens = 0;
+  let reportedCompletionTokens = 0;
+  let reportedCopilotCredits = 0;
+  let toolCallRounds = 0;
+  let promptTokensSeen = false;
+  let completionTokensSeen = false;
+  let copilotCreditsSeen = false;
+  let toolCallRoundsSeen = false;
+  for (const request of state.requests) {
+    const model = request.resultMetadata?.resolvedModel || normalizedCopilotModel(request.modelId);
+    if (model) models.add(model);
+    const requestTimestamp = isoTimestamp(request.timestamp);
+    if (requestTimestamp && (!sourceTimestamp || Date.parse(requestTimestamp) >= Date.parse(sourceTimestamp))) {
+      sourceTimestamp = requestTimestamp;
+      sourceTimestampProvenance = "journal.request.timestamp";
+    }
+    const responseTimestamp = isoTimestamp(request.responseTimestamp);
+    if (responseTimestamp && (!sourceTimestamp || Date.parse(responseTimestamp) >= Date.parse(sourceTimestamp))) {
+      sourceTimestamp = responseTimestamp;
+      sourceTimestampProvenance = "journal.request.responseTimestamp";
+    }
+    const promptTokens = nonNegativeNumber(request.promptTokens);
+    if (promptTokens !== null) {
+      reportedPromptTokens += promptTokens;
+      promptTokensSeen = true;
+    }
+    const completionTokens = nonNegativeNumber(request.completionTokens);
+    if (completionTokens !== null) {
+      reportedCompletionTokens += completionTokens;
+      completionTokensSeen = true;
+    }
+    const copilotCredits = nonNegativeNumber(request.copilotCredits);
+    if (copilotCredits !== null) {
+      reportedCopilotCredits += copilotCredits;
+      copilotCreditsSeen = true;
+    }
+    const requestToolCallRounds = nonNegativeNumber(request.resultMetadata?.toolCallRounds);
+    if (requestToolCallRounds !== null) {
+      toolCallRounds += requestToolCallRounds;
+      toolCallRoundsSeen = true;
+    }
+  }
+
+  const observation = observationBase({
+    agent: "copilot-vscode",
+    provider: "github",
+    model: modelSummary(models),
+    project: await vscodeWorkspaceProject(filename),
+    sourceTimestamp,
+    sourceTimestampProvenance,
+  });
+  observation.sessionId = nonEmptyString(state.sessionId) || Path.basename(filename, ".jsonl");
+  observation.requestCount = state.requests.length;
+  if (promptTokensSeen) observation.reportedPromptTokens = reportedPromptTokens;
+  if (completionTokensSeen) observation.reportedCompletionTokens = reportedCompletionTokens;
+  if (copilotCreditsSeen) observation.reportedCopilotCredits = Number(reportedCopilotCredits.toFixed(9));
+  if (toolCallRoundsSeen) observation.reportedToolCallRounds = toolCallRounds;
+  observation.counterProvenance = "chatSessions journal final request fields";
+  if (nonNegativeNumber(state.version) !== null) observation.formatVersion = Number(state.version);
+  session.stats.observation = observation;
+}
+
+async function processCopilotFile(filename, report, options, session, hint = null) {
+  const adapter = adapterForCopilotPath(filename, hint);
+  if (adapter === "copilot-cli") return processCopilotCli(filename, report, options, session);
+  if (adapter === "copilot-vscode") return processCopilotVscode(filename, report, options, session);
+  return false;
+}
+
+module.exports = {
+  adapterForCopilotPath,
+  copilotCliRoot,
+  copilotVscodeRoots,
+  discoverCopilotCliInputs,
+  discoverCopilotInputs,
+  discoverCopilotVscodeInputs,
+  isCopilotVscodeSnapshot,
+  processCopilotFile,
+};

--- a/lib/ingest/harnesses.js
+++ b/lib/ingest/harnesses.js
@@ -22,6 +22,11 @@ const {
   discoverGrokInputs,
   processObservedHarnessFile,
 } = require("./observed-harnesses");
+const {
+  adapterForCopilotPath,
+  discoverCopilotInputs,
+  processCopilotFile,
+} = require("./copilot");
 
 const UNKNOWN_SERVICE_MODE = "unknown";
 
@@ -188,12 +193,15 @@ async function discoverHarnessInputs(options = {}) {
   if (source === "all" || source === "opencode") inputs.push(...await discoverOpenCodeInputs(home));
   if (source === "all" || source === "cursor") inputs.push(...await discoverCursorInputs(home));
   if (source === "all" || source === "grok") inputs.push(...await discoverGrokInputs(home));
+  if (source === "all" || source === "copilot") inputs.push(...await discoverCopilotInputs(home));
   return dedupeInputs(inputs);
 }
 
 function adapterForPath(filename, hint = null) {
   if (hint) return hint;
   const normalized = filename.replace(/\\/g, "/");
+  const copilotAdapter = adapterForCopilotPath(filename, hint);
+  if (copilotAdapter) return copilotAdapter;
   if (Path.extname(filename).toLowerCase() === ".db") return "opencode";
   if (Path.extname(filename).toLowerCase() === ".json") return "gemini";
   if (normalized.includes("/.pi/agent/sessions/")) return "pi";
@@ -424,7 +432,9 @@ async function processQwenJsonl(filename, report, options, session) {
 
 async function processHarnessFile(filename, report, options, session, hint = null) {
   const adapter = adapterForPath(filename, hint);
-  if (adapter === "cursor" || adapter === "grok") {
+  if (adapter === "copilot-cli" || adapter === "copilot-vscode") {
+    await processCopilotFile(filename, report, options, session, adapter);
+  } else if (adapter === "cursor" || adapter === "grok") {
     await processObservedHarnessFile(filename, report, options, session, adapter);
   } else if (adapter === "pi") {
     await processPiJsonl(filename, report, options, session);

--- a/lib/ingest/observed-harnesses.js
+++ b/lib/ingest/observed-harnesses.js
@@ -219,5 +219,7 @@ module.exports = {
   adapterForObservedPath,
   discoverCursorInputs,
   discoverGrokInputs,
+  observationBase,
+  observedSourceError,
   processObservedHarnessFile,
 };

--- a/lib/ingest/sources.js
+++ b/lib/ingest/sources.js
@@ -74,7 +74,7 @@ function createIngestSources({
     // Keep the historical processJsonlFile entry point for storage backends,
     // while dispatching exact .json/.db and known harness JSONL formats here.
     // The session kind remains the actual source representation.
-    if (kind !== "jsonl" || ["cursor", "grok", "pi", "gemini", "qwen", "opencode"].includes(adapter)) {
+    if (kind !== "jsonl" || ["cursor", "grok", "copilot-cli", "copilot-vscode", "pi", "gemini", "qwen", "opencode"].includes(adapter)) {
       try {
         await processHarnessFile(filename, report, options, session, adapter);
       } finally {
@@ -181,7 +181,7 @@ function createIngestSources({
     }
 
     // Exact local harness adapters (Claude config/Desktop, Pi, Gemini, Qwen,
-    // and OpenCode), plus observed-only Cursor/Grok metadata adapters, share
+    // and OpenCode), plus observed-only Cursor/Grok/Copilot metadata adapters, share
     // this operational input kind so existing SQLite and ClickHouse sync paths
     // can continue to call processJsonlFile unchanged.
     inputs.push(...await discoverHarnessInputs(options));

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "tokenomics-viewer",
   "version": "0.0.1",
-  "description": "Local token, cost, and harness analytics for Codex, Claude Code, omp, Pi, Gemini, Qwen, OpenCode, Cursor, and Grok Build",
+  "description": "Local token, cost, and harness analytics for Codex, Claude Code, omp, Pi, Gemini, Qwen, OpenCode, Cursor, Grok Build, and GitHub Copilot",
   "keywords": [
     "codex",
+    "copilot",
     "claude",
     "code",
     "oh-my-pi",

--- a/public/index.html
+++ b/public/index.html
@@ -439,10 +439,16 @@
         const context = Number.isFinite(row.contextTokens)
           ? ' · context ' + formatTokenCount(row.contextTokens) + (Number.isFinite(row.contextWindowTokens) ? '/' + formatTokenCount(row.contextWindowTokens) : '')
           : '';
+        const native = [];
+        if (Number(row.requestCount || 0) > 0) native.push(formatTokenCount(row.requestCount) + ' recorded request' + (Number(row.requestCount) === 1 ? '' : 's'));
+        if (Number(row.premiumRequests || 0) > 0) native.push(formatTokenCount(row.premiumRequests) + ' premium request' + (Number(row.premiumRequests) === 1 ? '' : 's'));
+        if (Number(row.aiUnits || 0) > 0) native.push(Number(row.aiUnits).toLocaleString([], { maximumFractionDigits: 6 }) + ' AIU');
+        if (Number(row.reportedCopilotCredits || 0) > 0) native.push(Number(row.reportedCopilotCredits).toLocaleString([], { maximumFractionDigits: 6 }) + ' reported credits');
+        const nativeLine = native.length ? '<div class="observed-harness-card-meta">' + esc(native.join(' · ')) + '</div>' : '';
         return '<article class="observed-harness-card"><div class="observed-harness-card-head"><span class="observed-harness-card-label">' +
           esc(row.agent) + ' · ' + esc(row.provider) + '</span><strong>' + esc(String(sessions)) + ' session' + (sessions === 1 ? '' : 's') + '</strong></div>' +
           '<div class="observed-harness-card-meta">' + esc(model + ' · ' + project) + '</div>' +
-          '<div class="observed-harness-card-meta">' + esc(timestamp + context + ' · usage unavailable') + '</div></article>';
+          nativeLine + '<div class="observed-harness-card-meta">' + esc(timestamp + context + ' · exact usage unavailable') + '</div></article>';
       }).join('');
     }
 

--- a/test/cli-input.test.js
+++ b/test/cli-input.test.js
@@ -100,7 +100,7 @@ test("main writes final JSON report with per-session metrics", async () => {
 
 test("parseArgs rejects invalid values across the supported validation matrix", () => {
   const invalidCases = [
-    [["--source", "invalid"], "--source must be all, claude, codex, omp, pi, gemini, qwen, opencode, cursor, or grok"],
+    [["--source", "invalid"], "--source must be all, claude, codex, omp, pi, gemini, qwen, opencode, cursor, grok, or copilot"],
     [["--openai-context", "invalid"], "--openai-context must be auto, short, or long"],
     [["--format", "xml"], "--format must be text or json"],
     [["--db-engine", "invalid"], "--db-engine must be sqlite or clickhouse"],

--- a/test/copilot.test.js
+++ b/test/copilot.test.js
@@ -1,0 +1,263 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const Path = require("node:path");
+const test = require("node:test");
+const {
+  buildReport,
+  buildReportFromDatabase,
+  discoverInputs,
+  syncDatabase,
+} = require("../app");
+const { webSummary } = require("../lib/dashboard");
+const { adapterForPath } = require("../lib/ingest/harnesses");
+const { defaultOptions } = require("./support/fixtures");
+
+function tempHome() {
+  return fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-copilot-"));
+}
+
+function writeJsonl(filename, rows) {
+  fs.mkdirSync(Path.dirname(filename), { recursive: true });
+  fs.writeFileSync(filename, rows.map((row) => typeof row === "string" ? row : JSON.stringify(row)).join("\n") + "\n");
+}
+
+function copilotFixture(home) {
+  const cli = Path.join(home, ".copilot", "session-state", "cli-session", "events.jsonl");
+  writeJsonl(cli, [
+    {
+      id: "start",
+      type: "session.start",
+      timestamp: "2026-08-01T00:00:00.000Z",
+      data: {
+        sessionId: "cli-session",
+        producer: "copilot-agent",
+        copilotVersion: "1.0.78",
+        startTime: "2026-08-01T00:00:00.000Z",
+        context: { cwd: "/tmp/copilot-cli-project" },
+      },
+    },
+    {
+      id: "message",
+      type: "assistant.message",
+      timestamp: "2026-08-01T00:00:01.000Z",
+      data: { model: "claude-opus-5", outputTokens: 7, turnId: "turn-1", content: "cli-private-content-marker" },
+    },
+    {
+      id: "turn-end",
+      type: "assistant.turn_end",
+      timestamp: "2026-08-01T00:00:02.000Z",
+      data: { turnId: "turn-1" },
+    },
+    {
+      id: "checkpoint",
+      type: "session.usage_checkpoint",
+      timestamp: "2026-08-01T00:00:03.000Z",
+      data: { totalNanoAiu: 3_000_000_000, totalPremiumRequests: 2 },
+    },
+  ]);
+
+  const workspaceRoot = Path.join(
+    home,
+    "Library",
+    "Application Support",
+    "Code",
+    "User",
+    "workspaceStorage",
+    "workspace-hash",
+  );
+  const vscode = Path.join(workspaceRoot, "chatSessions", "vscode-session.jsonl");
+  writeJsonl(vscode, [
+    {
+      kind: 0,
+      v: {
+        creationDate: Date.parse("2026-08-02T00:00:00.000Z"),
+        sessionId: "vscode-session",
+        version: 3,
+        responderUsername: "GitHub Copilot",
+        inputState: {
+          selectedModel: {
+            identifier: "copilot/claude-opus-5",
+            metadata: { extension: { _lower: "github.copilot-chat" } },
+          },
+        },
+        requests: [{
+          requestId: "request-1",
+          modelId: "copilot/claude-opus-5",
+          promptTokens: 10,
+          completionTokens: 2,
+          copilotCredits: 1,
+          timestamp: Date.parse("2026-08-02T00:00:01.000Z"),
+          responseTimestamp: Date.parse("2026-08-02T00:00:02.000Z"),
+        }],
+      },
+    },
+    { kind: 1, k: ["requests", 0, "promptTokens"], v: 12 },
+    { kind: 1, k: ["requests", 0, "completionTokens"], v: 4 },
+    { kind: 1, k: ["requests", 0, "copilotCredits"], v: 1.5 },
+    {
+      kind: 1,
+      k: ["requests", 0, "result"],
+      v: {
+        metadata: {
+          promptTokens: 12,
+          outputTokens: 3,
+          resolvedModel: "claude-opus-5",
+          toolCallRounds: [{}, {}],
+        },
+      },
+    },
+    {
+      kind: 2,
+      k: ["requests"],
+      i: null,
+      v: [{
+        requestId: "request-2",
+        modelId: "copilot/claude-opus-5",
+        promptTokens: 20,
+        completionTokens: 5,
+        copilotCredits: 2,
+        timestamp: Date.parse("2026-08-02T00:01:00.000Z"),
+        responseTimestamp: Date.parse("2026-08-02T00:01:01.000Z"),
+        result: {
+          metadata: {
+            promptTokens: 20,
+            outputTokens: 4,
+            resolvedModel: "claude-opus-5",
+            toolCallRounds: [{}],
+          },
+        },
+      }],
+    },
+    {
+      kind: 2,
+      k: ["requests", 1, "response"],
+      i: null,
+      v: [{ value: "vscode-private-content-marker" }],
+    },
+  ]);
+  fs.writeFileSync(Path.join(workspaceRoot, "workspace.json"), JSON.stringify({ folder: "file:///tmp/copilot-vscode-project" }));
+
+  const unrelated = Path.join(
+    home,
+    "Library",
+    "Application Support",
+    "Code",
+    "User",
+    "workspaceStorage",
+    "other-workspace",
+    "chatSessions",
+    "other.jsonl",
+  );
+  writeJsonl(unrelated, [{ kind: 0, v: { responderUsername: "Another Extension", requests: [] } }]);
+
+  return { cli, unrelated, vscode };
+}
+
+test("discovers Copilot CLI and VS Code sessions while filtering unrelated VS Code chats", async () => {
+  const home = tempHome();
+  const paths = copilotFixture(home);
+  const inputs = await discoverInputs(defaultOptions({ home, source: "all" }));
+  assert.deepEqual(inputs.map((input) => input.path).sort(), [fs.realpathSync(paths.cli), fs.realpathSync(paths.vscode)].sort());
+  assert.deepEqual(inputs.map((input) => input.adapter).sort(), ["copilot-cli", "copilot-vscode"]);
+  assert.equal(adapterForPath(paths.cli), "copilot-cli");
+  assert.equal(adapterForPath(paths.vscode), "copilot-vscode");
+});
+
+test("Copilot CLI and VS Code counters remain observed-only and do not change exact totals", async () => {
+  const home = tempHome();
+  const paths = copilotFixture(home);
+  const report = await buildReport(defaultOptions({ home, source: "copilot", progress: false }));
+
+  assert.equal(report.sessions.length, 2);
+  assert.equal(report.total.requests, 0);
+  assert.equal(report.total.input, 0);
+  assert.equal(report.total.output, 0);
+  assert.equal(report.total.costUsd, 0);
+  assert.deepEqual(report.agents, {});
+  assert.deepEqual(report.serviceModes, {});
+  assert.doesNotMatch(JSON.stringify(report), /(?:cli|vscode)-private-content-marker/);
+
+  const cli = report.sessions.find((session) => session.path === fs.realpathSync(paths.cli));
+  assert.deepEqual(cli.stats.observation, {
+    agent: "copilot-cli",
+    provider: "github",
+    model: "claude-opus-5",
+    project: "/tmp/copilot-cli-project",
+    measurement: "observed-only",
+    exactUsageAvailable: false,
+    sourceTimestamp: "2026-08-01T00:00:03.000Z",
+    sourceTimestampProvenance: "event.timestamp",
+    sessionId: "cli-session",
+    requestCount: 1,
+    reportedOutputTokens: 7,
+    counterProvenance: "assistant.message.outputTokens + session.usage_checkpoint",
+    copilotVersion: "1.0.78",
+    premiumRequests: 2,
+    reportedNanoAiu: 3_000_000_000,
+    aiUnits: 3,
+  });
+
+  const vscode = report.sessions.find((session) => session.path === fs.realpathSync(paths.vscode));
+  assert.deepEqual(vscode.stats.observation, {
+    agent: "copilot-vscode",
+    provider: "github",
+    model: "claude-opus-5",
+    project: "/tmp/copilot-vscode-project",
+    measurement: "observed-only",
+    exactUsageAvailable: false,
+    sourceTimestamp: "2026-08-02T00:01:01.000Z",
+    sourceTimestampProvenance: "journal.request.responseTimestamp",
+    sessionId: "vscode-session",
+    requestCount: 2,
+    reportedPromptTokens: 32,
+    reportedCompletionTokens: 9,
+    reportedCopilotCredits: 3.5,
+    reportedToolCallRounds: 3,
+    counterProvenance: "chatSessions journal final request fields",
+    formatVersion: 3,
+  });
+
+  const summary = webSummary(report, defaultOptions({ now: new Date("2026-08-03T00:00:00.000Z") }));
+  assert.deepEqual(summary.observedHarnesses.map((row) => row.agent).sort(), ["copilot-cli", "copilot-vscode"]);
+  assert.equal(summary.observedHarnesses.find((row) => row.agent === "copilot-cli").premiumRequests, 2);
+  assert.equal(summary.observedHarnesses.find((row) => row.agent === "copilot-cli").aiUnits, 3);
+  assert.equal(summary.observedHarnesses.find((row) => row.agent === "copilot-vscode").reportedCopilotCredits, 3.5);
+});
+
+test("malformed Copilot journal records are isolated in lenient mode and throw in strict mode", async () => {
+  const home = tempHome();
+  const paths = copilotFixture(home);
+  fs.appendFileSync(paths.vscode, `${JSON.stringify({ kind: 9, k: [] })}\n`);
+  fs.appendFileSync(paths.cli, "{not-json\n");
+
+  const lenient = await buildReport(defaultOptions({ home, source: "copilot", progress: false }));
+  assert.equal(lenient.total.requests, 0);
+  assert.equal(lenient.sessions.length, 2);
+  assert.equal(lenient.sources.parseErrors, 2);
+  assert.equal(lenient.sessions.every((session) => session.parseErrors === 1), true);
+  assert.equal(lenient.sessions.every((session) => session.stats.observation?.measurement === "observed-only"), true);
+
+  await assert.rejects(
+    () => buildReport(defaultOptions({ home, source: "copilot", strictJson: true, progress: false })),
+    /Invalid JSON/,
+  );
+});
+
+test("Copilot observations survive SQLite sync and report reload", async () => {
+  const home = tempHome();
+  copilotFixture(home);
+  const db = Path.join(home, "tokenomics.sqlite");
+  const options = defaultOptions({ home, source: "copilot", db, progress: false });
+  const synced = await syncDatabase(options);
+  const reloaded = buildReportFromDatabase(db, options);
+
+  assert.equal(synced.sessions.length, 2);
+  assert.equal(reloaded.sessions.length, 2);
+  assert.equal(reloaded.total.requests, 0);
+  assert.deepEqual(reloaded.sessions.map((session) => session.stats.observation?.agent).sort(), ["copilot-cli", "copilot-vscode"]);
+  assert.equal(reloaded.sessions.find((session) => session.stats.observation?.agent === "copilot-cli").stats.observation.premiumRequests, 2);
+  assert.equal(reloaded.sessions.find((session) => session.stats.observation?.agent === "copilot-vscode").stats.observation.requestCount, 2);
+});


### PR DESCRIPTION
## Summary

- discover GitHub Copilot CLI `events.jsonl` sessions and Copilot-backed VS Code `chatSessions` journals
- replay and sanitize the two formats into observed-harness metadata
- expose native request/checkpoint counters in Observed Harness Coverage
- add `--source copilot`, documentation, package metadata, and a derivation-version bump

## Analytics and privacy contract

- Copilot remains `observed-only`; it contributes no exact requests, input/cache/output tokens, cost, agent totals, or service-mode totals
- conversation text, reasoning, tool payloads, response arrays, and account labels are discarded
- AIU, premium requests, prompt/completion counters, and Copilot credits remain harness-native observations, not billing telemetry

## Validation

- Node.js `v26.7.0`
- `node --test test/copilot.test.js test/cli-input.test.js`: 13/13 passed
- `node --test`: 266/266 passed
- `git diff --check`: passed
- `node --check lib/ingest/copilot.js`: passed
- `npm --cache /private/tmp/tokenomics-npm-cache pack --dry-run --json`: passed; `lib/ingest/copilot.js` included
- base: `origin/main` at `5a5c89e45669515c07afedce2f2417073bd37990`
- diff SHA-256: `c96a1d7d8d07ce76962a36c55e2c03121882c2557bb71c741d840d5b30c050ad`

## Draft gaps

- the repository lacks `.claude/skills/review/SKILL.md`, so the independent local review runner failed closed at preflight; this PR has manual source review and executed tests, but no independent reviewer receipt
- current tests use sanitized synthetic fixtures; validate more current Copilot CLI and VS Code journal variants before marking ready
- SQLite persistence is covered; a live ClickHouse round-trip was not run in this pass
- exact billing remains intentionally unavailable until Copilot exposes a proven complete per-call contract

🕵️‍♂️
