### PR TITLE
Add macOS launch-at-login support

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,9 +42,5 @@ jobs:
           node scripts/generate-macos-summary-fixture.js
           git diff --exit-code -- mac/Tests/TokenomicsMenubarTests/Fixtures
           node --test test/macos-contract.test.js
-      - name: Run tests
-        run: swift test -Xswiftc -warnings-as-errors
-        working-directory: mac
-      - name: Build release executable
-        run: swift build -c release -Xswiftc -warnings-as-errors
-        working-directory: mac
+      - name: Test and build app bundle
+        run: ./mac/build-app.sh

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ The local defaults are:
 ### Check and Control the Local Server
 
 ```bash
+cd "${TOKENOMICS_DATA_HOME:-${XDG_DATA_HOME:-$HOME/.local/share}}/tokenomics-viewer"
 chctl --version
 chctl local server list
 curl -fsS http://127.0.0.1:8123/ping
@@ -158,14 +159,16 @@ chctl local client --name tokenomics --query "SELECT version()"
 Start or stop the named server:
 
 ```bash
+cd "${TOKENOMICS_DATA_HOME:-${XDG_DATA_HOME:-$HOME/.local/share}}/tokenomics-viewer"
 chctl local server start --name tokenomics --http-port 8123 --tcp-port 9000
 chctl local server stop tokenomics
 ```
 
 `clickhousectl` stores local server state under `.clickhouse/` in the directory
-where it is run. Run control commands from the same directory where you started
-`tokenomics-launch`. If `chctl local server list` is unexpectedly empty, check
-your current directory first.
+where it is run. `tokenomics-launch` always invokes it from Tokenomics' persistent
+data directory, independent of the shell, Finder, or Login Items working directory.
+Run manual control commands from that same data directory. If
+`chctl local server list` is unexpectedly empty, check your current directory first.
 
 To install `clickhousectl` manually:
 
@@ -478,14 +481,15 @@ prints a shell-specific suggestion but does not modify the file itself.
 ### ClickHouse Is Not Reachable
 
 ```bash
+cd "${TOKENOMICS_DATA_HOME:-${XDG_DATA_HOME:-$HOME/.local/share}}/tokenomics-viewer"
 chctl local server list
 curl -fsS http://127.0.0.1:8123/ping
 ```
 
-Run both commands from the launch directory because local `clickhousectl`
-servers are directory-scoped. If port `8123` belongs to another service, either
-stop that service or run Tokenomics directly against another ClickHouse HTTP
-endpoint with `--clickhouse-url`.
+Run both commands from the Tokenomics data directory because local
+`clickhousectl` servers are directory-scoped. If port `8123` belongs to another
+service, either stop that service or run Tokenomics directly against another
+ClickHouse HTTP endpoint with `--clickhouse-url`.
 
 ### The Dashboard Port Is Busy
 

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -62,11 +62,15 @@ ClickHouse is the default backend and is installed automatically when needed.
 `;
 }
 
-function launcherDataPath(env = process.env, home = Os.homedir()) {
+function launcherDataDirectory(env = process.env, home = Os.homedir()) {
   const base = env.TOKENOMICS_DATA_HOME
     || env.XDG_DATA_HOME
     || Path.join(home, ".local", "share");
-  return Path.join(base, "tokenomics-viewer", "tokenomics.sqlite");
+  return Path.join(base, "tokenomics-viewer");
+}
+
+function launcherDataPath(env = process.env, home = Os.homedir()) {
+  return Path.join(launcherDataDirectory(env, home), "tokenomics.sqlite");
 }
 
 
@@ -74,6 +78,7 @@ async function ensureClickHouse({
   healthCheck,
   findChctl,
   installChctl,
+  projectDirectory,
   runCommand,
   waitForHealth,
 }) {
@@ -85,17 +90,24 @@ async function ensureClickHouse({
   }
   if (!chctl) throw new Error("clickhousectl installation completed but chctl was not found in PATH or ~/.local/bin");
 
-  await runCommand(chctl, ["local", "use", "stable"]);
+  const commandOptions = projectDirectory ? { cwd: projectDirectory } : undefined;
+  if (projectDirectory) await fsp.mkdir(projectDirectory, { recursive: true });
+
+  await runCommand(chctl, ["local", "use", "stable"], commandOptions);
   try {
     await runCommand(chctl, [
       "local", "server", "start",
       "--name", "tokenomics",
       "--http-port", "8123",
       "--tcp-port", "9000",
-    ]);
+    ], commandOptions);
   } catch (createError) {
     try {
-      await runCommand(chctl, ["local", "server", "start", "--name", "tokenomics"]);
+      await runCommand(
+        chctl,
+        ["local", "server", "start", "--name", "tokenomics"],
+        commandOptions,
+      );
     } catch {
       throw createError;
     }
@@ -306,8 +318,9 @@ async function openBrowserSafely(runtime, url, noOpen) {
 
 function defaultRuntime() {
   const clickhouseHealth = () => httpOk(`${CLICKHOUSE_URL}/ping`);
+  const dataDirectory = launcherDataDirectory();
   return {
-    sqliteDb: launcherDataPath(),
+    sqliteDb: Path.join(dataDirectory, "tokenomics.sqlite"),
     log: console.log,
     dashboardReady,
     triggerSync,
@@ -315,6 +328,7 @@ function defaultRuntime() {
       healthCheck: clickhouseHealth,
       findChctl: async () => await findExecutable("chctl") || await findExecutable("clickhousectl"),
       installChctl,
+      projectDirectory: dataDirectory,
       runCommand,
       waitForHealth: () => waitUntil(clickhouseHealth, { timeoutMs: 120_000, label: "ClickHouse" }),
     }),
@@ -373,6 +387,7 @@ module.exports = {
   ensureClickHouse,
   findExecutable,
   launcherAppArgs,
+  launcherDataDirectory,
   launcherDataPath,
   launcherHelpText,
   parseLauncherArgs,

--- a/mac/.gitignore
+++ b/mac/.gitignore
@@ -2,3 +2,4 @@
 .swiftpm/
 DerivedData/
 TokenomicsMenubar.app/
+dist/

--- a/mac/Info.plist
+++ b/mac/Info.plist
@@ -12,6 +12,10 @@
 	<string>TokenomicsMenubar</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.0.1</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>LSMinimumSystemVersion</key>

--- a/mac/README.md
+++ b/mac/README.md
@@ -25,6 +25,28 @@ cd mac
 swift run TokenomicsMenubar
 ```
 
+`swift run` is useful for UI development, but launch-at-login requires a signed
+application bundle. Build an ad-hoc signed development bundle and run all Swift
+tests with one command from the repository root:
+
+```sh
+./mac/build-app.sh
+open mac/dist/Tokenomics.app
+```
+
+The app's **Settings → Startup** section uses macOS `SMAppService.mainApp` and
+stays in sync with **System Settings → General → Login Items**. If macOS requires
+approval, the settings view links to that system panel.
+
+For a release build, provide a Developer ID identity. The script enables the
+hardened runtime and timestamp for non-ad-hoc signatures; notarization remains
+a separate release step.
+
+```sh
+TOKENOMICS_CODESIGN_IDENTITY="Developer ID Application: Example (TEAMID)" \
+  ./mac/build-app.sh
+```
+
 Run the Swift checks from `mac/`:
 
 ```sh

--- a/mac/Sources/TokenomicsMenubar/LoginItemController.swift
+++ b/mac/Sources/TokenomicsMenubar/LoginItemController.swift
@@ -1,0 +1,111 @@
+import Combine
+import Foundation
+import ServiceManagement
+
+public enum LoginItemRegistrationStatus: Equatable, Sendable {
+    case notRegistered
+    case enabled
+    case requiresApproval
+    case unavailable
+}
+
+@MainActor
+protocol LoginItemServicing: AnyObject {
+    var status: LoginItemRegistrationStatus { get }
+    func register() throws
+    func unregister() throws
+}
+
+@MainActor
+private final class MainAppLoginItemService: LoginItemServicing {
+    private let service = SMAppService.mainApp
+
+    var status: LoginItemRegistrationStatus {
+        switch service.status {
+        case .notRegistered:
+            return .notRegistered
+        case .enabled:
+            return .enabled
+        case .requiresApproval:
+            return .requiresApproval
+        case .notFound:
+            return .unavailable
+        @unknown default:
+            return .unavailable
+        }
+    }
+
+    func register() throws {
+        try service.register()
+    }
+
+    func unregister() throws {
+        try service.unregister()
+    }
+}
+
+@MainActor
+public final class LoginItemController: ObservableObject {
+    @Published public private(set) var status: LoginItemRegistrationStatus
+    @Published public private(set) var lastErrorMessage: String?
+
+    public var isEnabled: Bool { status == .enabled }
+    public var canChangeRegistration: Bool {
+        status != .requiresApproval && status != .unavailable
+    }
+
+    private let service: LoginItemServicing
+    private let openSettingsHandler: () -> Void
+
+    public convenience init() {
+        self.init(
+            service: MainAppLoginItemService(),
+            openSettings: { SMAppService.openSystemSettingsLoginItems() }
+        )
+    }
+
+    init(
+        service: LoginItemServicing,
+        openSettings: @escaping () -> Void = { SMAppService.openSystemSettingsLoginItems() }
+    ) {
+        self.service = service
+        openSettingsHandler = openSettings
+        status = service.status
+    }
+
+    public func refresh() {
+        status = service.status
+        if status == .enabled || status == .notRegistered {
+            lastErrorMessage = nil
+        }
+    }
+
+    public func setEnabled(_ enabled: Bool) {
+        lastErrorMessage = nil
+
+        if enabled && status == .requiresApproval {
+            openSystemSettings()
+            return
+        }
+        if status == .unavailable {
+            lastErrorMessage = "Launch at login is available from the packaged Tokenomics.app."
+            return
+        }
+        if enabled == isEnabled { return }
+
+        do {
+            if enabled {
+                try service.register()
+            } else {
+                try service.unregister()
+            }
+        } catch {
+            lastErrorMessage = error.localizedDescription
+        }
+        status = service.status
+    }
+
+    public func openSystemSettings() {
+        openSettingsHandler()
+    }
+}

--- a/mac/Sources/TokenomicsMenubar/SettingsWindowController.swift
+++ b/mac/Sources/TokenomicsMenubar/SettingsWindowController.swift
@@ -3,8 +3,13 @@ import SwiftUI
 
 @MainActor
 public final class SettingsWindowController: NSWindowController {
-    public init(preferences: PreferencesStore) {
-        let contentSize = NSSize(width: 460, height: 440)
+    static let defaultContentSize = NSSize(width: 460, height: 440)
+
+    public init(
+        preferences: PreferencesStore,
+        loginItemController: LoginItemController = LoginItemController()
+    ) {
+        let contentSize = Self.defaultContentSize
         let window = NSWindow(
             contentRect: NSRect(origin: .zero, size: contentSize),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
@@ -12,7 +17,10 @@ public final class SettingsWindowController: NSWindowController {
             defer: false
         )
         let hostingController = NSHostingController(
-            rootView: SettingsView(preferences: preferences) { [weak window] in
+            rootView: SettingsView(
+                preferences: preferences,
+                loginItemController: loginItemController
+            ) { [weak window] in
                 window?.close()
             }
         )

--- a/mac/Sources/TokenomicsMenubar/TokenomicsMenubarApp.swift
+++ b/mac/Sources/TokenomicsMenubar/TokenomicsMenubarApp.swift
@@ -3,8 +3,22 @@ import SwiftUI
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
+    private let activationPolicyHandler: (NSApplication.ActivationPolicy) -> Void
+
+    override init() {
+        activationPolicyHandler = { policy in
+            _ = NSApp.setActivationPolicy(policy)
+        }
+        super.init()
+    }
+
+    init(activationPolicyHandler: @escaping (NSApplication.ActivationPolicy) -> Void) {
+        self.activationPolicyHandler = activationPolicyHandler
+        super.init()
+    }
+
     func applicationWillFinishLaunching(_ notification: Notification) {
-        NSApp.setActivationPolicy(.accessory)
+        activationPolicyHandler(.accessory)
     }
 }
 

--- a/mac/Sources/TokenomicsMenubar/Views.swift
+++ b/mac/Sources/TokenomicsMenubar/Views.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Charts
+import Combine
 import SwiftUI
 
 enum BudgetUsageLevel: Equatable {
@@ -750,13 +751,19 @@ private struct DailyUsageChart: View {
 
 public struct SettingsView: View {
     @ObservedObject var preferences: PreferencesStore
+    @ObservedObject private var loginItemController: LoginItemController
     private let onApply: () -> Void
     @State private var portText: String
     @State private var launcherPathText: String
     @State private var intervalText: String
 
-    public init(preferences: PreferencesStore, onApply: @escaping () -> Void = {}) {
+    public init(
+        preferences: PreferencesStore,
+        loginItemController: LoginItemController,
+        onApply: @escaping () -> Void = {}
+    ) {
         self.preferences = preferences
+        _loginItemController = ObservedObject(wrappedValue: loginItemController)
         self.onApply = onApply
         _portText = State(initialValue: String(preferences.preferredPort))
         _launcherPathText = State(initialValue: preferences.launcherPath)
@@ -795,6 +802,38 @@ public struct SettingsView: View {
                     }
                 }
             }
+            Section("Startup") {
+                Toggle(
+                    "Launch Tokenomics at login",
+                    isOn: Binding(
+                        get: { loginItemController.isEnabled },
+                        set: { loginItemController.setEnabled($0) }
+                    )
+                )
+                .disabled(!loginItemController.canChangeRegistration)
+
+                switch loginItemController.status {
+                case .requiresApproval:
+                    Text("macOS requires approval before Tokenomics can launch at login.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Button("Open Login Items…") {
+                        loginItemController.openSystemSettings()
+                    }
+                case .unavailable:
+                    Text("Build and open Tokenomics.app to configure launch at login.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                case .notRegistered, .enabled:
+                    EmptyView()
+                }
+
+                if let error = loginItemController.lastErrorMessage {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
             HStack {
                 Spacer()
                 Button("Apply") {
@@ -811,6 +850,10 @@ public struct SettingsView: View {
         .formStyle(.grouped)
         .padding(12)
         .frame(width: 460)
+        .onAppear { loginItemController.refresh() }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            loginItemController.refresh()
+        }
     }
 
     private func chooseLauncher() {

--- a/mac/Tests/TokenomicsMenubarTests/TokenomicsMenubarTests.swift
+++ b/mac/Tests/TokenomicsMenubarTests/TokenomicsMenubarTests.swift
@@ -35,6 +35,67 @@ final class BudgetUsageLevelTests: XCTestCase {
     }
 }
 
+@MainActor
+final class LoginItemControllerTests: XCTestCase {
+    func testRegistersAndUnregistersTheMainApp() {
+        let service = RecordingLoginItemService(status: .notRegistered)
+        let controller = LoginItemController(service: service)
+
+        controller.setEnabled(true)
+
+        XCTAssertEqual(service.registerCount, 1)
+        XCTAssertEqual(controller.status, .enabled)
+        XCTAssertTrue(controller.isEnabled)
+
+        controller.setEnabled(false)
+
+        XCTAssertEqual(service.unregisterCount, 1)
+        XCTAssertEqual(controller.status, .notRegistered)
+        XCTAssertFalse(controller.isEnabled)
+    }
+
+    func testRequiresApprovalOpensSystemSettingsWithoutReregistering() {
+        let service = RecordingLoginItemService(status: .requiresApproval)
+        var openSettingsCount = 0
+        let controller = LoginItemController(
+            service: service,
+            openSettings: { openSettingsCount += 1 }
+        )
+
+        controller.setEnabled(true)
+
+        XCTAssertEqual(openSettingsCount, 1)
+        XCTAssertEqual(service.registerCount, 0)
+        XCTAssertFalse(controller.canChangeRegistration)
+    }
+
+    func testUnavailableServiceExplainsThatAnAppBundleIsRequired() {
+        let service = RecordingLoginItemService(status: .unavailable)
+        let controller = LoginItemController(service: service)
+
+        controller.setEnabled(true)
+
+        XCTAssertEqual(service.registerCount, 0)
+        XCTAssertEqual(
+            controller.lastErrorMessage,
+            "Launch at login is available from the packaged Tokenomics.app."
+        )
+    }
+
+    func testRegistrationFailureIsSurfacedAndKeepsTheObservedStatus() {
+        let service = RecordingLoginItemService(
+            status: .notRegistered,
+            registrationError: LoginItemTestError.registrationFailed
+        )
+        let controller = LoginItemController(service: service)
+
+        controller.setEnabled(true)
+
+        XCTAssertEqual(controller.status, .notRegistered)
+        XCTAssertEqual(controller.lastErrorMessage, "Registration failed")
+    }
+}
+
 final class QuotaPresentationTests: XCTestCase {
     func testQuotaLabelsAndCountdownUseInjectedClock() {
         let now = ISO8601DateFormatter().date(from: "2026-08-03T12:00:00Z")!
@@ -76,20 +137,19 @@ final class QuotaPresentationTests: XCTestCase {
 
 @MainActor
 final class SettingsWindowControllerTests: XCTestCase {
-    func testAppUsesAnActivatableAccessoryPolicy() {
-        let app = NSApplication.shared
-        let originalPolicy = app.activationPolicy()
-        defer { app.setActivationPolicy(originalPolicy) }
+    func testAppRequestsAnActivatableAccessoryPolicy() {
+        var requestedPolicies: [NSApplication.ActivationPolicy] = []
+        AppDelegate(activationPolicyHandler: { requestedPolicies.append($0) })
+            .applicationWillFinishLaunching(
+                Notification(name: NSApplication.willFinishLaunchingNotification)
+            )
 
-        AppDelegate().applicationWillFinishLaunching(
-            Notification(name: NSApplication.willFinishLaunchingNotification, object: app)
-        )
-
-        XCTAssertEqual(app.activationPolicy(), .accessory)
+        XCTAssertEqual(requestedPolicies, [.accessory])
     }
 
     func testPresentDismissesTransientWindowAndShowsFullSettingsWindow() async {
         _ = NSApplication.shared
+        let canValidateWindowGeometry = NSApp.isRunning
         let suiteName = "TokenomicsMenubarTests.settings-window"
         let suite = UserDefaults(suiteName: suiteName)!
         suite.removePersistentDomain(forName: suiteName)
@@ -110,7 +170,10 @@ final class SettingsWindowControllerTests: XCTestCase {
         XCTAssertFalse(transientWindow.isVisible)
         XCTAssertTrue(controller.window?.isVisible == true)
         XCTAssertEqual(controller.window?.title, "Settings")
-        XCTAssertEqual(controller.window?.contentLayoutRect.size, NSSize(width: 460, height: 440))
+        XCTAssertEqual(SettingsWindowController.defaultContentSize, NSSize(width: 460, height: 440))
+        if canValidateWindowGeometry {
+            XCTAssertEqual(controller.window?.contentLayoutRect.size, SettingsWindowController.defaultContentSize)
+        }
 
         controller.close()
         transientWindow.close()
@@ -1106,6 +1169,36 @@ private final class FailingLauncher: TokenomicsLauncher {
     func start(executablePath: String, port: Int, timeout: Duration) async throws -> any TokenomicsProcessHandle {
         throw LauncherError.executableNotFound
     }
+}
+
+@MainActor
+private final class RecordingLoginItemService: LoginItemServicing {
+    var status: LoginItemRegistrationStatus
+    private let registrationError: Error?
+    private(set) var registerCount = 0
+    private(set) var unregisterCount = 0
+
+    init(status: LoginItemRegistrationStatus, registrationError: Error? = nil) {
+        self.status = status
+        self.registrationError = registrationError
+    }
+
+    func register() throws {
+        registerCount += 1
+        if let registrationError { throw registrationError }
+        status = .enabled
+    }
+
+    func unregister() throws {
+        unregisterCount += 1
+        status = .notRegistered
+    }
+}
+
+private enum LoginItemTestError: LocalizedError {
+    case registrationFailed
+
+    var errorDescription: String? { "Registration failed" }
 }
 
 private func ISODate(_ value: String) -> Date {

--- a/mac/build-app.sh
+++ b/mac/build-app.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+set -euo pipefail
+
+script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+output_dir="${TOKENOMICS_APP_OUTPUT_DIR:-$script_dir/dist}"
+signing_identity="${TOKENOMICS_CODESIGN_IDENTITY:--}"
+run_tests=1
+
+if [[ -z "${DEVELOPER_DIR:-}" && -d /Applications/Xcode.app/Contents/Developer ]]; then
+    export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+fi
+
+build_cache_dir="$script_dir/.build/tokenomics-cache"
+export XDG_CACHE_HOME="$build_cache_dir/xdg"
+export CLANG_MODULE_CACHE_PATH="$build_cache_dir/clang-module-cache"
+export SWIFTPM_MODULECACHE_OVERRIDE="$build_cache_dir/swift-module-cache"
+swiftpm_cache_dir="$build_cache_dir/swiftpm-cache"
+swiftpm_config_dir="$build_cache_dir/swiftpm-config"
+swiftpm_security_dir="$build_cache_dir/swiftpm-security"
+mkdir -p \
+    "$XDG_CACHE_HOME" \
+    "$CLANG_MODULE_CACHE_PATH" \
+    "$SWIFTPM_MODULECACHE_OVERRIDE" \
+    "$swiftpm_cache_dir" \
+    "$swiftpm_config_dir" \
+    "$swiftpm_security_dir"
+
+swift_package_options=(
+    --disable-sandbox
+    --cache-path "$swiftpm_cache_dir"
+    --config-path "$swiftpm_config_dir"
+    --security-path "$swiftpm_security_dir"
+    --scratch-path "$script_dir/.build"
+)
+
+usage() {
+    echo "Usage: $0 [--skip-tests] [--output DIR] [--sign IDENTITY]"
+    echo
+    echo "Builds and verifies Tokenomics.app. Tests run by default."
+    echo "The default signing identity is '-' (ad-hoc, for local development)."
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --skip-tests)
+            run_tests=0
+            shift
+            ;;
+        --output)
+            [[ $# -ge 2 ]] || { echo "--output requires a directory" >&2; exit 2; }
+            output_dir="$2"
+            shift 2
+            ;;
+        --sign)
+            [[ $# -ge 2 ]] || { echo "--sign requires an identity" >&2; exit 2; }
+            signing_identity="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+[[ -n "$output_dir" && "$output_dir" != "/" ]] || {
+    echo "Refusing unsafe output directory: $output_dir" >&2
+    exit 2
+}
+
+command -v xcrun >/dev/null || { echo "xcrun is required" >&2; exit 1; }
+command -v codesign >/dev/null || { echo "codesign is required" >&2; exit 1; }
+command -v plutil >/dev/null || { echo "plutil is required" >&2; exit 1; }
+
+if [[ $run_tests -eq 1 ]]; then
+    echo "==> Running Swift tests"
+    (
+        cd "$script_dir"
+        xcrun swift test "${swift_package_options[@]}" -Xswiftc -warnings-as-errors
+    )
+fi
+
+echo "==> Building release executable"
+(
+    cd "$script_dir"
+    xcrun swift build -c release "${swift_package_options[@]}" -Xswiftc -warnings-as-errors
+)
+bin_dir="$(cd "$script_dir" && xcrun swift build -c release "${swift_package_options[@]}" --show-bin-path)"
+executable="$bin_dir/TokenomicsMenubar"
+[[ -x "$executable" ]] || { echo "Missing release executable: $executable" >&2; exit 1; }
+
+mkdir -p "$output_dir"
+staging_dir="$(mktemp -d "$output_dir/.Tokenomics.app.XXXXXX")"
+cleanup() {
+    [[ ! -d "$staging_dir" ]] || rm -rf -- "$staging_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$staging_dir/Contents/MacOS"
+install -m 0755 "$executable" "$staging_dir/Contents/MacOS/TokenomicsMenubar"
+install -m 0644 "$script_dir/Info.plist" "$staging_dir/Contents/Info.plist"
+plutil -lint "$staging_dir/Contents/Info.plist"
+
+echo "==> Signing app bundle with: $signing_identity"
+if [[ "$signing_identity" == "-" ]]; then
+    codesign --force --sign - "$staging_dir"
+else
+    codesign --force --options runtime --timestamp --sign "$signing_identity" "$staging_dir"
+fi
+codesign --verify --deep --strict --verbose=2 "$staging_dir"
+
+app_path="$output_dir/Tokenomics.app"
+rm -rf -- "$app_path"
+mv "$staging_dir" "$app_path"
+trap - EXIT
+
+bundle_identifier="$(plutil -extract CFBundleIdentifier raw -o - "$app_path/Contents/Info.plist")"
+[[ "$bundle_identifier" == "com.tokenomics.viewer.menubar" ]] || {
+    echo "Unexpected bundle identifier: $bundle_identifier" >&2
+    exit 1
+}
+
+echo "==> Built and verified $app_path"

--- a/test/launcher.test.js
+++ b/test/launcher.test.js
@@ -11,6 +11,7 @@ const {
   ensureClickHouse,
   findExecutable,
   launcherAppArgs,
+  launcherDataDirectory,
   launcherDataPath,
   parseLauncherArgs,
   runLauncher,
@@ -154,6 +155,32 @@ test("ClickHouse setup retries an existing named server without redefining ports
   assert.deepEqual(calls.at(-1), ["wait"]);
 });
 
+test("ClickHouse setup uses a stable writable project directory", async (t) => {
+  const temporary = await fs.mkdtemp(Path.join(Os.tmpdir(), "tokenomics-clickhouse-project-"));
+  t.after(() => fs.rm(temporary, { recursive: true, force: true }));
+  const projectDirectory = Path.join(temporary, "data", "tokenomics-viewer");
+  const calls = [];
+  let startCalls = 0;
+
+  await ensureClickHouse({
+    healthCheck: async () => false,
+    findChctl: async () => "/bin/chctl",
+    installChctl: async () => { throw new Error("must not install"); },
+    projectDirectory,
+    runCommand: async (command, args, options) => {
+      calls.push({ command, args, options });
+      if (args.includes("--http-port") && ++startCalls === 1) {
+        throw new Error("server already exists");
+      }
+    },
+    waitForHealth: async () => {},
+  });
+
+  assert.equal((await fs.stat(projectDirectory)).isDirectory(), true);
+  assert.equal(calls.length, 3);
+  assert.ok(calls.every(({ options }) => options.cwd === projectDirectory));
+});
+
 test("launcher app arguments enforce sync and selected engine after user arguments", () => {
   assert.deepEqual(launcherAppArgs({
     engine: "clickhouse",
@@ -165,7 +192,11 @@ test("launcher app arguments enforce sync and selected engine after user argumen
   ]);
 });
 
-test("launcher stores SQLite data outside the application release", () => {
+test("launcher stores backend data outside the application release", () => {
+  assert.equal(
+    launcherDataDirectory({ TOKENOMICS_DATA_HOME: "/var/tokenomics-data" }, "/home/user"),
+    Path.join("/var/tokenomics-data", "tokenomics-viewer"),
+  );
   assert.equal(
     launcherDataPath({ TOKENOMICS_DATA_HOME: "/var/tokenomics-data" }, "/home/user"),
     Path.join("/var/tokenomics-data", "tokenomics-viewer", "tokenomics.sqlite"),


### PR DESCRIPTION
## Summary

- add a Settings → Startup toggle that registers or unregisters only the Tokenomics main app with SMAppService
- surface macOS approval and registration errors, with a direct link to Login Items settings
- keep managed `chctl` state in Tokenomics' persistent data directory so Finder and Login Items launches do not write through a read-only working directory
- add one command to test, build, package, sign, and verify Tokenomics.app
- use the same bundle-building command in macOS CI

## Testing

- `node --test` — 263/263 passed
- `./mac/build-app.sh` — 44/44 Swift tests passed; release build and ad-hoc signature verification passed
- production launcher probe from `/System` — fake `chctl` observed the configured writable Tokenomics data directory
- generated macOS fixtures matched the checked-in contract
- JavaScript and Bash syntax, git diff, staged-secret, and artifact checks passed

## Residual risk

- An actual login-cycle smoke was not run because registering the item would persistently change the local Login Items state.
- Existing stopped `chctl` servers created under another project directory are not migrated automatically; Tokenomics will create and sync its stable project-scoped server instead.
- The default development bundle uses an ad-hoc signature; Developer ID signing and notarization remain release steps.

🕵️‍♂️
