### PR TITLE
Make ClickHouse sync append-incremental and refresh pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,10 @@ When running from a source checkout, replace `tokenomics-launch` with
 ## ClickHouse
 
 ClickHouse is the default and recommended database. The launcher normally
-installs and manages it, so manual setup is not required.
+installs and manages it, so manual setup is not required. The dashboard starts
+listening before the automatic sync finishes; `/api/sync` and the UI expose the
+running, succeeded, or failed state while synchronization continues in the
+background.
 
 The local defaults are:
 
@@ -195,6 +198,11 @@ Credentials can also be supplied through `TOKENOMICS_CLICKHOUSE_USER` and
 `TOKENOMICS_CLICKHOUSE_URL` and `TOKENOMICS_CLICKHOUSE_DATABASE` variables.
 Prefer environment variables to command-line passwords so credentials do not
 appear in shell history or process listings.
+
+Webserver mode binds its HTTP endpoint before the initial sync begins and serves
+a valid snapshot while `/api/sync` reports progress. Later syncs keep the last
+completed statistics readable; pass `--no-sync` to serve the current database
+without starting an automatic scan.
 
 ### Batching, Compression, and Reset
 
@@ -257,20 +265,48 @@ future source proves a session-level model. Grok records retain the model and
 project from `summary.json`, plus `contextTokensUsed` and
 `contextWindowTokens` snapshots from `signals.json` when present.
 
-Sync is incremental by source fingerprint. Unchanged sessions are skipped;
-changed files or archive entries replace their previous normalized data. Codex
-fork metadata and replay traces are used to avoid counting inherited parent
-history again in subagent sessions.
+Sync is incremental by source fingerprint. Unchanged sessions are skipped.
+Plain append-only Codex and Claude Code JSONL files resume after the last
+complete newline, using a ClickHouse-stored byte cursor and resumable parser
+checkpoint; an incomplete trailing record waits for the next sync. The cursor
+binds the device/inode, a tail hash, and bounded prefix samples. Truncation,
+rotation, a changed guard, Codex fork/replay input, or an unsafe parser
+checkpoint falls back to a new full source epoch. The bounded guard deliberately
+trusts the append-only producer contract: hashing every byte on every sync would
+make a tiny append proportional to the lifetime of the file, and an in-place
+rewrite outside the sampled windows can therefore require a manual reset.
+
+Claude Code checkpoints retain only a bounded recent request-ID window. The
+durable ClickHouse event key (request ID when present, otherwise the global
+source line) remains the exact cross-append and retry deduplication authority,
+so an old duplicate does not force the checkpoint or parser memory to grow with
+the session. Compressed files, archive entries, and other adapters replace their
+previous normalized data. Codex fork metadata and replay traces avoid counting
+inherited parent history again in subagent sessions.
 
 All calendar buckets and range boundaries use UTC: day, ISO week, month, year,
 and the existing 15-minute timeline. A version upgrade that changes a derived
 field such as UTC calendar keys or service tier causes one full source reimport;
 later syncs return to normal fingerprint-based incrementality.
 
-ClickHouse source versions are immutable. A sync stages changed sources and a
-complete source manifest, then publishes one global generation marker last.
-Reports pin that generation, so a failed multi-source sync leaves the previous
-complete report visible instead of exposing a partial import.
+Each append-only ClickHouse source keeps one immutable epoch ID while new
+normalized rows are added only for the newly completed byte range. A rewrite
+starts a new epoch. A sync writes manifest deltas only for changed or removed
+sources. Every 128 delta generations it writes a metadata-only checkpoint of
+the current source heads, bounding later manifest reconstruction without
+rereading or reinserting session events. Deltas live in a time-ordered table,
+and reports constrain that primary-key range to post-checkpoint generations.
+Each checkpoint records its base generation; a checkpoint crossed by a
+concurrent commit is ignored while its changed-source delta remains available.
+The sync then publishes one global generation marker last. Reports reconstruct
+and pin both
+the active epoch and its committed byte offset at that marker,
+deduplicate idempotent retries by logical event key, and replace provisional
+open-turn metrics by turn key. A failed sync can leave recoverable staged rows,
+but they remain past the committed offset and therefore cannot advance either
+the report or the next parser cursor. Physical storage grows with newly observed
+events (plus failed staging retries and orphaned epochs after rewrites), not with
+repeated copies of the entire session or source manifest.
 
 Pricing revisions are deliberately excluded from source fingerprints. Editing
 a rate or adding a model updates normalized database costs without reopening
@@ -401,8 +437,10 @@ necessarily a user request or completed task, and tariff coverage means only
 that the local catalog recognized an event. Without outcome or quality data,
 Tokenomics does not rank effort levels as objectively better or worse.
 
-GPT-5.6 Sol, Terra, and Luna support separate input, cache-write, cache-read, and
-output rates. Legacy Codex `input_tokens` plus `cached_input_tokens` records are
+GPT-6 Astra and GPT-5.6 Sol, Terra, and Luna support separate input,
+cache-write, cache-read, and output rates. Packaged GPT-5.6 Sol prices preserve
+the pre-August 21, 2026 tariff and apply the reduced rate from that date.
+Legacy Codex `input_tokens` plus `cached_input_tokens` records are
 treated as total input with cached input as a read subset. Explicit
 `cache_creation_input_tokens` plus `cache_read_input_tokens` records preserve
 cache writes separately. Tokenomics does not invent cache-write volume for
@@ -410,8 +448,8 @@ legacy records that cannot prove it.
 
 For standard pricing, Codex `thread_settings_applied.service_tier=priority`
 applies the documented ChatGPT fast-mode credit multipliers: `2.5x` for
-GPT-5.6 and GPT-5.5, and `2x` for GPT-5.4
-([official fast-mode documentation](https://developers.openai.com/codex/speed)).
+GPT-6 Astra, GPT-5.6, and GPT-5.5, and `2x` for GPT-5.4
+([official fast-mode documentation](https://learn.chatgpt.com/docs/agent-configuration/speed)).
 This is deliberately separate from API Priority processing. Missing or unknown
 tiers remain standard-priced instead of silently assuming fast mode. In
 particular, a forked child rollout that omits its own service tier does not

--- a/app.js
+++ b/app.js
@@ -65,11 +65,7 @@ async function main(argv = process.argv.slice(2)) {
     return options;
   }
   if (options.webserver) {
-    let preloadedReport = null;
-    if (options.webserverSync) {
-      preloadedReport = await storage.syncDatabase(options);
-    }
-    const server = await web.startWebServer({ ...options, preloadedReport });
+    const server = await web.startWebServer(options);
     const address = server.address();
     const host = address.address === "::" ? "localhost" : address.address;
     reportText.logProgress(options, `[webserver] http://${host}:${address.port}`);

--- a/lib/core/aggregate.js
+++ b/lib/core/aggregate.js
@@ -73,6 +73,7 @@ function addUsage(report, record, options) {
   const event = {
     sourcePath: record.sourcePath || null,
     lineNo: Number.isFinite(record.lineNo) ? record.lineNo : null,
+    requestId: typeof record.requestId === "string" ? record.requestId : null,
     timestamp: isValidDate(timestamp) ? timestamp.toISOString() : null,
     provider,
     model,

--- a/lib/core/configuration.js
+++ b/lib/core/configuration.js
@@ -3,7 +3,7 @@
 const { createHash } = require("node:crypto");
 const { PRICING, PRICING_SOURCES } = require("./pricing");
 
-const PACKAGED_CONFIGURATION_REVISION = "packaged-4";
+const PACKAGED_CONFIGURATION_REVISION = "packaged-5";
 const ALLOWED_SETTINGS = new Set(["openaiContext", "pricingBasis", "pricingRevision", "regionalMultiplier", "monthlyCostLimitUsd", "usageProfile"]);
 const ALLOWED_MATCH_MODES = new Set(["snapshot", "prefix", "exact"]);
 const ALLOWED_VARIANTS = new Set(["standard", "short", "long"]);
@@ -18,6 +18,8 @@ const LEGACY_PACKAGED_3_CATALOG_SIGNATURE = "35dc489b59c5c2075f4e995081f3f110505
 const LEGACY_PACKAGED_3_CLICKHOUSE_CATALOG_SIGNATURE = "74902efdcc89bc1aece721d1e99eee36a2791aa023f1f33cadf15ac5753f8e8d";
 const PACKAGED_4_CATALOG_SIGNATURE = "90161eead388329f274372c80e38da02a5c9f35ba53bf1e8bfc37e4dd79a078a";
 const PACKAGED_4_CLICKHOUSE_CATALOG_SIGNATURE = "363f3a993b26f3680bf0842577c14e93efbf76726ea9130eb75eba5ecdf483ef";
+const PACKAGED_5_CATALOG_SIGNATURE = "5ec7d98e245ec35398a75660e43bc634a051fbd91f356c141f6fd59a371695ba";
+const PACKAGED_5_CLICKHOUSE_CATALOG_SIGNATURE = "4015c4a91a133a023f8c057b9d4f512632d3a00d30d4c63de522a92366e0e4cd";
 
 function pricingRowId(row) {
   return [
@@ -67,6 +69,8 @@ function rowFromPrices(provider, model, variant, prices, extra = {}) {
     cacheRead: provider === "openai" ? (prices.cachedInput ?? null) : (prices.cacheRead ?? null),
     output: prices.output,
     sourceUrl: provider === "openai" && model === "codex-auto-review" ? ""
+             : provider === "openai" && model === "gpt-6-astra" ? PRICING_SOURCES.openaiGpt6Astra
+             : provider === "openai" && model === "gpt-5.6-sol" ? PRICING_SOURCES.openaiGpt56
              : provider === "openai" ? PRICING_SOURCES.openai
              : provider === "omp" ? PRICING_SOURCES.omp
              : PRICING_SOURCES.anthropic,
@@ -277,6 +281,9 @@ function packagedPricingCatalogRevision(sourceRows) {
   }
   if (signature === PACKAGED_4_CATALOG_SIGNATURE || signature === PACKAGED_4_CLICKHOUSE_CATALOG_SIGNATURE) {
     return "packaged-4";
+  }
+  if (signature === PACKAGED_5_CATALOG_SIGNATURE || signature === PACKAGED_5_CLICKHOUSE_CATALOG_SIGNATURE) {
+    return "packaged-5";
   }
   return "";
 }

--- a/lib/core/pricing.js
+++ b/lib/core/pricing.js
@@ -15,6 +15,7 @@ const UNKNOWN_SERVICE_TIER = "unknown";
 // ChatGPT Codex fast-mode credit multipliers. These are intentionally kept
 // separate from API Priority processing, which has different rates.
 const OPENAI_FAST_MULTIPLIERS = {
+  "gpt-6-astra": 2.5,
   "gpt-5.5": 2.5,
   "gpt-5.6-sol": 2.5,
   "gpt-5.6-terra": 2.5,
@@ -31,11 +32,12 @@ const ANTHROPIC_FAST_MULTIPLIERS = {
 
 const PRICING_SOURCES = {
   openai: "https://developers.openai.com/api/docs/pricing",
+  openaiGpt6Astra: "https://developers.openai.com/api/docs/models/gpt-6-astra",
   openaiGpt56: "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
   openaiGpt5: "https://developers.openai.com/api/docs/models/gpt-5",
   openaiGpt51: "https://developers.openai.com/api/docs/models/gpt-5.1",
   openaiCodex: "https://developers.openai.com/api/docs/models/gpt-5-codex",
-  openaiCodexFast: "https://developers.openai.com/codex/speed",
+  openaiCodexFast: "https://learn.chatgpt.com/docs/agent-configuration/speed",
   openaiCodexMini: "https://developers.openai.com/api/docs/models/codex-mini-latest",
   anthropic: "https://docs.anthropic.com/en/docs/about-claude/pricing",
   anthropicFast: "https://code.claude.com/docs/en/fast-mode",
@@ -46,14 +48,30 @@ const PRICING_SOURCES = {
 const PRICING = {
   openai: {
     models: {
+      "gpt-6-astra": {
+        short: { input: 10.00, cacheCreate30m: 12.50, cachedInput: 1.00, output: 50.00 },
+        long: { input: 20.00, cacheCreate30m: 25.00, cachedInput: 2.00, output: 75.00 },
+      },
       "gpt-5.5": {
         short: { input: 5.00, cachedInput: 0.50, output: 30.00 },
         long: { input: 10.00, cachedInput: 1.00, output: 45.00 },
       },
-      "gpt-5.6-sol": {
-        short: { input: 5.00, cacheCreate30m: 6.25, cachedInput: 0.50, output: 30.00 },
-        long: { input: 10.00, cacheCreate30m: 12.50, cachedInput: 1.00, output: 45.00 },
-      },
+      "gpt-5.6-sol": [
+        {
+          until: "2026-08-20T23:59:59.999Z",
+          prices: {
+            short: { input: 5.00, cacheCreate30m: 6.25, cachedInput: 0.50, output: 30.00 },
+            long: { input: 10.00, cacheCreate30m: 12.50, cachedInput: 1.00, output: 45.00 },
+          },
+        },
+        {
+          from: "2026-08-21T00:00:00.000Z",
+          prices: {
+            short: { input: 4.00, cacheCreate30m: 5.00, cachedInput: 0.40, output: 20.00 },
+            long: { input: 8.00, cacheCreate30m: 10.00, cachedInput: 0.80, output: 30.00 },
+          },
+        },
+      ],
       "gpt-5.6-terra": [
         {
           until: "2026-07-29T23:59:59.999Z",

--- a/lib/core/report-model.js
+++ b/lib/core/report-model.js
@@ -295,6 +295,8 @@ function addOutputCharTokenMetric(report, record) {
   const event = {
     sourcePath: source.sourcePath || null,
     turnId: source.turnId || null,
+    turnKey: source.turnKey || null,
+    lineNo: Number.isFinite(source.lineNo) ? source.lineNo : null,
     timestamp: isValidDate(timestamp) ? timestamp.toISOString() : null,
     provider,
     model,

--- a/lib/ingest/append-cursor.js
+++ b/lib/ingest/append-cursor.js
@@ -1,0 +1,107 @@
+"use strict";
+
+const { createHash } = require("node:crypto");
+const fsp = require("node:fs/promises");
+
+const APPEND_CURSOR_VERSION = 2;
+const APPEND_GUARD_BYTES = 4 * 1024;
+const APPEND_PREFIX_SAMPLES = 4;
+const NEWLINE_SCAN_BYTES = 64 * 1024;
+
+async function readRange(filename, start, length) {
+  if (length <= 0) return Buffer.alloc(0);
+  const handle = await fsp.open(filename, "r");
+  try {
+    const buffer = Buffer.allocUnsafe(length);
+    const { bytesRead } = await handle.read(buffer, 0, length, start);
+    return buffer.subarray(0, bytesRead);
+  } finally {
+    await handle.close();
+  }
+}
+
+async function lastCompleteJsonlOffset(filename, size) {
+  let end = Number(size) || 0;
+  while (end > 0) {
+    const start = Math.max(0, end - NEWLINE_SCAN_BYTES);
+    const buffer = await readRange(filename, start, end - start);
+    const newline = buffer.lastIndexOf(0x0a);
+    if (newline >= 0) return start + newline + 1;
+    end = start;
+  }
+  return 0;
+}
+
+async function appendGuard(filename, offset) {
+  const end = Number(offset) || 0;
+  const start = Math.max(0, end - APPEND_GUARD_BYTES);
+  const buffer = await readRange(filename, start, end - start);
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+async function appendPrefixGuard(filename, offset) {
+  const end = Number(offset) || 0;
+  const hash = createHash("sha256");
+  hash.update(String(end));
+  if (end <= 0) return hash.digest("hex");
+  const window = Math.min(APPEND_GUARD_BYTES, end);
+  const maxStart = Math.max(0, end - window);
+  const starts = new Set([0]);
+  for (let sample = 1; sample < APPEND_PREFIX_SAMPLES; sample += 1) {
+    starts.add(Math.floor(maxStart * sample / APPEND_PREFIX_SAMPLES));
+  }
+  for (const start of [...starts].sort((a, b) => a - b)) {
+    hash.update(String(start));
+    hash.update(await readRange(filename, start, window));
+  }
+  return hash.digest("hex");
+}
+
+async function inspectAppendFile(filename, suppliedStat = null) {
+  const stat = suppliedStat || await fsp.stat(filename);
+  const completeOffset = await lastCompleteJsonlOffset(filename, stat.size);
+  return {
+    version: APPEND_CURSOR_VERSION,
+    size: Number(stat.size),
+    mtimeMs: Number(stat.mtimeMs),
+    device: String(stat.dev),
+    inode: String(stat.ino),
+    completeOffset,
+    guard: await appendGuard(filename, completeOffset),
+    prefixGuard: await appendPrefixGuard(filename, completeOffset),
+  };
+}
+
+async function validateAppendCursor(filename, previous, current) {
+  if (
+    !previous ||
+    Number(previous.cursor_version) !== APPEND_CURSOR_VERSION ||
+    !previous.parser_checkpoint ||
+    !previous.cursor_prefix_guard ||
+    String(previous.file_device) !== current.device ||
+    String(previous.file_inode) !== current.inode
+  ) {
+    return { mode: "full", reason: "missing-or-incompatible-cursor" };
+  }
+
+  const cursorOffset = Number(previous.segment_end);
+  if (!Number.isSafeInteger(cursorOffset) || cursorOffset < 0 || current.completeOffset < cursorOffset) {
+    return { mode: "full", reason: "truncated" };
+  }
+  const guard = await appendGuard(filename, cursorOffset);
+  if (guard !== previous.cursor_guard) return { mode: "full", reason: "guard-mismatch" };
+  const prefixGuard = await appendPrefixGuard(filename, cursorOffset);
+  if (prefixGuard !== previous.cursor_prefix_guard) return { mode: "full", reason: "prefix-guard-mismatch" };
+  if (current.completeOffset === cursorOffset) return { mode: "unchanged", reason: "no-complete-record" };
+  return { mode: "append", reason: "verified-append", start: cursorOffset, end: current.completeOffset };
+}
+
+module.exports = {
+  APPEND_CURSOR_VERSION,
+  APPEND_GUARD_BYTES,
+  appendGuard,
+  appendPrefixGuard,
+  inspectAppendFile,
+  lastCompleteJsonlOffset,
+  validateAppendCursor,
+};

--- a/lib/ingest/parser.js
+++ b/lib/ingest/parser.js
@@ -43,6 +43,74 @@ const {
 const { addRateLimitSnapshot } = require("../core/rate-limits");
 const { addTelemetrySnapshot } = require("../core/telemetry");
 
+const CODEX_PARSER_CHECKPOINT_VERSION = 1;
+// The durable ClickHouse event key (request ID or global source line) performs
+// exact cross-range and retry deduplication.
+// Keep only a bounded recent window here to suppress adjacent duplicates while
+// avoiding a checkpoint whose size grows with the lifetime of the session.
+const CLAUDE_REQUEST_CHECKPOINT_LIMIT = 1_024;
+
+function cloneCheckpointValue(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function restoreParserCheckpoint(checkpoint, sourceLabel) {
+  if (!checkpoint) return null;
+  const kind = checkpoint.kind || "codex";
+  if (checkpoint.version !== CODEX_PARSER_CHECKPOINT_VERSION) {
+    throw new Error(`Unsupported ${kind === "claude" ? "Claude" : "Codex"} parser checkpoint version: ${checkpoint.version}`);
+  }
+  if (checkpoint.sourceLabel !== sourceLabel) {
+    throw new Error(`${kind === "claude" ? "Claude" : "Codex"} parser checkpoint source mismatch: ${checkpoint.sourceLabel} != ${sourceLabel}`);
+  }
+  if (kind === "claude") {
+    if (
+      checkpoint.deduplication !== "clickhouse-event-key" ||
+      !Array.isArray(checkpoint.recentRequestIds) ||
+      checkpoint.recentRequestIds.length > CLAUDE_REQUEST_CHECKPOINT_LIMIT ||
+      checkpoint.recentRequestIds.some((id) => typeof id !== "string" || !id)
+    ) {
+      throw new Error("Claude parser checkpoint is not safe to resume");
+    }
+    return {
+      kind,
+      seenRequestIds: [...new Set(checkpoint.recentRequestIds)],
+    };
+  }
+  if (kind !== "codex") throw new Error(`Unsupported parser checkpoint kind: ${kind}`);
+  if (!checkpoint.sessionId || checkpoint.forkedFromId || checkpoint.skippingForkReplay) {
+    throw new Error("Codex parser checkpoint is not safe to resume");
+  }
+
+  const turn = checkpoint.turn ? cloneCheckpointValue(checkpoint.turn) : null;
+  if (turn) {
+    turn.timestamp = new Date(turn.timestamp);
+    turn.turnKey ||= turn.turnId ? `id:${turn.turnId}` : `line:${Number(turn.lastLineNo) || 0}`;
+    turn.lastLineNo = Number(turn.lastLineNo) || 0;
+  }
+  return {
+    kind,
+    sessionId: checkpoint.sessionId,
+    forkedFromId: null,
+    forkParentTraces: null,
+    forkReplayBoundaryTraces: null,
+    skippingForkReplay: false,
+    preScannedForkReplay: false,
+    preferLastTokenUsageAfterForkReplay: false,
+    project: checkpoint.project,
+    model: checkpoint.model,
+    provider: checkpoint.provider,
+    effort: checkpoint.effort,
+    serviceTier: checkpoint.serviceTier,
+    serviceMode: checkpoint.serviceMode,
+    totalUsage: cloneCheckpointValue(checkpoint.totalUsage),
+    visibleChars: cloneCheckpointValue(checkpoint.visibleChars),
+    assistantOutputChars: cloneCheckpointValue(checkpoint.assistantOutputChars),
+    turn,
+    hasCodexMetadata: true,
+  };
+}
+
 function createLineProcessor(report, options, sourceLabel, session = null) {
   const newAssistantOutputChars = () => ({
     responseItem: 0,
@@ -53,8 +121,10 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
   const preferredAssistantOutputChars = (chars) =>
     chars.responseItem > 0 ? chars.responseItem : chars.agentMessage;
 
-  const newTurn = (turnId, timestamp) => ({
+  const newTurn = (turnId, timestamp, lineNo) => ({
     turnId: turnId || null,
+    turnKey: turnId ? `id:${turnId}` : `line:${Number(lineNo) || 0}`,
+    lastLineNo: Number(lineNo) || 0,
     timestamp: isValidDate(timestamp) ? timestamp : new Date(NaN),
     project: UNKNOWN_PROJECT,
     model: UNKNOWN_MODEL,
@@ -68,7 +138,10 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
     hasOutputCharMetric: false,
     lastTokenUsageKey: null,
   });
-  const codexState = {
+  const parserCheckpoint = options.parserCheckpoint || options.codexParserCheckpoint;
+  const restoredCheckpoint = restoreParserCheckpoint(parserCheckpoint, sourceLabel);
+  const restoredCodexState = restoredCheckpoint?.kind === "codex" ? restoredCheckpoint : null;
+  const codexState = restoredCodexState || {
     sessionId: null,
     forkedFromId: null,
     forkParentTraces: null,
@@ -95,7 +168,11 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
     activeModel: null,
   };
 
-  const seenClaudeRequests = new Set();
+  const seenClaudeRequests = new Set(restoredCheckpoint?.kind === "claude" ? restoredCheckpoint.seenRequestIds : []);
+  let hasClaudeUsage = restoredCheckpoint?.kind === "claude";
+  if (restoredCodexState) {
+    report._rateLimitSequence = Number(parserCheckpoint.rateLimitSequence) || 0;
+  }
 
   const updateTurnMeta = () => {
     if (!codexState.turn) return;
@@ -118,6 +195,8 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
       event = addOutputCharTokenMetric(report, {
         sourcePath: session?.path || sourceLabel,
         turnId: turn.turnId,
+        turnKey: turn.turnKey,
+        lineNo: turn.lastLineNo,
         timestamp: turn.timestamp,
         provider: turn.provider,
         model: turn.model,
@@ -153,17 +232,19 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
     updateTurnMeta();
   };
 
-  const ensureTurn = (turnId, timestamp) => {
+  const ensureTurn = (turnId, timestamp, lineNo) => {
     const normalizedTurnId = turnId || null;
     const timestampValue = isValidDate(timestamp) ? timestamp : new Date(NaN);
     if (codexState.turn && normalizedTurnId && codexState.turn.turnId && normalizedTurnId !== codexState.turn.turnId) {
       flushTurn();
     }
     if (!codexState.turn) {
-      codexState.turn = newTurn(normalizedTurnId, timestampValue);
+      codexState.turn = newTurn(normalizedTurnId, timestampValue, lineNo);
     } else if (!codexState.turn.turnId && normalizedTurnId) {
       codexState.turn.turnId = normalizedTurnId;
+      codexState.turn.turnKey = `id:${normalizedTurnId}`;
     }
+    codexState.turn.lastLineNo = Math.max(Number(codexState.turn.lastLineNo) || 0, Number(lineNo) || 0);
     if (!isValidDate(codexState.turn.timestamp) && isValidDate(timestampValue)) {
       codexState.turn.timestamp = timestampValue;
     }
@@ -321,15 +402,15 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
     }
 
     if (json.type === "event_msg" && json.payload?.type === "task_started") {
-      ensureTurn(json.payload.turn_id || null, new Date(json.timestamp));
+      ensureTurn(json.payload.turn_id || null, new Date(json.timestamp), lineNo);
     } else if (json.type === "turn_context" && json.payload?.turn_id) {
-      ensureTurn(json.payload.turn_id, new Date(json.timestamp));
+      ensureTurn(json.payload.turn_id, new Date(json.timestamp), lineNo);
     }
 
     const assistantOutputTextChars = codexAssistantOutputTextChars(json);
     addCodexVisibleChars(codexState.visibleChars, json);
     if (assistantOutputTextChars > 0) {
-      ensureTurn(null, new Date(json.timestamp));
+      ensureTurn(null, new Date(json.timestamp), lineNo);
       const shape = json.type === "response_item" ? "responseItem" : "agentMessage";
       codexState.assistantOutputChars[shape] += assistantOutputTextChars;
       codexState.turn.assistantOutputChars[shape] += assistantOutputTextChars;
@@ -348,7 +429,7 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
       if (session) session.tokenCountSnapshots += 1;
 
       const timestamp = new Date(json.timestamp);
-      ensureTurn(null, timestamp);
+      ensureTurn(null, timestamp, lineNo);
       const provider = codexState.provider || "openai";
       const model = codexState.model;
       const effort = codexState.effort;
@@ -422,11 +503,16 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
       const visibleOutputChars = preferredAssistantOutputChars(codexState.assistantOutputChars);
       if (visibleOutputChars > 0 && visibleOutputTokens > 0) {
         const charsPerToken = visibleOutputChars / visibleOutputTokens;
+        const outputMetricKey = codexState.turn.hasOutputCharMetric
+          ? `${codexState.turn.turnKey}:request:${lineNo}`
+          : codexState.turn.turnKey;
         codexState.turn.hasOutputCharMetric = true;
         if (charsPerToken <= MAX_VALID_OUTPUT_CHARS_PER_TOKEN) {
           const outputCharMetric = addOutputCharTokenMetric(report, {
             sourcePath: session?.path || sourceLabel,
             turnId: codexState.turn?.turnId || null,
+            turnKey: outputMetricKey || null,
+            lineNo,
             timestamp,
             provider,
             model,
@@ -478,6 +564,7 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
 
     if (json.type === "assistant" && json.message?.usage) {
       const requestKey = json.requestId || json.uuid;
+      hasClaudeUsage = true;
       const model = json.message.model || UNKNOWN_MODEL;
       if (json.error !== "rate_limit") {
         addTelemetrySnapshot(report, {
@@ -507,11 +594,60 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
         serviceMode: serviceModeFromClaudeSpeed(json.message.usage.speed),
         sourcePath: session?.path || sourceLabel,
         lineNo,
+        requestId: requestKey || null,
       }, options);
       if (session) addToStats(session.stats, added.usage, added.cost);
     }
   };
   if (typeof report._afterLine === "function") processor.afterLine = report._afterLine;
+  processor.checkpoint = () => {
+    if (
+      hasClaudeUsage &&
+      !codexState.hasCodexMetadata &&
+      !ompState.hasOmpSession
+    ) {
+      return {
+        version: CODEX_PARSER_CHECKPOINT_VERSION,
+        kind: "claude",
+        sourceLabel,
+        deduplication: "clickhouse-event-key",
+        recentRequestIds: [...seenClaudeRequests].slice(-CLAUDE_REQUEST_CHECKPOINT_LIMIT),
+      };
+    }
+    if (
+      !codexState.hasCodexMetadata ||
+      !codexState.sessionId ||
+      codexState.forkedFromId ||
+      codexState.forkParentTraces ||
+      codexState.forkReplayBoundaryTraces ||
+      codexState.skippingForkReplay ||
+      codexState.preScannedForkReplay ||
+      codexState.preferLastTokenUsageAfterForkReplay ||
+      ompState.hasOmpSession ||
+      hasClaudeUsage
+    ) {
+      return null;
+    }
+    return {
+      version: CODEX_PARSER_CHECKPOINT_VERSION,
+      kind: "codex",
+      sourceLabel,
+      sessionId: codexState.sessionId,
+      forkedFromId: null,
+      skippingForkReplay: false,
+      project: codexState.project,
+      model: codexState.model,
+      provider: codexState.provider,
+      effort: codexState.effort,
+      serviceTier: codexState.serviceTier,
+      serviceMode: codexState.serviceMode,
+      totalUsage: cloneCheckpointValue(codexState.totalUsage),
+      visibleChars: cloneCheckpointValue(codexState.visibleChars),
+      assistantOutputChars: cloneCheckpointValue(codexState.assistantOutputChars),
+      turn: cloneCheckpointValue(codexState.turn),
+      rateLimitSequence: report._rateLimitSequence,
+    };
+  };
   processor.finalize = () => {
     flushTurn();
     return typeof processor.afterLine === "function" ? processor.afterLine() : null;
@@ -520,5 +656,7 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
 }
 
 module.exports = {
+  CLAUDE_REQUEST_CHECKPOINT_LIMIT,
+  CODEX_PARSER_CHECKPOINT_VERSION,
   createLineProcessor,
 };

--- a/lib/ingest/sources.js
+++ b/lib/ingest/sources.js
@@ -47,10 +47,16 @@ function createIngestSources({
     return paths.filter((path) => !path.endsWith(".jsonl.zst") || !available.has(path.slice(0, -4)));
   }
 
-  function openJsonlStream(filename) {
+  function openJsonlStream(filename, range = null) {
     if (!filename.endsWith(".jsonl.zst")) {
-      return fs.createReadStream(filename, { encoding: "utf8" });
+      const streamOptions = { encoding: "utf8" };
+      if (range) {
+        streamOptions.start = range.start;
+        streamOptions.end = range.end - 1;
+      }
+      return fs.createReadStream(filename, streamOptions);
     }
+    if (range) throw new Error("Byte-range ingestion is unavailable for compressed JSONL");
     const input = fs.createReadStream(filename);
     const decoder = zlib.createZstdDecompress();
     input.on("error", (error) => decoder.destroy(error));
@@ -65,10 +71,11 @@ function createIngestSources({
     const stat = await fsp.stat(filename);
     const adapter = adapterForPath(filename, inputMeta?.adapter || null);
     const kind = fileKind(filename);
+    const range = inputMeta?.range || null;
     const session = startSession(report, options, {
       kind,
       path: filename,
-      sizeBytes: stat.size,
+      sizeBytes: range ? Math.max(0, range.end - range.start) : stat.size,
     });
 
     // Keep the historical processJsonlFile entry point for storage backends,
@@ -80,24 +87,31 @@ function createIngestSources({
       } finally {
         finishSession(session, options);
       }
-      return;
+      return null;
     }
 
-    const processor = createLineProcessor(report, options, filename, session);
-    const stream = openJsonlStream(filename);
+    const processingOptions = range?.parserCheckpoint
+      ? { ...options, parserCheckpoint: range.parserCheckpoint }
+      : options;
+    const processor = createLineProcessor(report, processingOptions, filename, session);
+    const stream = openJsonlStream(filename, range);
     try {
-      await processLineStream(stream, processor, session);
+      return await processLineStream(stream, processor, session, {
+        finalize: range?.finalize !== false,
+        lineNoOffset: range?.lineNoOffset || 0,
+      });
     } finally {
       finishSession(session, options);
     }
   }
 
-  async function processLineStream(stream, processor, session = null) {
+  async function processLineStream(stream, processor, session = null, control = {}) {
     const rl = readline.createInterface({
       input: stream,
       crlfDelay: Infinity,
     });
-    let lineNo = 0;
+    const lineNoOffset = Number(control.lineNoOffset) || 0;
+    let lineNo = lineNoOffset;
     for await (const line of rl) {
       lineNo += 1;
       if (session) session.lines += 1;
@@ -107,10 +121,21 @@ function createIngestSources({
         if (drain && typeof drain.then === "function") await drain;
       }
     }
-    if (typeof processor.finalize === "function") {
+    const parserCheckpoint = typeof processor.checkpoint === "function"
+      ? processor.checkpoint()
+      : null;
+    // Capture resumable parser state first, then emit a reporting snapshot for
+    // an open final turn. The ClickHouse output metric key replaces that
+    // provisional snapshot when the same turn grows in a later append.
+    if (control.finalize !== false && typeof processor.finalize === "function") {
       const drain = processor.finalize();
       if (drain && typeof drain.then === "function") await drain;
     }
+    return {
+      lineNo,
+      linesRead: lineNo - lineNoOffset,
+      parserCheckpoint,
+    };
   }
 
   async function processZipEntry(zipFile, entry, report, options) {
@@ -459,6 +484,16 @@ function createIngestSources({
     const persistedHeaders = (options.persistedCodexSessionHeaders || [])
       .map(storedCodexSessionHeader)
       .filter(Boolean);
+    if (!currentHeaders.some((header) => header.forkedFromId)) {
+      return currentHeaders.length > 0
+        ? {
+          tracesBySession: new Map(),
+          replaySessions: new Set(),
+          replayBoundariesBySession: new Map(),
+          currentHeaders,
+        }
+        : null;
+    }
     const headersBySession = new Map(persistedHeaders.map((header) => [header.id, header]));
     for (const header of currentHeaders) headersBySession.set(header.id, header);
     const parentSessionIds = new Set(currentHeaders.map((header) => header.forkedFromId).filter(Boolean));

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -203,7 +203,7 @@ async function dashboardReady(baseUrl, expectedEngine = null) {
     });
     if (!response.ok) return false;
     const body = await response.json();
-    if (!body?.sync) return false;
+    if (!body?.sync || body.sync.available !== true) return false;
     if (!expectedEngine) return true;
     const engine = body.sync.engine || body.sync.result?.engine;
     return engine === expectedEngine;
@@ -249,7 +249,7 @@ async function waitForDashboardProcess(
   await waitUntil(async () => {
     if (exited) throw new Error(`Tokenomics exited before becoming ready with exit code ${exitCode}`);
     return ready(url);
-  }, { timeoutMs, intervalMs, label: "Tokenomics startup sync" });
+  }, { timeoutMs, intervalMs, label: "Tokenomics dashboard" });
 }
 
 async function portAvailable(port, host = "127.0.0.1") {
@@ -361,7 +361,7 @@ async function runLauncher(argv, dependencies = {}) {
     child.stop();
     throw error;
   }
-  runtime.log(`Tokenomics is ready at ${url}`);
+  runtime.log(`Tokenomics dashboard is available at ${url}; synchronization continues in the background.`);
   await openBrowserSafely(runtime, url, options.noOpen);
   return child.exit;
 }
@@ -369,6 +369,7 @@ async function runLauncher(argv, dependencies = {}) {
 module.exports = {
   CLICKHOUSE_URL,
   browserCommand,
+  dashboardReady,
   downloadClickHouseInstaller,
   ensureClickHouse,
   findExecutable,

--- a/lib/report/text.js
+++ b/lib/report/text.js
@@ -249,7 +249,7 @@ function renderTextReport(report, options) {
   const lines = [];
   lines.push("Tokenomics Viewer");
   lines.push(`Sources: files=${formatInt(report.sources.files)}, zip_files=${formatInt(report.sources.zipFiles)}, zip_entries=${formatInt(report.sources.zipEntries)}, skipped=${formatInt(report.sources.skippedFiles)}, token_count_snapshots=${formatInt(report.sources.tokenCountSnapshots)}, skipped_token_count_snapshots=${formatInt(report.sources.skippedTokenCountSnapshots)}, parse_errors=${formatInt(report.sources.parseErrors)}`);
-  lines.push(`Pricing sources: OpenAI=${PRICING_SOURCES.openai}; OpenAI GPT-5.6=${PRICING_SOURCES.openaiGpt56}; OpenAI models=${PRICING_SOURCES.openaiGpt5}; OpenAI Codex=${PRICING_SOURCES.openaiCodex}; Codex fast mode=${PRICING_SOURCES.openaiCodexFast}; Anthropic=${PRICING_SOURCES.anthropic}; Claude fast mode=${PRICING_SOURCES.anthropicFast}`);
+  lines.push(`Pricing sources: OpenAI=${PRICING_SOURCES.openai}; OpenAI GPT-6 Astra=${PRICING_SOURCES.openaiGpt6Astra}; OpenAI GPT-5.6=${PRICING_SOURCES.openaiGpt56}; OpenAI models=${PRICING_SOURCES.openaiGpt5}; OpenAI Codex=${PRICING_SOURCES.openaiCodex}; Codex fast mode=${PRICING_SOURCES.openaiCodexFast}; Anthropic=${PRICING_SOURCES.anthropic}; Claude fast mode=${PRICING_SOURCES.anthropicFast}`);
   lines.push(`OpenAI context pricing mode: ${options.openaiContext}`);
   lines.push(formatStatsLine("Total", report.total));
   lines.push(printSection("By provider", report.providers, options.top));

--- a/lib/storage/clickhouse.js
+++ b/lib/storage/clickhouse.js
@@ -5,6 +5,13 @@ const { randomUUID } = require("node:crypto");
 const { URL } = require("node:url");
 const { listZipEntries } = require("../ingest/archive");
 const {
+  APPEND_CURSOR_VERSION,
+  appendGuard,
+  appendPrefixGuard,
+  inspectAppendFile,
+  validateAppendCursor,
+} = require("../ingest/append-cursor");
+const {
   MAX_VALID_OUTPUT_CHARS_PER_TOKEN,
   bucket,
   dateKey,
@@ -42,6 +49,7 @@ const DEFAULT_CLICKHOUSE_URL = "http://127.0.0.1:8123";
 const DEFAULT_CLICKHOUSE_DATABASE = "tokenomics";
 const DEFAULT_CLICKHOUSE_INSERT_BATCH_ROWS = 100_000;
 const DEFAULT_CLICKHOUSE_INSERT_BATCH_BYTES = 32 * 1024 * 1024;
+const CLICKHOUSE_MANIFEST_CHECKPOINT_INTERVAL = 128;
 const CLICKHOUSE_SOURCE_TABLES = ["telemetry_events", "rate_limit_samples", "output_char_metrics", "usage_events", "sessions", "codex_sessions"];
 const CLICKHOUSE_PRICING_PROJECTION_REVISION = "2";
 
@@ -187,9 +195,30 @@ function createClickHouseBackend(dependencies = {}) {
         fingerprint String CODEC(ZSTD(3)),
         size_bytes UInt64 CODEC(Delta, ZSTD(1)),
         compressed_size_bytes UInt64 CODEC(Delta, ZSTD(1)),
-        imported_at String CODEC(ZSTD(1))
+        imported_at String CODEC(ZSTD(1)),
+        cursor_version UInt64 CODEC(T64, ZSTD(1)),
+        segment_start UInt64 CODEC(Delta, ZSTD(1)),
+        segment_end UInt64 CODEC(Delta, ZSTD(1)),
+        cursor_line UInt64 CODEC(Delta, ZSTD(1)),
+        cursor_guard String CODEC(ZSTD(1)),
+        cursor_prefix_guard String CODEC(ZSTD(1)),
+        parser_checkpoint String CODEC(ZSTD(6)),
+        file_device String CODEC(ZSTD(1)),
+        file_inode String CODEC(ZSTD(1))
       ) ENGINE = MergeTree
       ORDER BY source_path
+    `);
+    await clickHouseRequest(client, `
+      ALTER TABLE sources
+        ADD COLUMN IF NOT EXISTS cursor_version UInt64 DEFAULT 0 CODEC(T64, ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS segment_start UInt64 DEFAULT 0 CODEC(Delta, ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS segment_end UInt64 DEFAULT 0 CODEC(Delta, ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS cursor_line UInt64 DEFAULT 0 CODEC(Delta, ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS cursor_guard String DEFAULT '' CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS cursor_prefix_guard String DEFAULT '' CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS parser_checkpoint String DEFAULT '' CODEC(ZSTD(6)),
+        ADD COLUMN IF NOT EXISTS file_device String DEFAULT '' CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS file_inode String DEFAULT '' CODEC(ZSTD(1))
     `);
     await clickHouseRequest(client, `
       CREATE TABLE IF NOT EXISTS codex_sessions (
@@ -200,6 +229,7 @@ function createClickHouseBackend(dependencies = {}) {
         kind LowCardinality(String) CODEC(ZSTD(1)),
         archive_path String CODEC(ZSTD(3)),
         entry_name String CODEC(ZSTD(3)),
+        segment_end UInt64 CODEC(Delta, ZSTD(1)),
         updated_at_ms UInt64 CODEC(Delta, ZSTD(1))
       ) ENGINE = ReplacingMergeTree(updated_at_ms)
       ORDER BY session_id
@@ -213,6 +243,7 @@ function createClickHouseBackend(dependencies = {}) {
         kind LowCardinality(String) CODEC(ZSTD(1)),
         archive_path String CODEC(ZSTD(3)),
         entry_name String CODEC(ZSTD(3)),
+        segment_end UInt64 CODEC(Delta, ZSTD(1)),
         updated_at_ms UInt64 CODEC(Delta, ZSTD(1))
       ) ENGINE = MergeTree
       ORDER BY (session_id, source_path, import_id, updated_at_ms)
@@ -234,15 +265,24 @@ function createClickHouseBackend(dependencies = {}) {
         parse_errors UInt64 CODEC(Delta, ZSTD(1)),
         token_count_snapshots UInt64 CODEC(Delta, ZSTD(1)),
         skipped_token_count_snapshots UInt64 CODEC(Delta, ZSTD(1)),
+        segment_start UInt64 CODEC(Delta, ZSTD(1)),
+        segment_end UInt64 CODEC(Delta, ZSTD(1)),
         stats_json String CODEC(ZSTD(6))
       ) ENGINE = MergeTree
       ORDER BY source_path
     `);
     await clickHouseRequest(client, `
+      ALTER TABLE sessions
+        ADD COLUMN IF NOT EXISTS segment_start UInt64 DEFAULT 0 CODEC(Delta, ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS segment_end UInt64 DEFAULT 0 CODEC(Delta, ZSTD(1))
+    `);
+    await clickHouseRequest(client, `
       CREATE TABLE IF NOT EXISTS usage_events (
         source_path String CODEC(ZSTD(3)),
         import_id String CODEC(ZSTD(3)),
+        segment_end UInt64 CODEC(Delta, ZSTD(1)),
         line_no UInt64 CODEC(Delta, ZSTD(1)),
+        event_key String CODEC(ZSTD(3)),
         timestamp Nullable(String) CODEC(ZSTD(1)),
         date_key String CODEC(ZSTD(1)),
         week_key String CODEC(ZSTD(1)),
@@ -282,6 +322,8 @@ function createClickHouseBackend(dependencies = {}) {
     await clickHouseRequest(client, `
       ALTER TABLE usage_events
         ADD COLUMN IF NOT EXISTS import_id String DEFAULT '' CODEC(ZSTD(3)),
+        ADD COLUMN IF NOT EXISTS segment_end UInt64 DEFAULT 0 CODEC(Delta, ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS event_key String DEFAULT '' CODEC(ZSTD(3)),
         ADD COLUMN IF NOT EXISTS service_tier LowCardinality(String) DEFAULT 'unknown' CODEC(ZSTD(1)),
         ADD COLUMN IF NOT EXISTS service_mode LowCardinality(String) DEFAULT 'unknown' CODEC(ZSTD(1)),
         ADD COLUMN IF NOT EXISTS agent LowCardinality(String) DEFAULT 'unknown' CODEC(ZSTD(1)),
@@ -297,6 +339,8 @@ function createClickHouseBackend(dependencies = {}) {
         source_path String CODEC(ZSTD(3)),
         import_id String CODEC(ZSTD(3)),
         turn_id String CODEC(ZSTD(3)),
+        turn_key String CODEC(ZSTD(3)),
+        metric_revision UInt64 CODEC(Delta, ZSTD(1)),
         timestamp Nullable(String) CODEC(ZSTD(1)),
         date_key String CODEC(ZSTD(1)),
         week_key String CODEC(ZSTD(1)),
@@ -313,9 +357,15 @@ function createClickHouseBackend(dependencies = {}) {
       ORDER BY (date_key, source_path, turn_id)
     `);
     await clickHouseRequest(client, `
+      ALTER TABLE output_char_metrics
+        ADD COLUMN IF NOT EXISTS turn_key String DEFAULT '' CODEC(ZSTD(3)),
+        ADD COLUMN IF NOT EXISTS metric_revision UInt64 DEFAULT 0 CODEC(Delta, ZSTD(1))
+    `);
+    await clickHouseRequest(client, `
       CREATE TABLE IF NOT EXISTS rate_limit_samples (
         source_path String CODEC(ZSTD(3)),
         import_id String CODEC(ZSTD(3)),
+        segment_end UInt64 CODEC(Delta, ZSTD(1)),
         line_no UInt64 CODEC(Delta, ZSTD(1)),
         sample_key String CODEC(ZSTD(3)),
         group_key String CODEC(ZSTD(3)),
@@ -348,6 +398,7 @@ function createClickHouseBackend(dependencies = {}) {
       CREATE TABLE IF NOT EXISTS telemetry_events (
         source_path String CODEC(ZSTD(3)),
         import_id String CODEC(ZSTD(3)),
+        segment_end UInt64 CODEC(Delta, ZSTD(1)),
         line_no UInt64 CODEC(Delta, ZSTD(1)),
         timestamp String CODEC(ZSTD(1)),
         timestamp_ms UInt64 CODEC(Delta, ZSTD(1)),
@@ -365,16 +416,55 @@ function createClickHouseBackend(dependencies = {}) {
       CREATE TABLE IF NOT EXISTS import_generation_sources (
         generation_id String CODEC(ZSTD(3)),
         source_path String CODEC(ZSTD(3)),
-        import_id String CODEC(ZSTD(3))
+        import_id String CODEC(ZSTD(3)),
+        committed_segment_end Nullable(UInt64) CODEC(ZSTD(1)),
+        deleted UInt8 CODEC(T64, ZSTD(1))
       ) ENGINE = MergeTree
       ORDER BY (generation_id, source_path)
     `);
+    await clickHouseRequest(client, `
+      ALTER TABLE import_generation_sources
+        ADD COLUMN IF NOT EXISTS committed_segment_end Nullable(UInt64) DEFAULT NULL CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS deleted UInt8 DEFAULT 0 CODEC(T64, ZSTD(1))
+    `);
+    await clickHouseRequest(client, `
+      CREATE TABLE IF NOT EXISTS import_generation_source_deltas (
+        committed_at_ms UInt64 CODEC(Delta, ZSTD(1)),
+        generation_id String CODEC(ZSTD(3)),
+        source_path String CODEC(ZSTD(3)),
+        import_id String CODEC(ZSTD(3)),
+        committed_segment_end Nullable(UInt64) CODEC(ZSTD(1)),
+        deleted UInt8 CODEC(T64, ZSTD(1))
+      ) ENGINE = MergeTree
+      ORDER BY (committed_at_ms, generation_id, source_path)
+    `);
+    for (const table of ["codex_sessions", "codex_session_versions", "rate_limit_samples", "telemetry_events"]) {
+      await clickHouseRequest(client, `
+        ALTER TABLE ${table}
+          ADD COLUMN IF NOT EXISTS segment_end UInt64 DEFAULT 0 CODEC(Delta, ZSTD(1))
+      `);
+    }
     await clickHouseRequest(client, `
       CREATE TABLE IF NOT EXISTS import_generations (
         generation_id String CODEC(ZSTD(3)),
         committed_at_ms UInt64 CODEC(Delta, ZSTD(1))
       ) ENGINE = MergeTree
       ORDER BY (committed_at_ms, generation_id)
+    `);
+    await clickHouseRequest(client, `
+      CREATE TABLE IF NOT EXISTS import_generation_checkpoints (
+        committed_at_ms UInt64 CODEC(Delta, ZSTD(1)),
+        generation_id String CODEC(ZSTD(3)),
+        base_committed_at_ms UInt64 CODEC(Delta, ZSTD(1)),
+        base_generation_id String CODEC(ZSTD(3))
+      ) ENGINE = MergeTree
+      ORDER BY (committed_at_ms, generation_id)
+    `);
+    await clickHouseRequest(client, `
+      ALTER TABLE import_generation_checkpoints
+        ADD COLUMN IF NOT EXISTS committed_at_ms UInt64 DEFAULT 0 CODEC(Delta, ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS base_committed_at_ms UInt64 DEFAULT 0 CODEC(Delta, ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS base_generation_id String DEFAULT '' CODEC(ZSTD(3))
     `);
     await clickHouseRequest(client, `
       CREATE TABLE IF NOT EXISTS configuration_revisions (
@@ -478,6 +568,8 @@ function createClickHouseBackend(dependencies = {}) {
     for (const table of [
       "import_generations",
       "import_generation_sources",
+      "import_generation_source_deltas",
+      "import_generation_checkpoints",
       "configuration_revisions",
       "configuration_metadata",
       "analytics_settings",
@@ -503,6 +595,15 @@ function createClickHouseBackend(dependencies = {}) {
       size_bytes: number(source.sizeBytes),
       compressed_size_bytes: number(source.compressedSizeBytes),
       imported_at: new Date().toISOString(),
+      cursor_version: number(source.cursorVersion),
+      segment_start: number(source.segmentStart),
+      segment_end: number(source.segmentEnd),
+      cursor_line: number(source.cursorLine),
+      cursor_guard: source.cursorGuard || "",
+      cursor_prefix_guard: source.cursorPrefixGuard || "",
+      parser_checkpoint: source.parserCheckpoint ? JSON.stringify(source.parserCheckpoint) : "",
+      file_device: source.fileDevice || "",
+      file_inode: source.fileInode || "",
     };
   }
 
@@ -784,17 +885,159 @@ function createClickHouseBackend(dependencies = {}) {
     return commitClickHouseConfiguration(client, next, current.revision, current.committed_at_ms, options);
   }
 
+  function clickHouseActiveManifestDefinitions() {
+    return `
+      target_generation AS (
+        SELECT generation_id, committed_at_ms
+        FROM import_generations
+        WHERE generation_id = {generation:String}
+        LIMIT 1
+      ),
+      ordered_generations AS (
+        SELECT
+          source.generation_id AS generation_id,
+          source.committed_at_ms AS committed_at_ms,
+          lagInFrame(source.generation_id, 1, '') OVER (
+            ORDER BY source.committed_at_ms, source.generation_id
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+          ) AS previous_generation_id,
+          lagInFrame(source.committed_at_ms, 1, toUInt64(0)) OVER (
+            ORDER BY source.committed_at_ms, source.generation_id
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+          ) AS previous_committed_at_ms
+        FROM import_generations AS source
+        CROSS JOIN target_generation AS target
+        WHERE tuple(source.committed_at_ms, source.generation_id)
+          <= tuple(target.committed_at_ms, target.generation_id)
+      ),
+      valid_checkpoints AS (
+        SELECT
+          committed.generation_id AS generation_id,
+          committed.committed_at_ms AS committed_at_ms
+        FROM import_generation_checkpoints AS checkpoint
+        INNER JOIN ordered_generations AS committed USING (generation_id)
+        WHERE (
+          checkpoint.base_generation_id = committed.previous_generation_id
+          AND checkpoint.base_committed_at_ms = committed.previous_committed_at_ms
+        ) OR checkpoint.base_generation_id = checkpoint.generation_id
+      ),
+      checkpoint_boundary AS (
+        SELECT if(
+          count() = 0,
+          tuple(toUInt64(0), ''),
+          max(tuple(committed_at_ms, generation_id))
+        ) AS boundary
+        FROM valid_checkpoints
+      ),
+      checkpoint_snapshot AS (
+        SELECT
+          manifest.source_path AS source_path,
+          manifest.import_id AS import_id,
+          manifest.committed_segment_end AS committed_segment_end,
+          manifest.deleted AS deleted,
+          committed.generation_id AS generation_id,
+          committed.committed_at_ms AS committed_at_ms
+        FROM import_generation_sources AS manifest
+        INNER JOIN import_generations AS committed USING (generation_id)
+        CROSS JOIN checkpoint_boundary AS checkpoint
+        WHERE checkpoint.boundary.2 != ''
+          AND manifest.generation_id = checkpoint.boundary.2
+      ),
+      legacy_snapshot AS (
+        SELECT
+          manifest.source_path AS source_path,
+          manifest.import_id AS import_id,
+          manifest.committed_segment_end AS committed_segment_end,
+          manifest.deleted AS deleted,
+          committed.generation_id AS generation_id,
+          committed.committed_at_ms AS committed_at_ms
+        FROM import_generation_sources AS manifest
+        INNER JOIN import_generations AS committed USING (generation_id)
+        CROSS JOIN target_generation AS target
+        CROSS JOIN checkpoint_boundary AS checkpoint
+        WHERE checkpoint.boundary.2 = ''
+          AND manifest.generation_id = target.generation_id
+      ),
+      manifest_deltas AS (
+        SELECT
+          manifest.source_path AS source_path,
+          manifest.import_id AS import_id,
+          manifest.committed_segment_end AS committed_segment_end,
+          manifest.deleted AS deleted,
+          committed.generation_id AS generation_id,
+          committed.committed_at_ms AS committed_at_ms
+        FROM import_generation_source_deltas AS manifest
+        INNER JOIN import_generations AS committed USING (generation_id)
+        CROSS JOIN target_generation AS target
+        CROSS JOIN checkpoint_boundary AS checkpoint
+        WHERE tuple(manifest.committed_at_ms, manifest.generation_id) > checkpoint.boundary
+          AND tuple(manifest.committed_at_ms, manifest.generation_id)
+            <= tuple(target.committed_at_ms, target.generation_id)
+      ),
+      manifest_history AS (
+        SELECT * FROM checkpoint_snapshot
+        UNION ALL
+        SELECT * FROM legacy_snapshot
+        UNION ALL
+        SELECT * FROM manifest_deltas
+      ),
+      manifest_heads AS (
+        SELECT
+          source_path,
+          argMax(generation_id, tuple(committed_at_ms, generation_id)) AS generation_id
+        FROM manifest_history
+        GROUP BY source_path
+      ),
+      manifest_watermarks AS (
+        SELECT
+          source_path,
+          import_id,
+          max(committed_segment_end) AS committed_segment_end
+        FROM manifest_history
+        WHERE deleted = 0
+        GROUP BY source_path, import_id
+      ),
+      active_manifest AS (
+        SELECT
+          history.source_path AS source_path,
+          history.import_id AS import_id,
+          watermarks.committed_segment_end AS committed_segment_end
+        FROM manifest_history AS history
+        INNER JOIN manifest_heads AS head USING (source_path, generation_id)
+        INNER JOIN manifest_watermarks AS watermarks USING (source_path, import_id)
+        WHERE history.deleted = 0
+      )
+    `;
+  }
+
   async function loadClickHouseGenerationSources(client, generationId) {
     if (!generationId) return new Map();
     const rows = await clickHouseJsonEachRow(client, `
+      WITH ${clickHouseActiveManifestDefinitions()}
       SELECT
         manifest.source_path AS source_path,
-        manifest.import_id AS import_id,
-        argMax(source.fingerprint, source.imported_at) AS fingerprint
-      FROM import_generation_sources AS manifest
-      INNER JOIN sources AS source USING (source_path, import_id)
-      WHERE manifest.generation_id = {generation:String}
-      GROUP BY manifest.source_path, manifest.import_id
+        argMax(source.import_id, tuple(source.segment_end, source.imported_at, source.import_id)) AS import_id,
+        argMax(source.fingerprint, tuple(source.segment_end, source.imported_at, source.import_id)) AS fingerprint,
+        argMax(source.imported_at, tuple(source.segment_end, source.imported_at, source.import_id)) AS imported_at,
+        argMax(source.cursor_version, tuple(source.segment_end, source.imported_at, source.import_id)) AS cursor_version,
+        argMax(source.segment_start, tuple(source.segment_end, source.imported_at, source.import_id)) AS segment_start,
+        max(source.segment_end) AS segment_end,
+        argMax(source.cursor_line, tuple(source.segment_end, source.imported_at, source.import_id)) AS cursor_line,
+        argMax(source.cursor_guard, tuple(source.segment_end, source.imported_at, source.import_id)) AS cursor_guard,
+        argMax(source.cursor_prefix_guard, tuple(source.segment_end, source.imported_at, source.import_id)) AS cursor_prefix_guard,
+        argMax(source.parser_checkpoint, tuple(source.segment_end, source.imported_at, source.import_id)) AS parser_checkpoint,
+        argMax(source.file_device, tuple(source.segment_end, source.imported_at, source.import_id)) AS file_device,
+        argMax(source.file_inode, tuple(source.segment_end, source.imported_at, source.import_id)) AS file_inode,
+        uniqExact(source.import_id) AS active_import_count
+      FROM active_manifest AS manifest
+      INNER JOIN sources AS source
+        ON manifest.source_path = source.source_path
+        AND manifest.import_id = source.import_id
+        AND (
+          isNull(manifest.committed_segment_end)
+          OR source.segment_end <= manifest.committed_segment_end
+        )
+      GROUP BY manifest.source_path
     `, { params: { generation: generationId } });
     return new Map(rows.map((row) => [row.source_path, row]));
   }
@@ -812,15 +1055,48 @@ function createClickHouseBackend(dependencies = {}) {
     return new Map(rows.map((row) => [row.source_path, row]));
   }
 
-  async function commitClickHouseGeneration(client, sourceStates, previousCommitMs, options = {}) {
+  async function commitClickHouseGeneration(
+    client,
+    sourceStates,
+    previousCommitMs,
+    previousGenerationId,
+    options = {},
+    changedPaths = null,
+    checkpoint = false,
+  ) {
     const generationId = randomUUID();
-    const manifestRows = [...sourceStates.values()].map((state) => ({
-      generation_id: generationId,
-      source_path: state.source_path,
-      import_id: state.import_id || "",
-    }));
-    await clickHouseInsertRows(client, "import_generation_sources", manifestRows, options);
     const committedAtMs = Math.max(Date.now(), number(previousCommitMs) + 1);
+    const manifestRow = (sourcePath) => {
+      const state = sourceStates.get(sourcePath);
+      return {
+        generation_id: generationId,
+        source_path: sourcePath,
+        import_id: state?.import_id || "",
+        committed_segment_end: state?.segment_end === undefined || state?.segment_end === null
+          ? null
+          : number(state.segment_end),
+        deleted: state ? 0 : 1,
+      };
+    };
+    const deltaRows = changedPaths ? [...changedPaths].map(manifestRow) : [];
+    if (checkpoint) {
+      await clickHouseInsertRows(client, "import_generation_sources", [...sourceStates.keys()].map(manifestRow), options);
+      await clickHouseInsertRows(client, "import_generation_source_deltas", (previousGenerationId ? deltaRows : []).map((row) => ({
+        committed_at_ms: committedAtMs,
+        ...row,
+      })), options);
+      await clickHouseInsertRows(client, "import_generation_checkpoints", [{
+        base_committed_at_ms: number(previousCommitMs),
+        base_generation_id: previousGenerationId || "",
+        committed_at_ms: committedAtMs,
+        generation_id: generationId,
+      }], options);
+    } else {
+      await clickHouseInsertRows(client, "import_generation_source_deltas", deltaRows.map((row) => ({
+        committed_at_ms: committedAtMs,
+        ...row,
+      })), options);
+    }
     await clickHouseInsertRows(client, "import_generations", [{
       generation_id: generationId,
       committed_at_ms: committedAtMs,
@@ -828,38 +1104,82 @@ function createClickHouseBackend(dependencies = {}) {
     return { generation_id: generationId, committed_at_ms: committedAtMs };
   }
 
+  async function clickHouseManifestDeltaGenerations(client, generationId) {
+    if (!generationId) return 0;
+    const rows = await clickHouseJsonEachRow(client, `
+      WITH ${clickHouseActiveManifestDefinitions()}
+      SELECT uniqExact(generation_id) AS delta_generations
+      FROM manifest_deltas
+    `, { params: { generation: generationId } });
+    return number(rows[0]?.delta_generations);
+  }
+
+  async function ensureClickHouseManifestCheckpoint(client, committed, options = {}) {
+    if (!committed?.generation_id) return;
+    const rows = await clickHouseJsonEachRow(client, `
+      SELECT checkpoint.generation_id AS generation_id
+      FROM import_generation_checkpoints AS checkpoint
+      INNER JOIN import_generations AS committed USING (generation_id)
+      WHERE tuple(committed.committed_at_ms, committed.generation_id)
+        <= tuple({committedAt:UInt64}, {generation:String})
+      ORDER BY committed.committed_at_ms DESC, committed.generation_id DESC
+      LIMIT 1
+    `, {
+      params: {
+        committedAt: committed.committed_at_ms,
+        generation: committed.generation_id,
+      },
+    });
+    if (rows.length > 0) return;
+    await clickHouseInsertRows(client, "import_generation_checkpoints", [{
+      base_committed_at_ms: committed.committed_at_ms,
+      base_generation_id: committed.generation_id,
+      committed_at_ms: committed.committed_at_ms,
+      generation_id: committed.generation_id,
+    }], options);
+  }
+
   async function ensureClickHouseBaselineGeneration(client, options = {}) {
     const committed = await latestClickHouseGeneration(client);
-    if (committed) return committed;
+    if (committed) {
+      await ensureClickHouseManifestCheckpoint(client, committed, options);
+      return committed;
+    }
     const legacySources = await loadLegacyClickHouseSources(client);
     if (legacySources.size === 0) return null;
-    return commitClickHouseGeneration(client, legacySources, 0, options);
+    return commitClickHouseGeneration(client, legacySources, 0, "", options, null, true);
   }
 
   async function loadClickHouseCodexSessionHeaders(client, generationId) {
     if (!generationId) return [];
     return clickHouseJsonEachRow(client, `
+      WITH ${clickHouseActiveManifestDefinitions()}
       SELECT
-        session_id,
-        argMax(parent_session_id, updated_at_ms) AS parent_session_id,
-        argMax(source_path, updated_at_ms) AS source_path,
-        argMax(kind, updated_at_ms) AS kind,
-        argMax(archive_path, updated_at_ms) AS archive_path,
-        argMax(entry_name, updated_at_ms) AS entry_name
+        headers.session_id AS session_id,
+        argMax(headers.parent_session_id, headers.updated_at_ms) AS parent_session_id,
+        argMax(headers.source_path, headers.updated_at_ms) AS source_path,
+        argMax(headers.kind, headers.updated_at_ms) AS kind,
+        argMax(headers.archive_path, headers.updated_at_ms) AS archive_path,
+        argMax(headers.entry_name, headers.updated_at_ms) AS entry_name
       FROM (
         SELECT
           session_id, parent_session_id, source_path, import_id,
-          kind, archive_path, entry_name, updated_at_ms
+          kind, archive_path, entry_name, segment_end, updated_at_ms
         FROM codex_session_versions
         UNION ALL
         SELECT
           session_id, parent_session_id, source_path, import_id,
-          kind, archive_path, entry_name, updated_at_ms
+          kind, archive_path, entry_name, segment_end, updated_at_ms
         FROM codex_sessions
       ) AS headers
-      INNER JOIN import_generation_sources AS manifest USING (source_path, import_id)
-      WHERE manifest.generation_id = {generation:String}
-      GROUP BY session_id
+      INNER JOIN active_manifest AS manifest
+        ON manifest.source_path = headers.source_path
+        AND manifest.import_id = headers.import_id
+        AND (
+          isNull(manifest.committed_segment_end)
+          OR headers.segment_end <= manifest.committed_segment_end
+        )
+      GROUP BY headers.session_id
     `, { params: { generation: generationId } });
   }
 
@@ -878,6 +1198,7 @@ function createClickHouseBackend(dependencies = {}) {
         kind: source.kind,
         archivePath: source.archivePath || null,
         entryName: source.entryName || null,
+        segmentEnd: number(sourceState.segment_end),
         updatedAt: new Date().toISOString(),
       });
     }
@@ -889,12 +1210,13 @@ function createClickHouseBackend(dependencies = {}) {
       kind: row.kind,
       archive_path: row.archivePath || "",
       entry_name: row.entryName || "",
+      segment_end: row.segmentEnd,
       updated_at_ms: Date.parse(row.updatedAt),
     }));
     await clickHouseInsertRows(client, "codex_session_versions", rows, options);
   }
 
-  function removeSupersededClickHouseSources(sourceStates, changedSources, currentHeaders, persistedHeaders) {
+  function removeSupersededClickHouseSources(sourceStates, changedSources, manifestChanges, currentHeaders, persistedHeaders) {
     const persistedSourceBySession = new Map();
     for (const header of persistedHeaders || []) {
       const sessionId = normalizeCodexUuid(header.sessionId ?? header.session_id);
@@ -908,12 +1230,15 @@ function createClickHouseBackend(dependencies = {}) {
       const sourcePath = header?.source?.sourcePath;
       if (!sessionId || !sourcePath || !changedSources.has(sourcePath)) continue;
       const previousPath = persistedSourceBySession.get(sessionId);
-      if (previousPath && previousPath !== sourcePath && sourceStates.delete(previousPath)) removed += 1;
+      if (previousPath && previousPath !== sourcePath && sourceStates.delete(previousPath)) {
+        manifestChanges.add(previousPath);
+        removed += 1;
+      }
     }
     return removed;
   }
 
-  function clickHouseSessionRow(session, importId) {
+  function clickHouseSessionRow(session, importId, source = {}) {
     return {
       source_path: session.path,
       import_id: importId,
@@ -930,16 +1255,20 @@ function createClickHouseBackend(dependencies = {}) {
       parse_errors: number(session.parseErrors),
       token_count_snapshots: number(session.tokenCountSnapshots),
       skipped_token_count_snapshots: number(session.skippedTokenCountSnapshots),
+      segment_start: number(source.segmentStart),
+      segment_end: number(source.segmentEnd),
       stats_json: JSON.stringify(session.stats),
     };
   }
 
-  function clickHouseUsageEventRow(event, defaultSourcePath, importId) {
+  function clickHouseUsageEventRow(event, defaultSourcePath, importId, segmentEnd) {
     const timestamp = event.timestamp ? new Date(event.timestamp) : new Date(NaN);
     return {
       source_path: event.sourcePath || defaultSourcePath,
       import_id: importId,
+      segment_end: number(segmentEnd),
       line_no: number(event.lineNo),
+      event_key: event.requestId ? `request:${event.requestId}` : `line:${number(event.lineNo)}`,
       timestamp: event.timestamp || null,
       date_key: dateKey(timestamp),
       week_key: weekKey(timestamp),
@@ -982,6 +1311,8 @@ function createClickHouseBackend(dependencies = {}) {
       source_path: event.sourcePath || defaultSourcePath,
       import_id: importId,
       turn_id: event.turnId || "",
+      turn_key: event.turnKey || (event.turnId ? `id:${event.turnId}` : `line:${number(event.lineNo)}`),
+      metric_revision: number(event.metricRevision),
       timestamp: event.timestamp || null,
       date_key: dateKey(timestamp),
       week_key: weekKey(timestamp),
@@ -997,11 +1328,12 @@ function createClickHouseBackend(dependencies = {}) {
     };
   }
 
-  function clickHouseRateLimitSampleRow(sample, defaultSourcePath, importId) {
+  function clickHouseRateLimitSampleRow(sample, defaultSourcePath, importId, segmentEnd) {
     const timestamp = new Date(sample.timestampMs);
     return {
       source_path: sample.sourcePath || defaultSourcePath,
       import_id: importId,
+      segment_end: number(segmentEnd),
       line_no: number(sample.lineNo),
       sample_key: sample.key,
       group_key: sample.groupKey,
@@ -1030,11 +1362,12 @@ function createClickHouseBackend(dependencies = {}) {
     };
   }
 
-  function clickHouseTelemetryEventRow(event, defaultSourcePath, importId) {
+  function clickHouseTelemetryEventRow(event, defaultSourcePath, importId, segmentEnd) {
     const timestamp = new Date(event.timestamp);
     return {
       source_path: event.sourcePath || defaultSourcePath,
       import_id: importId,
+      segment_end: number(segmentEnd),
       line_no: number(event.lineNo),
       timestamp: event.timestamp,
       timestamp_ms: timestamp.getTime(),
@@ -1093,20 +1426,26 @@ function createClickHouseBackend(dependencies = {}) {
   }
 
   async function processAndStoreClickHouseSource(client, source, fingerprint, options) {
-    const importId = randomUUID();
+    // A source keeps one immutable epoch id for its append-only lifetime.
+    // Rewrites create a new epoch; ordinary tails add rows to the same one.
+    const importId = source.importId || randomUUID();
     const usageSink = createClickHouseRowSink(client, "usage_events", options);
     const outputCharMetricSink = createClickHouseRowSink(client, "output_char_metrics", options);
     const rateLimitSink = createClickHouseRowSink(client, "rate_limit_samples", options);
     const telemetrySink = createClickHouseRowSink(client, "telemetry_events", options);
     const report = newReport();
-    report._usageEventSink = (event) => usageSink.push(clickHouseUsageEventRow(event, source.path, importId));
-    report._outputCharMetricSink = (event) => outputCharMetricSink.push(clickHouseOutputCharMetricRow(event, source.path, importId));
-    report._rateLimitSampleSink = (sample) => rateLimitSink.push(clickHouseRateLimitSampleRow(sample, source.path, importId));
-    report._telemetryEventSink = (event) => telemetrySink.push(clickHouseTelemetryEventRow(event, source.path, importId));
+    report._usageEventSink = (event) => usageSink.push(clickHouseUsageEventRow(event, source.path, importId, source.segmentEnd));
+    report._outputCharMetricSink = (event) => outputCharMetricSink.push(clickHouseOutputCharMetricRow({
+      ...event,
+      metricRevision: source.segmentEnd,
+    }, source.path, importId));
+    report._rateLimitSampleSink = (sample) => rateLimitSink.push(clickHouseRateLimitSampleRow(sample, source.path, importId, source.segmentEnd));
+    report._telemetryEventSink = (event) => telemetrySink.push(clickHouseTelemetryEventRow(event, source.path, importId, source.segmentEnd));
     report._afterLine = () => drainClickHouseSinks([usageSink, outputCharMetricSink, rateLimitSink, telemetrySink]);
 
+    let processingResult = null;
     if (source.kind === "jsonl") {
-      await processJsonlFile(source.path, report, options);
+      processingResult = await processJsonlFile(source.path, report, options, source.inputMeta || null);
     } else if (source.kind === "zip-entry") {
       await processZipEntry(source.archivePath, source.entry, report, options);
     } else {
@@ -1117,15 +1456,16 @@ function createClickHouseBackend(dependencies = {}) {
     await outputCharMetricSink.finish();
     await rateLimitSink.finish();
     await telemetrySink.finish();
-    await clickHouseInsertRows(client, "sessions", report.sessions.map((session) => clickHouseSessionRow(session, importId)), options);
+    await clickHouseInsertRows(client, "sessions", report.sessions.map((session) => clickHouseSessionRow(session, importId, source)), options);
     // Insert the marker only after every source-owned table has been written.
-    await clickHouseInsertRows(client, "sources", [clickHouseSourceRow(source, fingerprint, importId)], options);
+    source.cursorLine = processingResult?.lineNo || source.cursorLine || 0;
+    source.parserCheckpoint = processingResult?.parserCheckpoint || null;
+    const sourceRow = clickHouseSourceRow(source, fingerprint, importId);
+    await clickHouseInsertRows(client, "sources", [sourceRow], options);
     return {
       report,
       sourceState: {
-        source_path: source.path,
-        import_id: importId,
-        fingerprint,
+        ...sourceRow,
       },
     };
   }
@@ -1146,6 +1486,46 @@ function createClickHouseBackend(dependencies = {}) {
     await sink.finish();
   }
 
+  function clickHouseAppendableJsonlInput(input) {
+    return input.path.endsWith(".jsonl") && ![
+      "cursor",
+      "grok",
+      "pi",
+      "gemini",
+      "qwen",
+      "opencode",
+    ].includes(input.adapter);
+  }
+
+  function hasClickHouseResumableCursor(sourceState) {
+    return (
+      Number(sourceState?.cursor_version) === APPEND_CURSOR_VERSION
+      && Boolean(sourceState?.parser_checkpoint)
+      && Boolean(sourceState?.cursor_guard)
+      && Boolean(sourceState?.cursor_prefix_guard)
+      && sourceState?.file_device !== undefined
+      && sourceState?.file_device !== null
+      && sourceState?.file_inode !== undefined
+      && sourceState?.file_inode !== null
+    );
+  }
+
+  async function preflightClickHouseAppendSources(preparedInputs, changedSourcePaths, sourceStates) {
+    for (const input of preparedInputs) {
+      if (
+        input.kind !== "jsonl"
+        || changedSourcePaths.has(input.path)
+        || !clickHouseAppendableJsonlInput(input)
+      ) continue;
+      const sourceState = sourceStates.get(input.path);
+      if (!hasClickHouseResumableCursor(sourceState)) continue;
+      const current = await inspectAppendFile(input.path, input.stat);
+      const plan = await validateAppendCursor(input.path, sourceState, current);
+      input.clickHouseAppendPreflight = { current, plan };
+      if (plan.mode !== "unchanged") changedSourcePaths.add(input.path);
+    }
+  }
+
   async function syncClickHouseJsonlSource(client, input, sourceStates, options) {
     const stat = input.stat || await fsp.stat(input.path);
     const fingerprint = sourceFingerprint({
@@ -1154,20 +1534,105 @@ function createClickHouseBackend(dependencies = {}) {
       mtimeMs: stat.mtimeMs,
     });
     const sourceState = sourceStates.get(input.path);
-    // An unchanged source is already committed and must not enter cleanup.
-    if (sameSourceFingerprint(sourceState?.fingerprint, fingerprint)) return false;
+    const appendable = clickHouseAppendableJsonlInput(input);
+    if (!appendable) {
+      // Other formats have no resumable cursor, so their source fingerprint is
+      // the only cheap unchanged-source authority.
+      if (sameSourceFingerprint(sourceState?.fingerprint, fingerprint)) return false;
+      const staged = await processAndStoreClickHouseSource(client, {
+        kind: "jsonl",
+        path: input.path,
+        sizeBytes: stat.size,
+        inputMeta: input,
+      }, fingerprint, options);
+      sourceStates.set(input.path, staged.sourceState);
+      return staged.sourceState;
+    }
 
-    const source = {
-      kind: "jsonl",
-      path: input.path,
-      sizeBytes: stat.size,
+    // Legacy and deliberately non-resumable parser states still use the source
+    // fingerprint. They have no cursor contract that a bounded guard can prove.
+    if (
+      sameSourceFingerprint(sourceState?.fingerprint, fingerprint)
+      && !hasClickHouseResumableCursor(sourceState)
+    ) return false;
+
+    // Append-only sources always validate the bounded cursor guards, even if a
+    // producer preserves size and mtime while rewriting bytes in place.
+    const preflight = input.clickHouseAppendPreflight || null;
+    const current = preflight?.current || await inspectAppendFile(input.path, stat);
+    if (!sourceState && current.completeOffset === 0) return false;
+    let plan = { mode: "full", reason: "new-source", start: 0, end: current.completeOffset };
+    if (sourceState && number(sourceState.active_import_count) > 1) {
+      plan = { mode: "full", reason: "legacy-multi-import-manifest" };
+    } else if (sourceState) {
+      plan = preflight?.plan || await validateAppendCursor(input.path, sourceState, current);
+    }
+    if (plan.mode === "unchanged") return false;
+    if (plan.mode === "full") {
+      plan.start = 0;
+      plan.end = current.completeOffset;
+    }
+    if (plan.end <= plan.start) return false;
+
+    let parserCheckpoint = null;
+    if (plan.mode === "append") {
+      try {
+        parserCheckpoint = JSON.parse(sourceState.parser_checkpoint);
+      } catch {
+        plan = { mode: "full", reason: "invalid-checkpoint", start: 0, end: current.completeOffset };
+      }
+    }
+
+    const stageRange = async (rangePlan, checkpoint = null) => {
+      const source = {
+        kind: "jsonl",
+        path: input.path,
+        importId: rangePlan.mode === "append" ? sourceState.import_id : null,
+        sizeBytes: stat.size,
+        cursorVersion: APPEND_CURSOR_VERSION,
+        segmentStart: rangePlan.start,
+        segmentEnd: rangePlan.end,
+        cursorGuard: current.guard,
+        cursorPrefixGuard: current.prefixGuard,
+        fileDevice: current.device,
+        fileInode: current.inode,
+        inputMeta: {
+          ...input,
+          range: {
+            start: rangePlan.start,
+            end: rangePlan.end,
+            lineNoOffset: rangePlan.mode === "append" ? number(sourceState.cursor_line) : 0,
+            parserCheckpoint: checkpoint,
+          },
+        },
+      };
+      return processAndStoreClickHouseSource(client, source, fingerprint, options);
     };
-    const staged = await processAndStoreClickHouseSource(client, source, fingerprint, options);
-    sourceStates.set(input.path, staged.sourceState);
-    return staged.sourceState;
+
+    const assertSourceStable = async () => {
+      const postStat = await fsp.stat(input.path);
+      const sourceStable = (
+        String(postStat.dev) === current.device &&
+        String(postStat.ino) === current.inode &&
+        await appendGuard(input.path, plan.end) === current.guard &&
+        await appendPrefixGuard(input.path, plan.end) === current.prefixGuard
+      );
+      if (!sourceStable) throw new Error(`JSONL source changed while importing: ${input.path}`);
+    };
+    let staged = await stageRange(plan, parserCheckpoint);
+    await assertSourceStable();
+    if (plan.mode === "append" && !staged.sourceState.parser_checkpoint) {
+      plan = { mode: "full", reason: "checkpoint-became-unsafe", start: 0, end: current.completeOffset };
+      staged = await stageRange(plan);
+      await assertSourceStable();
+    }
+
+    const nextState = staged.sourceState;
+    sourceStates.set(input.path, nextState);
+    return nextState;
   }
 
-  async function syncClickHouseZipSource(client, input, sourceStates, changedSources, options, limiter) {
+  async function syncClickHouseZipSource(client, input, sourceStates, changedSources, manifestChanges, options, limiter) {
     const stat = input.stat || await fsp.stat(input.path);
     const entries = input.entries || (await listZipEntries(input.path))
       .filter((entry) => entry.fileName.endsWith(".jsonl"))
@@ -1180,6 +1645,7 @@ function createClickHouseBackend(dependencies = {}) {
     for (const sourcePath of sourceStates.keys()) {
       if (sourcePath.startsWith(archivePrefix) && !presentSources.has(sourcePath)) {
         sourceStates.delete(sourcePath);
+        manifestChanges.add(sourcePath);
         removed += 1;
       }
     }
@@ -1213,6 +1679,7 @@ function createClickHouseBackend(dependencies = {}) {
       const staged = await processAndStoreClickHouseSource(client, source, fingerprint, options);
       sourceStates.set(sourcePath, staged.sourceState);
       changedSources.add(sourcePath);
+      manifestChanges.add(sourcePath);
       changed += 1;
     }
     return { changed, manifestChanged: changed > 0 || removed > 0 };
@@ -1266,13 +1733,43 @@ function createClickHouseBackend(dependencies = {}) {
     };
   }
 
-  function clickHouseGenerationJoin(table, alias = table) {
+  function clickHouseLogicalKey(table, alias = "raw") {
+    if (table === "usage_events") {
+      return [`if(${alias}.event_key = '', concat('line:', toString(${alias}.line_no)), ${alias}.event_key)`];
+    }
+    if (table === "output_char_metrics") {
+      return [`if(${alias}.turn_key = '', concat('legacy:', ${alias}.turn_id, ':', ifNull(${alias}.timestamp, ''), ':', toString(${alias}.visible_output_chars), ':', toString(${alias}.visible_output_tokens)), ${alias}.turn_key)`];
+    }
+    if (table === "rate_limit_samples") return [`${alias}.line_no`, `${alias}.sample_key`, `${alias}.sequence`];
+    if (table === "telemetry_events") return [`${alias}.line_no`, `${alias}.event_kind`];
+    return [`${alias}.line_no`];
+  }
+
+  function clickHouseCommittedRowsDefinition(table, name) {
+    const activeName = `${name}_active`;
+    const logicalKey = clickHouseLogicalKey(table, activeName);
+    const commitRevision = table === "output_char_metrics" ? "metric_revision" : "segment_end";
+    const order = table === "output_char_metrics"
+      ? `${activeName}.metric_revision DESC`
+      : `${activeName}.line_no ASC`;
     return `
-      FROM ${table} AS ${alias}
-      INNER JOIN import_generation_sources AS manifest
-        ON manifest.source_path = ${alias}.source_path
-        AND manifest.import_id = ${alias}.import_id
-      WHERE manifest.generation_id = {generation:String}
+      ${activeName} AS (
+        SELECT raw.*
+        FROM ${table} AS raw
+        INNER JOIN active_manifest AS manifest
+          ON manifest.source_path = raw.source_path
+          AND manifest.import_id = raw.import_id
+          AND (
+            isNull(manifest.committed_segment_end)
+            OR raw.${commitRevision} <= manifest.committed_segment_end
+          )
+      ),
+      ${name} AS (
+        SELECT *
+        FROM ${activeName}
+        ORDER BY ${order}
+        LIMIT 1 BY ${activeName}.source_path, ${activeName}.import_id, ${logicalKey.join(", ")}
+      )
     `;
   }
 
@@ -1282,13 +1779,11 @@ function createClickHouseBackend(dependencies = {}) {
     const contextSource = `${name}_context`;
     const pricedSource = `${name}_pricing`;
     return `
+      ${clickHouseActiveManifestDefinitions()},
+      ${clickHouseCommittedRowsDefinition(table, `${name}_committed`)},
       ${longSource} AS (
         SELECT raw.*, ${pricing.hasLongExpression} AS has_long_price
-        FROM ${table} AS raw
-        INNER JOIN import_generation_sources AS manifest
-          ON manifest.source_path = raw.source_path
-          AND manifest.import_id = raw.import_id
-        WHERE manifest.generation_id = {generation:String}
+        FROM ${name}_committed AS raw
       ),
       ${contextSource} AS (
         SELECT raw.*, ${pricing.useLongExpression} AS use_long_price
@@ -1355,33 +1850,25 @@ function createClickHouseBackend(dependencies = {}) {
   function clickHouseGenerationCte(table, name, configuration) {
     if (!configuration) {
       return `
-        WITH ${name} AS (
-          SELECT raw.*
-          FROM ${table} AS raw
-          INNER JOIN import_generation_sources AS manifest
-            ON manifest.source_path = raw.source_path
-            AND manifest.import_id = raw.import_id
-          WHERE manifest.generation_id = {generation:String}
-        )
+        WITH ${clickHouseActiveManifestDefinitions()},
+        ${clickHouseCommittedRowsDefinition(table, name)}
       `;
     }
     const replacements = CLICKHOUSE_COST_COLUMNS.map((column) => (
       `if(costs.pricing_revision = '', raw.${column}, costs.${column}) AS ${column}`
     )).join(",\n          ");
     return `
-      WITH ${name} AS (
+      WITH ${clickHouseActiveManifestDefinitions()},
+      ${clickHouseCommittedRowsDefinition(table, `${name}_raw`)},
+      ${name} AS (
         SELECT
           raw.* REPLACE (${replacements})
-        FROM ${table} AS raw
-        INNER JOIN import_generation_sources AS manifest
-          ON manifest.source_path = raw.source_path
-          AND manifest.import_id = raw.import_id
+        FROM ${name}_raw AS raw
         LEFT JOIN usage_event_costs AS costs
           ON costs.pricing_revision = {pricingRevision:String}
           AND costs.source_path = raw.source_path
           AND costs.import_id = raw.import_id
           AND costs.line_no = raw.line_no
-        WHERE manifest.generation_id = {generation:String}
       )
     `;
   }
@@ -1399,6 +1886,7 @@ function createClickHouseBackend(dependencies = {}) {
     "service_tier",
     "service_mode",
     "agent",
+    "source_path",
   ];
 
   const CLICKHOUSE_USAGE_GROUPS = [
@@ -1424,6 +1912,7 @@ function createClickHouseBackend(dependencies = {}) {
     { bucket: "agents", grouped: ["agent"], keys: ["agent"] },
     { bucket: "modelEfforts", grouped: ["model", "effort"], keys: ["model", "effort"] },
     { bucket: "providerModelEffortDaily", grouped: ["provider", "model", "effort", "date_key"], keys: ["provider", "model", "effort", "date_key"] },
+    { bucket: "sourceStats", grouped: ["source_path"], keys: ["source_path"] },
   ];
 
   function clickHouseUsageGroupingMask(grouped) {
@@ -1523,9 +2012,11 @@ function createClickHouseBackend(dependencies = {}) {
       clickHouseGenerationCte("usage_events", "committed_usage_events", configuration),
     ), { params: { generation: generationId, pricingRevision: configuration.settings.pricingRevision } });
 
+    const sourceStats = new Map();
     for (const row of rows) {
       const stats = aggregateStatsFromRow(row);
-      if (row.bucket === "total") report.total = stats;
+      if (row.bucket === "sourceStats") sourceStats.set(row.key1, stats);
+      else if (row.bucket === "total") report.total = stats;
       else if (row.bucket === "quarterHourly") report.quarterHourly[row.key1] = stats;
       else if (row.bucket === "quarterHourlyProviderModels") {
         report.quarterHourlyProviderModels[row.key1] ??= {};
@@ -1573,6 +2064,7 @@ function createClickHouseBackend(dependencies = {}) {
         Object.assign(target, stats);
       }
     }
+    return sourceStats;
   }
 
   function mergeOutputCharMetricStats(target, row) {
@@ -1593,12 +2085,69 @@ function createClickHouseBackend(dependencies = {}) {
       : Math.max(target.outputCharsPerTokenMax, max);
   }
 
-  function clickHouseOutputCharStatsSelect(bucketName, key1Expr, key2Expr = "''", groupBy = "") {
-    return `
+  const CLICKHOUSE_OUTPUT_CHAR_GROUPING_DIMENSIONS = [
+    "date_key",
+    "week_key",
+    "month_key",
+    "year_key",
+    "provider",
+    "model",
+    "project",
+    "effort",
+    "source_path",
+  ];
+
+  const CLICKHOUSE_OUTPUT_CHAR_GROUPS = [
+    { bucket: "total", grouped: [] },
+    { bucket: "daily", grouped: ["date_key"], keys: ["date_key"] },
+    { bucket: "weekly", grouped: ["week_key"], keys: ["week_key"] },
+    { bucket: "monthly", grouped: ["month_key"], keys: ["month_key"] },
+    { bucket: "yearly", grouped: ["year_key"], keys: ["year_key"] },
+    { bucket: "providers", grouped: ["provider"], keys: ["provider"] },
+    { bucket: "models", grouped: ["model"], keys: ["model"] },
+    { bucket: "providerModels", grouped: ["provider", "model"], keys: ["concat(provider, '/', model)"] },
+    { bucket: "projects", grouped: ["project"], keys: ["project"] },
+    { bucket: "projectDaily", grouped: ["project", "date_key"], keys: ["project", "date_key"] },
+    { bucket: "projectModels", grouped: ["project", "model"], keys: ["project", "model"] },
+    { bucket: "efforts", grouped: ["effort"], keys: ["effort"] },
+    { bucket: "modelEfforts", grouped: ["model", "effort"], keys: ["model", "effort"] },
+    { bucket: "sourceStats", grouped: ["source_path"], keys: ["source_path"] },
+  ];
+
+  function clickHouseOutputCharGroupingMask(grouped) {
+    return CLICKHOUSE_OUTPUT_CHAR_GROUPING_DIMENSIONS.reduce((mask, dimension, index) => (
+      grouped.includes(dimension)
+        ? mask
+        : mask | (1 << (CLICKHOUSE_OUTPUT_CHAR_GROUPING_DIMENSIONS.length - index - 1))
+    ), 0);
+  }
+
+  function clickHouseOutputCharGroupExpression(selector) {
+    const branches = [];
+    for (const group of CLICKHOUSE_OUTPUT_CHAR_GROUPS) {
+      const value = selector(group);
+      if (value === null || value === undefined) continue;
+      branches.push(`groupingMask = ${clickHouseOutputCharGroupingMask(group.grouped)}, ${value}`);
+    }
+    return `multiIf(\n          ${branches.join(",\n          ")},\n          '')`;
+  }
+
+  function clickHouseOutputCharStatsQuery(generationCte) {
+    const groupingExpression = `grouping(${CLICKHOUSE_OUTPUT_CHAR_GROUPING_DIMENSIONS.join(", ")})`;
+    const bucketExpression = clickHouseOutputCharGroupExpression((group) => `'${group.bucket}'`);
+    const keyExpressions = [0, 1].map((keyIndex) => (
+      clickHouseOutputCharGroupExpression((group) => group.keys?.[keyIndex])
+    ));
+    const groupingSets = CLICKHOUSE_OUTPUT_CHAR_GROUPS.map((group) => (
+      group.grouped.length > 0 ? `(${group.grouped.join(", ")})` : "()"
+    )).join(",\n        ");
+
+    return `${generationCte}
       SELECT
-        '${bucketName}' AS bucket,
-        ${key1Expr} AS key1,
-        ${key2Expr} AS key2,
+        ${groupingExpression} AS groupingMask,
+        ${bucketExpression} AS bucket,
+        ${keyExpressions[0]} AS key1,
+        ${keyExpressions[1]} AS key2,
         sumIf(visible_output_chars, output_chars_per_token > 0 AND output_chars_per_token <= ${MAX_VALID_OUTPUT_CHARS_PER_TOKEN}) AS visibleOutputTextChars,
         sumIf(visible_output_tokens, output_chars_per_token > 0 AND output_chars_per_token <= ${MAX_VALID_OUTPUT_CHARS_PER_TOKEN}) AS visibleOutputTextTokens,
         countIf(output_chars_per_token > 0 AND output_chars_per_token <= ${MAX_VALID_OUTPUT_CHARS_PER_TOKEN}) AS outputCharTokenSamples,
@@ -1607,7 +2156,9 @@ function createClickHouseBackend(dependencies = {}) {
         maxIf(output_chars_per_token, output_chars_per_token > 0 AND output_chars_per_token <= ${MAX_VALID_OUTPUT_CHARS_PER_TOKEN}) AS outputCharsPerTokenMax,
         countIf(output_chars_per_token > ${MAX_VALID_OUTPUT_CHARS_PER_TOKEN}) AS outputCharTokenOutliers
       FROM committed_output_char_metrics AS output_char_metrics
-      ${groupBy}
+      GROUP BY GROUPING SETS (
+        ${groupingSets}
+      )
     `;
   }
 
@@ -1628,27 +2179,19 @@ function createClickHouseBackend(dependencies = {}) {
     return null;
   }
 
-  async function applyClickHouseOutputCharMetrics(client, report, generationId) {
-    const rows = await clickHouseJsonEachRow(client, clickHouseGenerationCte("output_char_metrics", "committed_output_char_metrics") + [
-      clickHouseOutputCharStatsSelect("total", "''"),
-      clickHouseOutputCharStatsSelect("daily", "date_key", "''", "GROUP BY date_key"),
-      clickHouseOutputCharStatsSelect("weekly", "week_key", "''", "GROUP BY week_key"),
-      clickHouseOutputCharStatsSelect("monthly", "month_key", "''", "GROUP BY month_key"),
-      clickHouseOutputCharStatsSelect("yearly", "year_key", "''", "GROUP BY year_key"),
-      clickHouseOutputCharStatsSelect("providers", "provider", "''", "GROUP BY provider"),
-      clickHouseOutputCharStatsSelect("models", "model", "''", "GROUP BY model"),
-      clickHouseOutputCharStatsSelect("providerModels", "concat(provider, '/', model)", "''", "GROUP BY provider, model"),
-      clickHouseOutputCharStatsSelect("projects", "project", "''", "GROUP BY project"),
-      clickHouseOutputCharStatsSelect("projectDaily", "project", "date_key", "GROUP BY project, date_key"),
-      clickHouseOutputCharStatsSelect("projectModels", "project", "model", "GROUP BY project, model"),
-      clickHouseOutputCharStatsSelect("efforts", "effort", "''", "GROUP BY effort"),
-      clickHouseOutputCharStatsSelect("modelEfforts", "model", "effort", "GROUP BY model, effort"),
-    ].join("\nUNION ALL\n"), { params: { generation: generationId } });
+  async function applyClickHouseOutputCharMetrics(client, report, generationId, sourceStats = new Map()) {
+    const rows = await clickHouseJsonEachRow(client, clickHouseOutputCharStatsQuery(
+      clickHouseGenerationCte("output_char_metrics", "committed_output_char_metrics"),
+    ), { params: { generation: generationId } });
 
     for (const row of rows) {
-      const target = outputCharTargetForBucket(report, row);
+      const target = row.bucket === "sourceStats"
+        ? (sourceStats.get(row.key1) || newStats())
+        : outputCharTargetForBucket(report, row);
+      if (row.bucket === "sourceStats") sourceStats.set(row.key1, target);
       if (target) mergeOutputCharMetricStats(target, row);
     }
+    return sourceStats;
   }
 
   async function applyClickHouseOutputCharQuantiles(client, report, generationId) {
@@ -1694,17 +2237,61 @@ function createClickHouseBackend(dependencies = {}) {
     }
   }
 
-  async function applyClickHouseSessions(client, report, generationId) {
+  function mergeStoredStats(target, source) {
+    for (const [key, value] of Object.entries(source)) {
+      if (key === "costsUsd") {
+        for (const [costKey, costValue] of Object.entries(value || {})) {
+          target.costsUsd[costKey] = number(target.costsUsd[costKey]) + number(costValue);
+        }
+      } else if (key.endsWith("Min")) {
+        if (value !== null && value !== undefined) {
+          target[key] = target[key] === null ? number(value) : Math.min(number(target[key]), number(value));
+        }
+      } else if (key.endsWith("Max")) {
+        if (value !== null && value !== undefined) {
+          target[key] = target[key] === null ? number(value) : Math.max(number(target[key]), number(value));
+        }
+      } else if (!key.endsWith("P10") && !key.endsWith("P99")) {
+        target[key] = typeof value === "number"
+          ? number(target[key]) + value
+          : value ?? target[key];
+      }
+    }
+    return target;
+  }
+
+  async function applyClickHouseSessions(client, report, generationId, sourceStats = new Map()) {
     const rows = await clickHouseJsonEachRow(client, `
+      WITH ${clickHouseActiveManifestDefinitions()},
+      committed_sessions_active AS (
+        SELECT sessions.*
+        FROM sessions
+        INNER JOIN active_manifest AS manifest
+          ON manifest.source_path = sessions.source_path
+          AND manifest.import_id = sessions.import_id
+          AND (
+            isNull(manifest.committed_segment_end)
+            OR sessions.segment_end <= manifest.committed_segment_end
+          )
+      ),
+      committed_sessions AS (
+        SELECT *
+        FROM committed_sessions_active
+        ORDER BY segment_end DESC
+        LIMIT 1 BY source_path, import_id, segment_start, segment_end
+      )
       SELECT
         kind, source_path, archive_path, entry_name, size_bytes, compressed_size_bytes,
         started_at, finished_at, duration_ms, lines, records, parse_errors,
         token_count_snapshots, skipped_token_count_snapshots, stats_json
-      ${clickHouseGenerationJoin("sessions")}
+      FROM committed_sessions
       ORDER BY source_path
     `, { params: { generation: generationId } });
+    const sessions = new Map();
     for (const row of rows) {
-      report.sessions.push({
+      const existing = sessions.get(row.source_path);
+      if (!existing) {
+        sessions.set(row.source_path, {
         kind: row.kind,
         path: row.source_path,
         archivePath: row.archive_path || null,
@@ -1720,21 +2307,47 @@ function createClickHouseBackend(dependencies = {}) {
         tokenCountSnapshots: number(row.token_count_snapshots),
         skippedTokenCountSnapshots: number(row.skipped_token_count_snapshots),
         stats: parseStoredStats(row.stats_json),
-      });
+        });
+        continue;
+      }
+      existing.sizeBytes += number(row.size_bytes);
+      existing.compressedSizeBytes += number(row.compressed_size_bytes);
+      if (row.started_at && (!existing.startedAt || row.started_at < existing.startedAt)) existing.startedAt = row.started_at;
+      if (row.finished_at && (!existing.finishedAt || row.finished_at > existing.finishedAt)) existing.finishedAt = row.finished_at;
+      existing.durationMs += number(row.duration_ms);
+      existing.lines += number(row.lines);
+      existing.records += number(row.records);
+      existing.parseErrors += number(row.parse_errors);
+      existing.tokenCountSnapshots += number(row.token_count_snapshots);
+      existing.skippedTokenCountSnapshots += number(row.skipped_token_count_snapshots);
+      mergeStoredStats(existing.stats, parseStoredStats(row.stats_json));
+    }
+    for (const session of sessions.values()) {
+      if (sourceStats.has(session.path)) {
+        session.stats = {
+          ...session.stats,
+          ...sourceStats.get(session.path),
+        };
+      }
+      report.sessions.push(session);
     }
   }
 
   async function applyClickHouseSources(client, report, generationId) {
     const rows = await clickHouseJsonEachRow(client, `
+      WITH ${clickHouseActiveManifestDefinitions()}
       SELECT
-        countIf(kind = 'jsonl') AS files,
-        countIf(kind = 'zip-entry') AS zipEntries,
+        uniqExactIf(source.source_path, kind = 'jsonl') AS files,
+        uniqExactIf(source.source_path, kind = 'zip-entry') AS zipEntries,
         uniqExactIf(archive_path, kind = 'zip-entry' AND archive_path != '') AS zipFiles
       FROM sources AS source
-      INNER JOIN import_generation_sources AS manifest
+      INNER JOIN active_manifest AS manifest
         ON manifest.source_path = source.source_path
         AND manifest.import_id = source.import_id
-      WHERE manifest.generation_id = {generation:String}
+        AND (
+          isNull(manifest.committed_segment_end)
+          OR source.segment_end <= manifest.committed_segment_end
+        )
     `, { params: { generation: generationId } });
     const row = rows[0] || {};
     report.sources.files = number(row.files);
@@ -1765,7 +2378,8 @@ function createClickHouseBackend(dependencies = {}) {
 
   function clickHouseRateLimitCte(configuration) {
     return `
-      WITH
+      WITH ${clickHouseActiveManifestDefinitions()},
+      ${clickHouseCommittedRowsDefinition("rate_limit_samples", "committed_rate_limit_samples")},
       repriced_samples AS (
         SELECT
           raw.source_path AS source_path,
@@ -1799,10 +2413,7 @@ function createClickHouseBackend(dependencies = {}) {
           raw.sequence AS sample_sequence,
           raw.source_path AS sample_source_path,
           raw.line_no AS sample_line_no
-        FROM rate_limit_samples AS raw
-        INNER JOIN import_generation_sources AS manifest
-          ON manifest.source_path = raw.source_path
-          AND manifest.import_id = raw.import_id
+        FROM committed_rate_limit_samples AS raw
         LEFT JOIN rate_limit_sample_costs AS costs
           ON costs.pricing_revision = {pricingRevision:String}
           AND costs.source_path = raw.source_path
@@ -1810,7 +2421,6 @@ function createClickHouseBackend(dependencies = {}) {
           AND costs.line_no = raw.line_no
           AND costs.sample_key = raw.sample_key
           AND costs.sequence = raw.sequence
-        WHERE manifest.generation_id = {generation:String}
       ),
       ordered AS (
         SELECT
@@ -2026,6 +2636,7 @@ function createClickHouseBackend(dependencies = {}) {
 
     for (const row of aggregateRows) {
       if (row.attr_type === "bucket") continue;
+      if (!report.rateLimits[row.bucket_type]) continue;
       const stats = report.rateLimits[row.bucket_type][row.bucket_key];
       if (!stats) continue;
       const attribution = rateLimitAttributionFromAggregate(row);
@@ -2058,6 +2669,7 @@ function createClickHouseBackend(dependencies = {}) {
       existingFingerprint: (sourcePath) => sourceStates.get(sourcePath)?.fingerprint || null,
       sourceFingerprint: fingerprintForConfiguration,
     });
+    await preflightClickHouseAppendSources(preparedInputs, changedSourcePaths, sourceStates);
     emitSyncProgress(options, {
       phase: "processing",
       totalSources,
@@ -2076,6 +2688,7 @@ function createClickHouseBackend(dependencies = {}) {
     }, preparedInputs);
     const limiter = createLimiter(options.limitFiles);
     const changedSources = new Set();
+    const manifestChanges = new Set();
     let manifestChanged = false;
     let changed = 0;
     for (const input of preparedInputs) {
@@ -2083,11 +2696,12 @@ function createClickHouseBackend(dependencies = {}) {
         if (!limiter.take()) continue;
         if (await syncClickHouseJsonlSource(client, input, sourceStates, processingOptions)) {
           changedSources.add(input.path);
+          manifestChanges.add(input.path);
           manifestChanged = true;
           changed += 1;
         }
       } else if (input.kind === "zip") {
-        const zipResult = await syncClickHouseZipSource(client, input, sourceStates, changedSources, processingOptions, limiter);
+        const zipResult = await syncClickHouseZipSource(client, input, sourceStates, changedSources, manifestChanges, processingOptions, limiter);
         if (zipResult.manifestChanged) manifestChanged = true;
         changed += zipResult.changed;
       }
@@ -2095,6 +2709,7 @@ function createClickHouseBackend(dependencies = {}) {
     if (removeSupersededClickHouseSources(
       sourceStates,
       changedSources,
+      manifestChanges,
       processingOptions.codexForkRegistry?.currentHeaders,
       persistedCodexSessionHeaders,
     ) > 0) {
@@ -2108,11 +2723,18 @@ function createClickHouseBackend(dependencies = {}) {
         changedSources,
         processingOptions,
       );
+      const checkpointManifest = !committed || (
+        await clickHouseManifestDeltaGenerations(client, committed.generation_id)
+        >= CLICKHOUSE_MANIFEST_CHECKPOINT_INTERVAL
+      );
       committed = await commitClickHouseGeneration(
         client,
         sourceStates,
         committed?.committed_at_ms,
+        committed?.generation_id,
         processingOptions,
+        manifestChanges,
+        checkpointManifest,
       );
     }
     emitSyncProgress(options, {
@@ -2135,10 +2757,10 @@ function createClickHouseBackend(dependencies = {}) {
       || (await ensureClickHouseBaselineGeneration(client, options))?.generation_id
       || "";
     const report = newReport();
-    await applyClickHouseUsageStats(client, report, generationId, configuration);
-    await applyClickHouseOutputCharMetrics(client, report, generationId);
+    const sourceStats = await applyClickHouseUsageStats(client, report, generationId, configuration);
+    await applyClickHouseOutputCharMetrics(client, report, generationId, sourceStats);
     await applyClickHouseOutputCharQuantiles(client, report, generationId);
-    await applyClickHouseSessions(client, report, generationId);
+    await applyClickHouseSessions(client, report, generationId, sourceStats);
     await applyClickHouseSources(client, report, generationId);
     await applyClickHouseUnpricedModels(client, report, generationId, configuration);
     await applyClickHouseRateLimits(client, report, generationId, configuration);

--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -3,6 +3,7 @@
 const http = require("node:http");
 const { URL } = require("node:url");
 const dashboard = require("./dashboard");
+const { newReport } = require("./core/report-model");
 
 const MAX_SYNC_EVENT_CLIENTS = 16;
 const MAX_CONFIGURATION_BODY_BYTES = 1024 * 1024;
@@ -532,13 +533,16 @@ function createWebServer({
   async function startWebServer(options) {
     const db = resolveDbPath(options);
     const reportOptions = { ...options, db };
+    const autoStartSync = Boolean(options.webserverSync && typeof syncDatabase === "function");
+    const initialReport = options.preloadedReport
+      || (autoStartSync ? newReport() : null);
     const serverOptions = {
       ...reportOptions,
       syncAllowed: isLoopbackHost(options.host),
       syncEventResponses: new Set(),
       reportCache: options.reportCache || createReportCache(
         () => buildReportFromSelectedDatabase(reportOptions),
-        options.preloadedReport || null,
+        initialReport,
       ),
     };
     if (typeof syncDatabase === "function") {
@@ -566,6 +570,9 @@ function createWebServer({
         resolve();
       });
     });
+    // Make readiness independent from ingestion latency. Clients can observe
+    // the initial run through /api/sync while report routes remain responsive.
+    if (autoStartSync) server.syncController.start();
     return server;
   }
 

--- a/test/append-cursor.test.js
+++ b/test/append-cursor.test.js
@@ -1,0 +1,82 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const Path = require("node:path");
+const test = require("node:test");
+const {
+  APPEND_CURSOR_VERSION,
+  inspectAppendFile,
+  validateAppendCursor,
+} = require("../lib/ingest/append-cursor");
+
+function storedCursor(snapshot, parserCheckpoint = { kind: "codex" }) {
+  return {
+    cursor_version: APPEND_CURSOR_VERSION,
+    segment_end: snapshot.completeOffset,
+    cursor_guard: snapshot.guard,
+    cursor_prefix_guard: snapshot.prefixGuard,
+    parser_checkpoint: JSON.stringify(parserCheckpoint),
+    file_device: snapshot.device,
+    file_inode: snapshot.inode,
+  };
+}
+
+test("append cursor advances only through complete JSONL records", async () => {
+  const dir = fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-append-cursor-test-"));
+  const filename = Path.join(dir, "session.jsonl");
+  const firstLine = `${JSON.stringify({ id: 1 })}\n`;
+  fs.writeFileSync(filename, `${firstLine}{"id":`);
+
+  const first = await inspectAppendFile(filename);
+  assert.equal(first.completeOffset, Buffer.byteLength(firstLine));
+
+  fs.appendFileSync(filename, "2}\n");
+  const appended = await inspectAppendFile(filename);
+  const appendPlan = await validateAppendCursor(filename, storedCursor(first), appended);
+  assert.deepEqual(appendPlan, {
+    mode: "append",
+    reason: "verified-append",
+    start: first.completeOffset,
+    end: appended.completeOffset,
+  });
+});
+
+test("append cursor fails closed on guarded-prefix mutation, truncation, and rotation", async () => {
+  const dir = fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-append-guard-test-"));
+  const filename = Path.join(dir, "session.jsonl");
+  fs.writeFileSync(filename, `${JSON.stringify({ id: "original" })}\n`);
+  const original = await inspectAppendFile(filename);
+  const cursor = storedCursor(original);
+
+  fs.writeFileSync(filename, `${JSON.stringify({ id: "mutated!" })}\n${JSON.stringify({ id: 2 })}\n`);
+  assert.equal((await validateAppendCursor(filename, cursor, await inspectAppendFile(filename))).reason, "guard-mismatch");
+
+  fs.truncateSync(filename, 0);
+  assert.equal((await validateAppendCursor(filename, cursor, await inspectAppendFile(filename))).reason, "truncated");
+
+  fs.renameSync(filename, `${filename}.old`);
+  fs.writeFileSync(filename, `${JSON.stringify({ id: "replacement" })}\n`);
+  assert.equal((await validateAppendCursor(filename, cursor, await inspectAppendFile(filename))).reason, "missing-or-incompatible-cursor");
+});
+
+test("append cursor detects an earlier prefix rewrite outside the tail guard", async () => {
+  const dir = fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-prefix-guard-test-"));
+  const filename = Path.join(dir, "session.jsonl");
+  const lines = Array.from({ length: 700 }, (_, index) => JSON.stringify({ id: index, payload: "x".repeat(40) }));
+  fs.writeFileSync(filename, `${lines.join("\n")}\n`);
+  const original = await inspectAppendFile(filename);
+  const cursor = storedCursor(original);
+
+  const handle = fs.openSync(filename, "r+");
+  try {
+    fs.writeSync(handle, Buffer.from("MUTATED!"), 0, 8, 128);
+  } finally {
+    fs.closeSync(handle);
+  }
+  fs.appendFileSync(filename, `${JSON.stringify({ id: "tail" })}\n`);
+
+  const plan = await validateAppendCursor(filename, cursor, await inspectAppendFile(filename));
+  assert.equal(plan.reason, "prefix-guard-mismatch");
+});

--- a/test/clickhouse-pricing.test.js
+++ b/test/clickhouse-pricing.test.js
@@ -36,6 +36,7 @@ test("ClickHouse pricing projection applies packaged fast multipliers from servi
   assert.match(sql.projection, /= 'priority'/);
   assert.match(sql.projection, /= 'fast'/);
   assert.match(sql.projection, /2\.5/);
+  assert.match(sql.projection, /Z3B0LTYtYXN0cmE=/);
   assert.match(sql.projection, /, 2,/);
 
   const custom = defaultConfiguration();

--- a/test/clickhouse.test.js
+++ b/test/clickhouse.test.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const assert = require("node:assert/strict");
-const { execFileSync } = require("node:child_process");
+const { execFileSync, spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const http = require("node:http");
 const os = require("node:os");
@@ -11,6 +11,7 @@ const { buildReportFromClickHouse, loadConfiguration, saveConfiguration, syncDat
 const {
   ANALYTICS_DERIVATION_VERSION,
 } = require("../lib/core/derivation");
+const { CLAUDE_REQUEST_CHECKPOINT_LIMIT } = require("../lib/ingest/parser");
 const { createClickHouseBackend } = require("../lib/storage/clickhouse");
 const { defaultOptions } = require("./support/fixtures");
 
@@ -82,13 +83,83 @@ function createClickHouseServer({ failureStatus = null, failureBody = "", failur
     return current;
   }
 
+  function latestValidCheckpointRank(generations, targetIndex) {
+    const ranks = new Map(generations.slice(0, targetIndex + 1).map((row, index) => [row.generation_id, index]));
+    return (activeRows.import_generation_checkpoints || []).reduce((latest, checkpoint) => {
+      const rank = ranks.get(checkpoint.generation_id);
+      if (rank === undefined) return latest;
+      const previous = rank > 0 ? generations[rank - 1] : null;
+      const valid = checkpoint.base_generation_id === checkpoint.generation_id || (
+        (checkpoint.base_generation_id || "") === (previous?.generation_id || "")
+        && Number(checkpoint.base_committed_at_ms || 0) === Number(previous?.committed_at_ms || 0)
+      );
+      return valid ? Math.max(latest, rank) : latest;
+    }, -1);
+  }
+
   function visibleRows(table, generationId = latestGeneration()?.generation_id) {
-    const manifest = new Map((activeRows.import_generation_sources || [])
-      .filter((row) => row.generation_id === generationId)
-      .map((row) => [row.source_path, row.import_id || ""]));
-    return (activeRows[table] || []).filter((row) => (
-      manifest.get(row.source_path) === (row.import_id || "")
+    const generations = [...(activeRows.import_generations || [])].sort((a, b) => (
+      Number(a.committed_at_ms) - Number(b.committed_at_ms)
+      || String(a.generation_id).localeCompare(String(b.generation_id))
     ));
+    const targetIndex = generations.findIndex((row) => row.generation_id === generationId);
+    if (targetIndex < 0) return [];
+    const generationRank = new Map(generations.slice(0, targetIndex + 1).map((row, index) => [row.generation_id, index]));
+    const checkpointRank = latestValidCheckpointRank(generations, targetIndex);
+    const snapshotRank = checkpointRank < 0 ? targetIndex : checkpointRank;
+    const manifestHistory = [
+      ...(activeRows.import_generation_sources || []).filter((row) => (
+        generationRank.get(row.generation_id) === snapshotRank
+      )),
+      ...(activeRows.import_generation_source_deltas || []).filter((row) => (
+        generationRank.has(row.generation_id)
+        && generationRank.get(row.generation_id) > checkpointRank
+      )),
+    ];
+    const headRank = new Map();
+    for (const row of manifestHistory) {
+      const rank = generationRank.get(row.generation_id);
+      if (rank >= (headRank.get(row.source_path) ?? -1)) headRank.set(row.source_path, rank);
+    }
+    const manifest = manifestHistory.filter((row) => (
+      !row.deleted && generationRank.get(row.generation_id) === headRank.get(row.source_path)
+    ));
+    const watermarks = new Map();
+    for (const row of manifestHistory) {
+      if (row.deleted || row.committed_segment_end === undefined || row.committed_segment_end === null) continue;
+      const key = `${row.source_path}\0${row.import_id || ""}`;
+      watermarks.set(key, Math.max(watermarks.get(key) ?? 0, Number(row.committed_segment_end)));
+    }
+    const activeImports = new Map(manifest.map((row) => [
+      `${row.source_path}\0${row.import_id || ""}`,
+      watermarks.get(`${row.source_path}\0${row.import_id || ""}`) ?? null,
+    ]));
+    const rows = (activeRows[table] || []).filter((row) => {
+      const key = `${row.source_path}\0${row.import_id || ""}`;
+      if (!activeImports.has(key)) return false;
+      const committedSegmentEnd = activeImports.get(key);
+      if (committedSegmentEnd === null) return true;
+      const rowSegmentEnd = table === "output_char_metrics"
+        ? Number(row.metric_revision || 0)
+        : Number(row.segment_end || 0);
+      return rowSegmentEnd <= committedSegmentEnd;
+    });
+    const keyed = new Map();
+    for (const row of rows) {
+      let key = null;
+      if (table === "usage_events") key = `${row.source_path}\0${row.import_id || ""}\0${row.event_key || `line:${row.line_no || 0}`}`;
+      else if (table === "output_char_metrics") key = `${row.source_path}\0${row.import_id || ""}\0${row.turn_key || JSON.stringify(row)}`;
+      else if (table === "rate_limit_samples") key = `${row.source_path}\0${row.import_id || ""}\0${row.line_no || 0}\0${row.sample_key || ""}\0${row.sequence || 0}`;
+      else if (table === "telemetry_events") key = `${row.source_path}\0${row.import_id || ""}\0${row.line_no || 0}\0${row.event_kind || ""}`;
+      else if (table === "sessions") key = `${row.source_path}\0${row.import_id || ""}\0${row.segment_start || 0}\0${row.segment_end || 0}`;
+      else if (table === "sources") key = `${row.source_path}\0${row.import_id || ""}`;
+      if (key === null) return rows;
+      const previous = keyed.get(key);
+      if (!previous || Number(row.metric_revision || row.segment_end || 0) >= Number(previous.metric_revision || previous.segment_end || 0)) {
+        keyed.set(key, row);
+      }
+    }
+    return [...keyed.values()];
   }
 
   const server = http.createServer((request, response) => {
@@ -163,10 +234,50 @@ function createClickHouseServer({ failureStatus = null, failureBody = "", failur
         activeRows[table] = (activeRows[table] || []).filter((row) => row.source_path !== sourcePath);
       }
 
-      if (query.includes("FROM import_generations") && query.includes("committed_at_ms")) {
+      if (query.includes("FROM import_generations") && query.includes("ORDER BY committed_at_ms DESC")) {
         const generation = latestGeneration();
         response.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
         response.end(generation ? `${JSON.stringify(generation)}\n` : "");
+        return;
+      }
+
+      if (
+        query.includes("SELECT checkpoint.generation_id AS generation_id")
+        && query.includes("FROM import_generation_checkpoints AS checkpoint")
+      ) {
+        const targetGeneration = url.searchParams.get("param_generation");
+        const targetCommittedAt = Number(url.searchParams.get("param_committedAt"));
+        const checkpoint = [...(activeRows.import_generation_checkpoints || [])]
+          .filter((row) => (
+            Number(row.committed_at_ms) < targetCommittedAt
+            || (
+              Number(row.committed_at_ms) === targetCommittedAt
+              && String(row.generation_id).localeCompare(targetGeneration) <= 0
+            )
+          ))
+          .sort((a, b) => (
+            Number(b.committed_at_ms) - Number(a.committed_at_ms)
+            || String(b.generation_id).localeCompare(String(a.generation_id))
+          ))[0];
+        response.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
+        response.end(checkpoint ? `${JSON.stringify({ generation_id: checkpoint.generation_id })}\n` : "");
+        return;
+      }
+
+      if (query.includes("AS delta_generations") && query.includes("FROM manifest_deltas")) {
+        const targetGeneration = url.searchParams.get("param_generation");
+        const generations = [...(activeRows.import_generations || [])].sort((a, b) => (
+          Number(a.committed_at_ms) - Number(b.committed_at_ms)
+          || String(a.generation_id).localeCompare(String(b.generation_id))
+        ));
+        const targetRank = generations.findIndex((row) => row.generation_id === targetGeneration);
+        const ranks = new Map(generations.slice(0, targetRank + 1).map((row, index) => [row.generation_id, index]));
+        const checkpointRank = latestValidCheckpointRank(generations, targetRank);
+        const manifestGenerations = new Set((activeRows.import_generation_source_deltas || [])
+          .filter((row) => ranks.has(row.generation_id) && ranks.get(row.generation_id) > checkpointRank)
+          .map((row) => row.generation_id));
+        response.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
+        response.end(`${JSON.stringify({ delta_generations: manifestGenerations.size })}\n`);
         return;
       }
 
@@ -206,10 +317,30 @@ function createClickHouseServer({ failureStatus = null, failureBody = "", failur
 
       if (query.includes("FROM import_generation_sources") && query.includes("source.fingerprint")) {
         const generationId = url.searchParams.get("param_generation");
-        const rows = visibleRows("sources", generationId).map((row) => ({
+        const rowsBySource = new Map();
+        const importsBySource = new Map();
+        for (const row of visibleRows("sources", generationId)) {
+          importsBySource.set(row.source_path, (importsBySource.get(row.source_path) || new Set()).add(row.import_id || ""));
+          const previous = rowsBySource.get(row.source_path);
+          if (!previous || Number(row.segment_end || 0) >= Number(previous.segment_end || 0)) {
+            rowsBySource.set(row.source_path, row);
+          }
+        }
+        const rows = [...rowsBySource.values()].map((row) => ({
           source_path: row.source_path,
           import_id: row.import_id || "",
           fingerprint: row.fingerprint,
+          imported_at: row.imported_at || "",
+          cursor_version: row.cursor_version || 0,
+          segment_start: row.segment_start || 0,
+          segment_end: row.segment_end || 0,
+          cursor_line: row.cursor_line || 0,
+          cursor_guard: row.cursor_guard || "",
+          cursor_prefix_guard: row.cursor_prefix_guard || "",
+          parser_checkpoint: row.parser_checkpoint || "",
+          file_device: row.file_device || "",
+          file_inode: row.file_inode || "",
+          active_import_count: importsBySource.get(row.source_path)?.size || 0,
         }));
         response.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
         response.end(rows.map((row) => JSON.stringify(row)).join("\n") + (rows.length ? "\n" : ""));
@@ -230,6 +361,14 @@ function createClickHouseServer({ failureStatus = null, failureBody = "", failur
           rowsBySession.set(row.session_id, row);
         }
         const rows = [...rowsBySession.values()];
+        response.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
+        response.end(rows.map((row) => JSON.stringify(row)).join("\n") + (rows.length ? "\n" : ""));
+        return;
+      }
+
+      if (query.includes("FROM committed_sessions") && query.includes("stats_json")) {
+        const generationId = url.searchParams.get("param_generation");
+        const rows = visibleRows("sessions", generationId);
         response.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
         response.end(rows.map((row) => JSON.stringify(row)).join("\n") + (rows.length ? "\n" : ""));
         return;
@@ -269,7 +408,7 @@ function createClickHouseServer({ failureStatus = null, failureBody = "", failur
           pricedOutput: usageRows,
           pricedReasoningOutput: 0,
         })}\n`);
-      } else if (query.includes("FROM sources AS source") && query.includes("countIf")) {
+      } else if (query.includes("FROM sources AS source") && query.includes("uniqExactIf")) {
         response.end(JSON.stringify({ files: 1, zipEntries: 0, zipFiles: 0 }) + "\n");
       } else {
         response.end("");
@@ -349,7 +488,7 @@ test("ClickHouse packaged pricing upgrade publishes Opus 5 overlays before the r
     const requests = mock.requests.slice(before);
 
     assert.notEqual(upgraded.revision, legacyRevision);
-    assert.match(upgraded.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
+    assert.match(upgraded.settings.pricingRevision, /^packaged-5:[0-9a-f]{32}$/);
     assert.ok(upgraded.prices.some((row) => row.provider === "anthropic" && row.model === "claude-opus-5"));
     const usageOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO usage_event_costs"));
     const rateLimitOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO rate_limit_sample_costs"));
@@ -385,6 +524,18 @@ test("ClickHouse packaged-3 migration materializes temporal Luna and Terra rows 
       .filter((row) => temporalModels.has(row.model) && row.effective_from === currentFrom)
       .map((row) => [`${row.model}:${row.variant}`, row]));
     mock.activeRows.pricing_catalog = mock.activeRows.pricing_catalog.flatMap((row) => {
+      if (row.model === "gpt-6-astra") return [];
+      if (row.model === "gpt-5.6-sol") {
+        if (row.effective_until !== "2026-08-20T23:59:59.999Z") return [];
+        return [{
+          ...row,
+          revision: legacyRevision,
+          row_id: `${row.provider}:${row.model}:${row.variant}`,
+          effective_from: "",
+          effective_until: "",
+          source_url: "https://developers.openai.com/api/docs/pricing",
+        }];
+      }
       if (!temporalModels.has(row.model)) return [{ ...row, revision: legacyRevision }];
       if (row.effective_until !== historicalUntil) return [];
       const current = currentRows.get(`${row.model}:${row.variant}`);
@@ -406,8 +557,13 @@ test("ClickHouse packaged-3 migration materializes temporal Luna and Terra rows 
     const requests = mock.requests.slice(before);
 
     assert.notEqual(upgraded.revision, legacyRevision);
-    assert.match(upgraded.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
+    assert.match(upgraded.settings.pricingRevision, /^packaged-5:[0-9a-f]{32}$/);
     assert.ok(upgraded.prices.some((row) => row.provider === "anthropic" && row.model === "claude-opus-5"));
+    assert.ok(upgraded.prices.some((row) => row.provider === "openai" && row.model === "gpt-6-astra"));
+    const solRows = upgraded.prices.filter((row) => row.provider === "openai" && row.model === "gpt-5.6-sol");
+    assert.equal(solRows.length, 4);
+    assert.equal(solRows.filter((row) => row.effectiveUntil === "2026-08-20T23:59:59.999Z").length, 2);
+    assert.equal(solRows.filter((row) => row.effectiveFrom === "2026-08-21T00:00:00.000Z").length, 2);
     const temporalRows = upgraded.prices.filter((row) => temporalModels.has(row.model));
     assert.equal(temporalRows.length, 8);
     assert.equal(temporalRows.filter((row) => row.effectiveUntil === historicalUntil).length, 4);
@@ -447,6 +603,18 @@ test("ClickHouse repairs a chained derived packaged migration only for an unchan
       if (row.key === "pricingRevision") row.value_json = JSON.stringify(legacyPricingRevision);
     }
     mock.activeRows.pricing_catalog = mock.activeRows.pricing_catalog.flatMap((row) => {
+      if (row.model === "gpt-6-astra") return [];
+      if (row.model === "gpt-5.6-sol") {
+        if (row.effective_until !== "2026-08-20T23:59:59.999Z") return [];
+        return [{
+          ...row,
+          revision: legacyRevision,
+          row_id: `${row.provider}:${row.model}:${row.variant}`,
+          effective_from: "",
+          effective_until: "",
+          source_url: "https://developers.openai.com/api/docs/pricing",
+        }];
+      }
       if (!temporalModels.has(row.model)) {
         return [{
           ...row,
@@ -480,7 +648,7 @@ test("ClickHouse repairs a chained derived packaged migration only for an unchan
     assert.equal(requests.some((request) => request.query.startsWith("INSERT INTO sources")), false);
     assert.ok(requests.some((request) => request.query.trimStart().startsWith("INSERT INTO usage_event_costs")));
     assert.ok(requests.some((request) => request.query.trimStart().startsWith("INSERT INTO rate_limit_sample_costs")));
-    assert.match(upgraded.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
+    assert.match(upgraded.settings.pricingRevision, /^packaged-5:[0-9a-f]{32}$/);
 
     const stableStart = mock.requests.length;
     assert.equal((await loadConfiguration(options)).revision, upgraded.revision);
@@ -493,18 +661,18 @@ test("ClickHouse repairs a chained derived packaged migration only for an unchan
     assert.equal(mock.requests.slice(futureProjectionStart).some((request) => request.query.trimStart().startsWith("INSERT INTO")), false);
 
     futureMetadata.pricing_projection_revision = "2";
-    futureMetadata.packaged_revision = "packaged-5";
+    futureMetadata.packaged_revision = "packaged-6";
     const futurePackageStart = mock.requests.length;
-    await assert.rejects(loadConfiguration(options), /packaged pricing revision packaged-5 is newer than packaged-4/);
+    await assert.rejects(loadConfiguration(options), /packaged pricing revision packaged-6 is newer than packaged-5/);
     assert.equal(mock.requests.slice(futurePackageStart).some((request) => request.query.trimStart().startsWith("INSERT INTO")), false);
 
     mock.activeRows.configuration_metadata = mock.activeRows.configuration_metadata
       .filter((row) => row.revision !== upgraded.revision);
     mock.activeRows.analytics_settings.find((row) => (
       row.revision === upgraded.revision && row.key === "pricingRevision"
-    )).value_json = JSON.stringify(`packaged-5:${"e".repeat(32)}`);
+    )).value_json = JSON.stringify(`packaged-6:${"e".repeat(32)}`);
     const futurePublicStart = mock.requests.length;
-    await assert.rejects(loadConfiguration(options), /stored packaged pricing revision packaged-5:.* is newer than packaged-4/);
+    await assert.rejects(loadConfiguration(options), /stored packaged pricing revision packaged-6:.* is newer than packaged-5/);
     assert.equal(mock.requests.slice(futurePublicStart).some((request) => request.query.trimStart().startsWith("INSERT INTO")), false);
   });
 });
@@ -536,7 +704,7 @@ test("ClickHouse rebuilds managed overlays when projection metadata is stale", a
     const requests = mock.requests.slice(before);
 
     assert.notEqual(upgraded.revision, legacyRevision);
-    assert.match(upgraded.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
+    assert.match(upgraded.settings.pricingRevision, /^packaged-5:[0-9a-f]{32}$/);
     assert.equal(requests.some((request) => request.query.startsWith("INSERT INTO sources")), false);
     const usageOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO usage_event_costs"));
     const rateLimitOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO rate_limit_sample_costs"));
@@ -573,7 +741,7 @@ test("ClickHouse restores managed provenance after an old profile-only writer", 
     const requests = mock.requests.slice(before);
 
     assert.notEqual(upgraded.revision, legacyRevision);
-    assert.match(upgraded.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
+    assert.match(upgraded.settings.pricingRevision, /^packaged-5:[0-9a-f]{32}$/);
     assert.equal(upgraded.settings.monthlyCostLimitUsd, 321);
     assert.equal(requests.some((request) => request.query.startsWith("INSERT INTO sources")), false);
     const usageOverlay = requests.findIndex((request) => request.query.trimStart().startsWith("INSERT INTO usage_event_costs"));
@@ -582,7 +750,7 @@ test("ClickHouse restores managed provenance after an old profile-only writer", 
     assert.match(requests[usageOverlay].query, /parseDateTime64BestEffortOrNull\(toString\(raw\.timestamp\)\)/);
     assert.ok(mock.activeRows.configuration_metadata.some((row) => (
       row.revision === upgraded.revision && row.managed_pricing === 1 &&
-      row.packaged_revision === "packaged-4" && row.pricing_projection_revision === "2"
+      row.packaged_revision === "packaged-5" && row.pricing_projection_revision === "2"
     )));
 
     const stableStart = mock.requests.length;
@@ -658,7 +826,7 @@ test("ClickHouse preserves edited standard rows while rebasing only older derive
     await loadConfiguration(options);
 
     const legacyRevision = "81fbbf48-6215-419b-bffb-ddd36a1e96d4";
-    const legacyPricingRevision = "packaged-4:fd7377f5073cecef6e9f9b83e190c1c4";
+    const legacyPricingRevision = "packaged-5:fd7377f5073cecef6e9f9b83e190c1c4";
     const historicalUntil = "2026-07-29T23:59:59.999Z";
     const temporalModels = new Set(["gpt-5.6-luna", "gpt-5.6-terra"]);
     mock.activeRows.configuration_revisions[0].revision = legacyRevision;
@@ -713,7 +881,7 @@ test("ClickHouse preserves edited standard rows while rebasing only older derive
     const rebasedLuna = rebased.prices.find((row) => row.model === "gpt-5.6-luna" && row.variant === "short");
 
     assert.notEqual(rebased.revision, legacyRevision);
-    assert.match(rebased.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
+    assert.match(rebased.settings.pricingRevision, /^packaged-5:[0-9a-f]{32}$/);
     assert.equal(rebasedLuna.input, 99);
     assert.equal(rebased.prices.some((row) => row.effectiveFrom === "2026-07-30T00:00:00.000Z"), false);
     assert.ok(rebaseRequests.some((request) => request.query.trimStart().startsWith("INSERT INTO usage_event_costs")));
@@ -829,6 +997,8 @@ test("ClickHouse sync streams usage rows in bounded insert chunks", async () => 
     assert.ok(queries.some((query) => query === "DROP TABLE IF EXISTS sessions"));
     assert.ok(queries.some((query) => query === "DROP TABLE IF EXISTS codex_sessions"));
     assert.ok(queries.some((query) => query === "DROP TABLE IF EXISTS import_generations"));
+    assert.ok(queries.some((query) => query === "DROP TABLE IF EXISTS import_generation_checkpoints"));
+    assert.ok(queries.some((query) => query === "DROP TABLE IF EXISTS import_generation_source_deltas"));
     assert.ok(queries.some((query) => query === "DROP TABLE IF EXISTS sources"));
     assert.ok(queries.some((query) => (
       query.includes("CREATE TABLE IF NOT EXISTS codex_sessions")
@@ -862,7 +1032,7 @@ test("ClickHouse sync streams usage rows in bounded insert chunks", async () => 
     assert.match(usageStatsQuery, /'agents'/);
     assert.match(usageStatsQuery, /\(provider, model, effort, date_key\)/);
     assert.equal((usageStatsQuery.match(/FROM usage_events AS raw/g) || []).length, 1);
-    assert.doesNotMatch(usageStatsQuery, /UNION ALL/);
+    assert.doesNotMatch(usageStatsQuery.slice(usageStatsQuery.indexOf("usage_events_with_dimensions AS")), /UNION ALL/);
     assert.equal(mock.inserts.usage_events.reduce((sum, insert) => sum + insert.rows, 0), rows);
     assert.equal(JSON.parse(mock.inserts.usage_events[0].body.trim().split("\n")[0]).service_tier, "unknown");
     const firstUsageRow = JSON.parse(mock.inserts.usage_events[0].body.trim().split("\n")[0]);
@@ -927,6 +1097,697 @@ test("ClickHouse usage sink flushes independently on the row limit", async () =>
 
   assert.deepEqual(mock.inserts.usage_events.map((insert) => insert.rows), [2, 2, 1]);
   assert.equal(mock.inserts.usage_events.reduce((sum, insert) => sum + insert.rows, 0), rows);
+});
+
+test("ClickHouse publishes only complete appended JSONL records in one stable source epoch", async () => {
+  const jsonl = createSessionFile({ rows: 2 });
+  const mock = createClickHouseServer();
+
+  await withServer(mock, async (url) => {
+    const options = defaultOptions({
+      dbEngine: "clickhouse",
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_append_segment_test",
+      paths: [jsonl],
+      progress: false,
+    });
+    const initial = await syncDatabase(options);
+    assert.equal(initial.total.requests, 2);
+    assert.equal(mock.visibleRows("sources").length, 1);
+    assert.ok(mock.visibleRows("sources")[0].parser_checkpoint);
+    const initialGenerationCount = mock.activeRows.import_generations.length;
+    const initialOffset = mock.visibleRows("sources")[0].segment_end;
+
+    const appendedRecord = JSON.stringify({
+      type: "event_msg",
+      timestamp: "2026-07-05T00:00:02.000Z",
+      payload: {
+        type: "token_count",
+        info: {
+          last_token_usage: {
+            input_tokens: 2,
+            cached_input_tokens: 0,
+            output_tokens: 1,
+          },
+          model_context_window: 128_000,
+        },
+      },
+    });
+    fs.appendFileSync(jsonl, appendedRecord);
+    const partial = await syncDatabase(options);
+    assert.equal(partial.total.requests, 2);
+    assert.equal(mock.activeRows.import_generations.length, initialGenerationCount);
+
+    fs.appendFileSync(jsonl, "\n");
+    const appended = await syncDatabase(options);
+    assert.equal(appended.total.requests, 3);
+    assert.equal(appended.sessions.length, 1);
+    assert.equal(appended.sessions[0].lines, 5);
+    assert.equal(mock.activeRows.import_generations.length, initialGenerationCount + 1);
+    assert.equal(mock.visibleRows("usage_events").length, 3);
+    assert.equal(mock.visibleRows("sources").length, 1);
+    const segments = mock.activeRows.sources
+      .filter((row) => row.source_path === jsonl)
+      .sort((a, b) => a.segment_start - b.segment_start);
+    assert.equal(segments.length, 2);
+    assert.equal(segments[0].import_id, segments[1].import_id);
+    assert.equal(segments[1].segment_start, initialOffset);
+    assert.equal(segments[1].cursor_line, 5);
+    assert.equal(
+      mock.inserts.usage_events.reduce((sum, insert) => sum + insert.rows, 0),
+      3,
+      "the append must insert only the new usage row",
+    );
+  });
+});
+
+test("ClickHouse replaces the provisional metric for an open final Codex turn", async () => {
+  const jsonl = createSessionFile({ rows: 0 });
+  const turnId = "019f4973-7053-7623-a798-0e4cf81ef0aa";
+  fs.appendFileSync(jsonl, [
+    JSON.stringify({
+      type: "turn_context",
+      timestamp: "2026-07-05T00:00:01.000Z",
+      payload: { turn_id: turnId, cwd: "/tmp/open-turn", model: "gpt-5.4-mini", effort: "medium" },
+    }),
+    JSON.stringify({
+      type: "event_msg",
+      timestamp: "2026-07-05T00:00:02.000Z",
+      payload: {
+        type: "token_count",
+        info: {
+          last_token_usage: { input_tokens: 10, cached_input_tokens: 0, output_tokens: 4 },
+          total_token_usage: { input_tokens: 10, cached_input_tokens: 0, output_tokens: 4 },
+        },
+      },
+    }),
+    JSON.stringify({
+      type: "response_item",
+      timestamp: "2026-07-05T00:00:03.000Z",
+      payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "abcdefghij" }] },
+    }),
+    "",
+  ].join("\n"));
+  const mock = createClickHouseServer();
+
+  await withServer(mock, async (url) => {
+    const options = defaultOptions({
+      dbEngine: "clickhouse",
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_open_turn_metric_test",
+      paths: [jsonl],
+      progress: false,
+    });
+    await syncDatabase(options);
+    assert.equal(mock.visibleRows("output_char_metrics").length, 1);
+    assert.equal(mock.visibleRows("output_char_metrics")[0].visible_output_tokens, 4);
+    assert.ok(JSON.parse(mock.visibleRows("sources")[0].parser_checkpoint).turn);
+
+    fs.appendFileSync(jsonl, `${JSON.stringify({
+      type: "event_msg",
+      timestamp: "2026-07-05T00:00:04.000Z",
+      payload: {
+        type: "token_count",
+        info: {
+          last_token_usage: { input_tokens: 2, cached_input_tokens: 0, output_tokens: 2 },
+          total_token_usage: { input_tokens: 12, cached_input_tokens: 0, output_tokens: 6 },
+        },
+      },
+    })}\n`);
+    await syncDatabase(options);
+
+    const logicalMetrics = mock.visibleRows("output_char_metrics");
+    assert.equal(logicalMetrics.length, 1);
+    assert.equal(logicalMetrics[0].turn_key, `id:${turnId}`);
+    assert.equal(logicalMetrics[0].visible_output_chars, 10);
+    assert.equal(logicalMetrics[0].visible_output_tokens, 2);
+    assert.equal(mock.activeRows.output_char_metrics.length, 2);
+  });
+});
+
+test("ClickHouse preserves multiple request metrics within one Codex turn", async () => {
+  const jsonl = createSessionFile({ rows: 0 });
+  const turnId = "019f4973-7053-7623-a798-0e4cf81ef0ab";
+  const tokenCount = (timestamp, totalInput, totalOutput) => ({
+    type: "event_msg",
+    timestamp,
+    payload: {
+      type: "token_count",
+      info: {
+        last_token_usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 2 },
+        total_token_usage: { input_tokens: totalInput, cached_input_tokens: 0, output_tokens: totalOutput },
+      },
+    },
+  });
+  fs.appendFileSync(jsonl, `${[
+    {
+      type: "turn_context",
+      timestamp: "2026-07-05T00:00:01.000Z",
+      payload: { turn_id: turnId, cwd: "/tmp/multi-metric", model: "gpt-5.4-mini", effort: "medium" },
+    },
+    {
+      type: "response_item",
+      timestamp: "2026-07-05T00:00:02.000Z",
+      payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "abcd" }] },
+    },
+    tokenCount("2026-07-05T00:00:03.000Z", 1, 2),
+    {
+      type: "response_item",
+      timestamp: "2026-07-05T00:00:04.000Z",
+      payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "abcdef" }] },
+    },
+    tokenCount("2026-07-05T00:00:05.000Z", 2, 4),
+  ].map(JSON.stringify).join("\n")}\n`);
+  const mock = createClickHouseServer();
+
+  await withServer(mock, async (url) => {
+    const report = await syncDatabase(defaultOptions({
+      dbEngine: "clickhouse",
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_multi_metric_turn_test",
+      paths: [jsonl],
+      progress: false,
+    }));
+    const metrics = mock.visibleRows("output_char_metrics");
+    assert.equal(metrics.length, 2);
+    assert.equal(metrics.reduce((sum, row) => sum + row.visible_output_chars, 0), 10);
+    assert.equal(metrics.reduce((sum, row) => sum + row.visible_output_tokens, 0), 4);
+    assert.deepEqual(metrics.map((row) => row.turn_key).sort(), [
+      `id:${turnId}`,
+      `id:${turnId}:request:7`,
+    ]);
+  });
+});
+
+test("ClickHouse append storage stays linear beyond the former 128-segment boundary", async () => {
+  const changing = createSessionFile({ rows: 1, sessionId: "019f4973-7053-7623-a798-0e4cf81ef0b1" });
+  const unchanged = createSessionFile({ rows: 1, sessionId: "019f4973-7053-7623-a798-0e4cf81ef0b2" });
+  const mock = createClickHouseServer();
+
+  await withServer(mock, async (url) => {
+    const options = defaultOptions({
+      dbEngine: "clickhouse",
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_linear_append_test",
+      paths: [changing, unchanged],
+      progress: false,
+    });
+    await syncDatabase(options);
+    const epoch = mock.visibleRows("sources").find((row) => row.source_path === changing).import_id;
+
+    for (let index = 0; index < 130; index += 1) {
+      fs.appendFileSync(changing, `${JSON.stringify({
+        type: "event_msg",
+        timestamp: `2026-07-05T00:${String(Math.floor(index / 60)).padStart(2, "0")}:${String(index % 60).padStart(2, "0")}.000Z`,
+        payload: {
+          type: "token_count",
+          info: {
+            last_token_usage: { input_tokens: index + 2, cached_input_tokens: 0, output_tokens: 1 },
+            model_context_window: 128_000,
+          },
+        },
+      })}\n`);
+      await syncDatabase(options);
+    }
+
+    const changingSources = mock.activeRows.sources.filter((row) => row.source_path === changing);
+    const unchangedSources = mock.activeRows.sources.filter((row) => row.source_path === unchanged);
+    const changingSnapshots = mock.activeRows.import_generation_sources.filter((row) => row.source_path === changing);
+    const changingDeltas = mock.activeRows.import_generation_source_deltas.filter((row) => row.source_path === changing);
+    const unchangedSnapshots = mock.activeRows.import_generation_sources.filter((row) => row.source_path === unchanged);
+    const unchangedDeltas = mock.activeRows.import_generation_source_deltas.filter((row) => row.source_path === unchanged);
+    assert.equal(changingSources.length, 131);
+    assert.ok(changingSources.every((row) => row.import_id === epoch));
+    assert.equal(unchangedSources.length, 1);
+    assert.equal(changingSnapshots.length, 2);
+    assert.equal(changingDeltas.length, 130);
+    assert.equal(unchangedSnapshots.length, 2, "unchanged sources are copied only into bounded metadata checkpoints");
+    assert.equal(unchangedDeltas.length, 0);
+    assert.equal(mock.activeRows.import_generation_checkpoints.length, 2);
+    const checkpointGeneration = mock.activeRows.import_generation_checkpoints.at(-1).generation_id;
+    const checkpointIndex = mock.activeRows.import_generations.findIndex((row) => row.generation_id === checkpointGeneration);
+    const boundedManifestGenerations = new Set(mock.activeRows.import_generation_source_deltas
+      .filter((row) => mock.activeRows.import_generations.findIndex((generation) => generation.generation_id === row.generation_id) > checkpointIndex)
+      .map((row) => row.generation_id));
+    assert.equal(boundedManifestGenerations.size, 1, "report delta reconstruction must be bounded after a checkpoint");
+    const deltaDdl = mock.requests.find((request) => (
+      request.query.includes("CREATE TABLE IF NOT EXISTS import_generation_source_deltas")
+    ))?.query;
+    assert.match(deltaDdl, /ORDER BY \(committed_at_ms, generation_id, source_path\)/);
+    const manifestQuery = mock.requests.find((request) => request.query.includes("manifest_deltas AS"))?.query;
+    assert.match(manifestQuery, /tuple\(manifest\.committed_at_ms, manifest\.generation_id\) > checkpoint\.boundary/);
+    assert.equal(mock.activeRows.usage_events.filter((row) => row.source_path === changing).length, 131);
+    assert.equal(mock.visibleRows("usage_events").filter((row) => row.source_path === changing).length, 131);
+  });
+});
+
+test("ClickHouse Claude append resumes exact request-id deduplication", async () => {
+  const dir = fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-ch-claude-append-test-"));
+  const jsonl = Path.join(dir, "claude-session.jsonl");
+  const claudeRecord = (requestId, timestamp) => JSON.stringify({
+    type: "assistant",
+    timestamp,
+    requestId,
+    cwd: "/tmp/claude-append",
+    message: {
+      model: "claude-opus-4-8",
+      usage: { input_tokens: 10, output_tokens: 2 },
+    },
+  });
+  fs.writeFileSync(jsonl, `${claudeRecord("req-a", "2026-08-15T00:00:00.000Z")}\n`);
+  const mock = createClickHouseServer();
+
+  await withServer(mock, async (url) => {
+    const options = defaultOptions({
+      dbEngine: "clickhouse",
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_claude_append_test",
+      paths: [jsonl],
+      progress: false,
+    });
+    await syncDatabase(options);
+    const firstCheckpoint = JSON.parse(mock.visibleRows("sources")[0].parser_checkpoint);
+    assert.equal(firstCheckpoint.kind, "claude");
+    assert.deepEqual(firstCheckpoint.recentRequestIds, ["req-a"]);
+
+    fs.appendFileSync(jsonl, [
+      claudeRecord("req-a", "2026-08-15T00:00:01.000Z"),
+      claudeRecord("req-b", "2026-08-15T00:00:02.000Z"),
+      "",
+    ].join("\n"));
+    const report = await syncDatabase(options);
+
+    assert.equal(report.total.requests, 2);
+    assert.equal(mock.visibleRows("usage_events").length, 2);
+    assert.equal(mock.visibleRows("sources").length, 1);
+    assert.equal(mock.inserts.usage_events.reduce((sum, insert) => sum + insert.rows, 0), 2);
+    const latest = mock.visibleRows("sources").sort((a, b) => a.segment_end - b.segment_end).at(-1);
+    assert.deepEqual(JSON.parse(latest.parser_checkpoint).recentRequestIds, ["req-a", "req-b"]);
+  });
+});
+
+test("ClickHouse Claude append resumes unkeyed usage by global line number", async () => {
+  const dir = fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-ch-claude-unkeyed-test-"));
+  const jsonl = Path.join(dir, "claude-session.jsonl");
+  const claudeRecord = (timestamp) => JSON.stringify({
+    type: "assistant",
+    timestamp,
+    cwd: "/tmp/claude-unkeyed",
+    message: {
+      model: "claude-opus-4-8",
+      usage: { input_tokens: 10, output_tokens: 2 },
+    },
+  });
+  fs.writeFileSync(jsonl, `${claudeRecord("2026-08-15T00:00:00.000Z")}\n`);
+  const mock = createClickHouseServer();
+
+  await withServer(mock, async (url) => {
+    const options = defaultOptions({
+      dbEngine: "clickhouse",
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_claude_unkeyed_test",
+      paths: [jsonl],
+      progress: false,
+    });
+    await syncDatabase(options);
+    const sourceBefore = mock.visibleRows("sources")[0];
+    assert.deepEqual(JSON.parse(sourceBefore.parser_checkpoint).recentRequestIds, []);
+
+    fs.appendFileSync(jsonl, `${claudeRecord("2026-08-15T00:00:01.000Z")}\n`);
+    const report = await syncDatabase(options);
+
+    assert.equal(report.total.requests, 2);
+    assert.deepEqual(mock.visibleRows("usage_events").map((row) => row.event_key), ["line:1", "line:2"]);
+    assert.equal(mock.visibleRows("sources")[0].import_id, sourceBefore.import_id);
+  });
+});
+
+test("ClickHouse append cursor validates guards when size and mtime are unchanged", async () => {
+  const dir = fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-ch-guarded-fingerprint-test-"));
+  const jsonl = Path.join(dir, "claude-session.jsonl");
+  const claudeRecord = (requestId) => JSON.stringify({
+    type: "assistant",
+    timestamp: "2026-08-15T00:00:00.000Z",
+    requestId,
+    cwd: "/tmp/claude-guarded-fingerprint",
+    message: {
+      model: "claude-opus-4-8",
+      usage: { input_tokens: 10, output_tokens: 2 },
+    },
+  });
+  const initial = `${claudeRecord("req-a")}\n`;
+  const replacement = `${claudeRecord("req-b")}\n`;
+  assert.equal(Buffer.byteLength(replacement), Buffer.byteLength(initial));
+  fs.writeFileSync(jsonl, initial);
+  const originalStat = fs.statSync(jsonl);
+  const mock = createClickHouseServer();
+  const progressEvents = [];
+
+  await withServer(mock, async (url) => {
+    const options = defaultOptions({
+      dbEngine: "clickhouse",
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_guarded_fingerprint_test",
+      paths: [jsonl],
+      progress: false,
+      onSyncProgress: (event) => progressEvents.push(event),
+    });
+    await syncDatabase(options);
+    const originalImportId = mock.visibleRows("sources")[0].import_id;
+
+    fs.writeFileSync(jsonl, replacement);
+    fs.utimesSync(jsonl, originalStat.atimeMs / 1_000, originalStat.mtimeMs / 1_000);
+    const replacementStat = fs.statSync(jsonl);
+    assert.equal(replacementStat.size, originalStat.size);
+    assert.equal(replacementStat.mtimeMs, originalStat.mtimeMs);
+
+    const secondSyncProgress = progressEvents.length;
+    const report = await syncDatabase(options);
+    assert.equal(report.total.requests, 1);
+    assert.equal(mock.visibleRows("usage_events")[0].event_key, "request:req-b");
+    assert.notEqual(mock.visibleRows("sources")[0].import_id, originalImportId);
+    assert.equal(
+      progressEvents.slice(secondSyncProgress).find((event) => event.phase === "processing")?.candidateSources,
+      1,
+      "the guard mismatch must enter the fork-aware changed-source pre-scan",
+    );
+  });
+});
+
+test("ClickHouse Claude deduplication stays exact after the bounded checkpoint window", async () => {
+  const dir = fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-ch-claude-bounded-test-"));
+  const jsonl = Path.join(dir, "claude-long-session.jsonl");
+  const claudeRecord = (requestId, second) => JSON.stringify({
+    type: "assistant",
+    timestamp: `2026-08-15T00:00:${String(second % 60).padStart(2, "0")}.000Z`,
+    requestId,
+    cwd: "/tmp/claude-bounded",
+    message: { model: "claude-opus-4-8", usage: { input_tokens: 1, output_tokens: 1 } },
+  });
+  const initialCount = CLAUDE_REQUEST_CHECKPOINT_LIMIT + 6;
+  fs.writeFileSync(jsonl, `${Array.from({ length: initialCount }, (_, index) => claudeRecord(`req-${index}`, index)).join("\n")}\n`);
+  const mock = createClickHouseServer();
+
+  await withServer(mock, async (url) => {
+    const options = defaultOptions({
+      dbEngine: "clickhouse",
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_claude_bounded_test",
+      paths: [jsonl],
+      progress: false,
+    });
+    await syncDatabase(options);
+    const sourceBefore = mock.visibleRows("sources")[0];
+    const checkpoint = JSON.parse(sourceBefore.parser_checkpoint);
+    assert.equal(checkpoint.recentRequestIds.length, CLAUDE_REQUEST_CHECKPOINT_LIMIT);
+    assert.equal(checkpoint.recentRequestIds.includes("req-0"), false);
+
+    fs.appendFileSync(jsonl, `${claudeRecord("req-0", initialCount)}\n${claudeRecord("req-new", initialCount + 1)}\n`);
+    const report = await syncDatabase(options);
+
+    assert.equal(report.total.requests, initialCount + 1);
+    assert.equal(mock.visibleRows("usage_events").length, initialCount + 1);
+    assert.equal(mock.activeRows.usage_events.length, initialCount + 2);
+    assert.equal(mock.visibleRows("sources")[0].import_id, sourceBefore.import_id);
+  });
+});
+
+test("ClickHouse rewrite replaces the old segment chain with one full import", async () => {
+  const jsonl = createSessionFile({ rows: 2 });
+  const replacement = createSessionFile({
+    rows: 1,
+    sessionId: "019f4973-7053-7623-a798-0e4cf81ef099",
+  });
+  const mock = createClickHouseServer();
+
+  await withServer(mock, async (url) => {
+    const options = defaultOptions({
+      dbEngine: "clickhouse",
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_rewrite_segment_test",
+      paths: [jsonl],
+      progress: false,
+    });
+    await syncDatabase(options);
+    fs.writeFileSync(jsonl, fs.readFileSync(replacement));
+    const report = await syncDatabase(options);
+
+    assert.equal(report.total.requests, 1);
+    assert.equal(mock.visibleRows("usage_events").length, 1);
+    assert.equal(mock.visibleRows("sources").length, 1);
+    assert.equal(mock.visibleRows("sources")[0].segment_start, 0);
+    assert.equal(mock.activeRows.usage_events.length, 3, "the replaced import remains physically orphaned");
+  });
+});
+
+test("ClickHouse keeps a legacy multi-import manifest visible until one full epoch migration", async () => {
+  const jsonl = createSessionFile({ rows: 2, sessionId: "019f4973-7053-7623-a798-0e4cf81ef0c1" });
+  const mock = createClickHouseServer();
+  mock.activeRows.import_generations = [{ generation_id: "legacy-segments", committed_at_ms: 1 }];
+  mock.activeRows.import_generation_sources = [
+    { generation_id: "legacy-segments", source_path: jsonl, import_id: "segment-a", deleted: 0 },
+    { generation_id: "legacy-segments", source_path: jsonl, import_id: "segment-b", deleted: 0 },
+  ];
+  mock.activeRows.sources = [
+    { source_path: jsonl, import_id: "segment-a", fingerprint: "old-a", imported_at: "2026-01-01", segment_end: 100 },
+    { source_path: jsonl, import_id: "segment-b", fingerprint: "old-b", imported_at: "2026-01-02", segment_end: 200 },
+  ];
+  mock.activeRows.usage_events = [
+    { source_path: jsonl, import_id: "segment-a", event_key: "line:3", line_no: 3 },
+    { source_path: jsonl, import_id: "segment-b", event_key: "line:4", line_no: 4 },
+  ];
+
+  await withServer(mock, async (url) => {
+    const options = defaultOptions({
+      dbEngine: "clickhouse",
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_legacy_segments_test",
+      paths: [jsonl],
+      progress: false,
+    });
+    const legacyReport = await buildReportFromClickHouse(options);
+    assert.equal(legacyReport.total.requests, 2);
+    assert.equal(mock.visibleRows("sources").length, 2);
+
+    const migrated = await syncDatabase(options);
+    assert.equal(migrated.total.requests, 2);
+    assert.equal(mock.visibleRows("usage_events").length, 2);
+    assert.equal(mock.visibleRows("sources").length, 1);
+    assert.equal(mock.activeRows.usage_events.length, 4, "legacy rows stay physically recoverable but become inactive");
+  });
+});
+
+test("ClickHouse append failure leaves the previous generation visible", async () => {
+  const jsonl = createSessionFile({ rows: 1 });
+  const mock = createClickHouseServer({
+    failureAfterInsert: {
+      acceptedBatches: 1,
+      body: "injected append failure",
+      table: "usage_events",
+    },
+  });
+
+  await withServer(mock, async (url) => {
+    const options = defaultOptions({
+      dbEngine: "clickhouse",
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_append_failure_test",
+      paths: [jsonl],
+      progress: false,
+    });
+    await syncDatabase(options);
+    const committedGenerations = mock.activeRows.import_generations.length;
+    fs.appendFileSync(jsonl, `${JSON.stringify({
+      type: "event_msg",
+      timestamp: "2026-07-05T00:00:03.000Z",
+      payload: {
+        type: "token_count",
+        info: {
+          last_token_usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+          model_context_window: 128_000,
+        },
+      },
+    })}\n`);
+
+    await assert.rejects(syncDatabase(options), /injected append failure/);
+    assert.equal(mock.activeRows.import_generations.length, committedGenerations);
+    assert.equal(mock.visibleRows("usage_events").length, 1);
+    assert.equal(mock.visibleRows("sources").length, 1);
+
+    const recovered = await syncDatabase(options);
+    assert.equal(recovered.total.requests, 2);
+    assert.equal(mock.visibleRows("usage_events").length, 2);
+    assert.equal(mock.visibleRows("sources").length, 1);
+  });
+});
+
+test("ClickHouse commit marker hides staged rows in an already-active source epoch", async () => {
+  const jsonl = createSessionFile({ rows: 1 });
+  const mock = createClickHouseServer({
+    failureAfterInsert: {
+      acceptedBatches: 0,
+      body: "injected manifest failure",
+      table: "import_generation_source_deltas",
+    },
+  });
+
+  await withServer(mock, async (url) => {
+    const options = defaultOptions({
+      dbEngine: "clickhouse",
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_marker_atomicity_test",
+      paths: [jsonl],
+      progress: false,
+    });
+    await syncDatabase(options);
+    const committedGenerations = mock.activeRows.import_generations.length;
+    const committedOffset = mock.visibleRows("sources")[0].segment_end;
+    fs.appendFileSync(jsonl, `${JSON.stringify({
+      type: "event_msg",
+      timestamp: "2026-07-05T00:00:03.000Z",
+      payload: {
+        type: "token_count",
+        info: {
+          last_token_usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+          model_context_window: 128_000,
+        },
+      },
+    })}\n`);
+
+    await assert.rejects(syncDatabase(options), /injected manifest failure/);
+    assert.equal(mock.activeRows.import_generations.length, committedGenerations);
+    assert.equal(mock.activeRows.usage_events.length, 2, "the delta was physically staged");
+    assert.equal(mock.activeRows.sources.length, 2, "the advanced cursor was physically staged");
+    assert.equal(mock.visibleRows("usage_events").length, 1, "the old manifest must hide the staged delta");
+    assert.equal(mock.visibleRows("sources")[0].segment_end, committedOffset, "the old manifest must pin the old cursor");
+    assert.equal((await buildReportFromClickHouse(options)).total.requests, 1);
+
+    const recovered = await syncDatabase(options);
+    assert.equal(recovered.total.requests, 2);
+    assert.equal(mock.visibleRows("usage_events").length, 2);
+    assert.equal(mock.visibleRows("sources").length, 1);
+    assert.ok(mock.activeRows.usage_events.length > mock.visibleRows("usage_events").length, "retry duplicates remain physical only");
+  });
+});
+
+test("ClickHouse rejects a stale concurrent checkpoint and keeps the stable-epoch watermark", async () => {
+  const mock = createClickHouseServer();
+  const sourcePath = "/tmp/concurrent-stable-epoch.jsonl";
+  mock.activeRows.import_generations = [
+    { generation_id: "baseline", committed_at_ms: 0 },
+    { generation_id: "newer-offset", committed_at_ms: 1 },
+    { generation_id: "later-stale-writer", committed_at_ms: 2 },
+  ];
+  mock.activeRows.import_generation_checkpoints = [
+    { generation_id: "baseline", committed_at_ms: 0, base_generation_id: "", base_committed_at_ms: 0 },
+    {
+      generation_id: "later-stale-writer",
+      committed_at_ms: 2,
+      base_generation_id: "baseline",
+      base_committed_at_ms: 0,
+    },
+  ];
+  mock.activeRows.import_generation_sources = [
+    {
+      generation_id: "baseline",
+      source_path: sourcePath,
+      import_id: "stable-epoch",
+      committed_segment_end: 0,
+      deleted: 0,
+    },
+    {
+      generation_id: "later-stale-writer",
+      source_path: sourcePath,
+      import_id: "stable-epoch",
+      committed_segment_end: 100,
+      deleted: 0,
+    },
+  ];
+  mock.activeRows.import_generation_source_deltas = [
+    {
+      generation_id: "newer-offset",
+      source_path: sourcePath,
+      import_id: "stable-epoch",
+      committed_segment_end: 200,
+      deleted: 0,
+    },
+    {
+      generation_id: "later-stale-writer",
+      source_path: sourcePath,
+      import_id: "stable-epoch",
+      committed_segment_end: 100,
+      deleted: 0,
+    },
+  ];
+  mock.activeRows.sources = [
+    { source_path: sourcePath, import_id: "stable-epoch", segment_end: 100 },
+    { source_path: sourcePath, import_id: "stable-epoch", segment_end: 200 },
+  ];
+  mock.activeRows.usage_events = [
+    { source_path: sourcePath, import_id: "stable-epoch", segment_end: 100, event_key: "line:1", line_no: 1 },
+    { source_path: sourcePath, import_id: "stable-epoch", segment_end: 200, event_key: "line:2", line_no: 2 },
+  ];
+
+  await withServer(mock, async (url) => {
+    const report = await buildReportFromClickHouse(defaultOptions({
+      dbEngine: "clickhouse",
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_monotonic_watermark_test",
+      progress: false,
+    }));
+    assert.equal(report.total.requests, 2);
+    assert.equal(mock.visibleRows("usage_events").length, 2);
+    assert.equal(mock.visibleRows("sources")[0].segment_end, 200);
+    assert.ok(mock.requests.some((request) => request.query.includes("manifest_watermarks")));
+  });
+});
+
+test("ClickHouse session segment aggregation preserves non-numeric metadata", async () => {
+  const mock = createClickHouseServer();
+  const sourcePath = "/tmp/observed-session-segments.jsonl";
+  const observation = {
+    agent: "cursor-agent",
+    provider: "cursor",
+    model: "(unknown model)",
+    project: "/tmp/project",
+    measurement: "observed-only",
+    exactUsageAvailable: false,
+  };
+  mock.activeRows.import_generations = [{ generation_id: "committed", committed_at_ms: 1 }];
+  mock.activeRows.import_generation_sources = [{
+    generation_id: "committed",
+    source_path: sourcePath,
+    import_id: "stable-epoch",
+    committed_segment_end: 200,
+    deleted: 0,
+  }];
+  mock.activeRows.sessions = [
+    {
+      source_path: sourcePath,
+      import_id: "stable-epoch",
+      segment_start: 0,
+      segment_end: 100,
+      stats_json: JSON.stringify({ observation }),
+    },
+    {
+      source_path: sourcePath,
+      import_id: "stable-epoch",
+      segment_start: 100,
+      segment_end: 200,
+      stats_json: JSON.stringify({ observation }),
+    },
+  ];
+
+  await withServer(mock, async (url) => {
+    const report = await buildReportFromClickHouse(defaultOptions({
+      dbEngine: "clickhouse",
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_session_metadata_test",
+      progress: false,
+    }));
+    assert.equal(report.sessions.length, 1);
+    assert.deepEqual(report.sessions[0].stats.observation, observation);
+  });
 });
 
 test("ClickHouse keeps the whole committed generation visible when a later source fails", async () => {
@@ -995,7 +1856,7 @@ test("ClickHouse keeps the whole committed generation visible when a later sourc
       request.query.trim() === "INSERT INTO import_generations FORMAT JSONEachRow"
     ));
     const lastDataInsert = mock.requests.findLastIndex((request) => (
-      /^INSERT INTO (usage_events|output_char_metrics|rate_limit_samples|telemetry_events|sessions|sources|codex_session_versions|import_generation_sources) FORMAT JSONEachRow$/.test(request.query.trim())
+      /^INSERT INTO (usage_events|output_char_metrics|rate_limit_samples|telemetry_events|sessions|sources|codex_session_versions|import_generation_sources|import_generation_source_deltas|import_generation_checkpoints) FORMAT JSONEachRow$/.test(request.query.trim())
     ));
     assert.ok(markerInsert > lastDataInsert, "the global generation marker must be published last");
 
@@ -1067,7 +1928,18 @@ test("ClickHouse report pins one committed generation across every query", async
   const usageStatsQuery = mock.requests.find((request) => request.query.includes("quarterHourlyProviderModels"))?.query;
   assert.ok(usageStatsQuery);
   assert.match(usageStatsQuery, /GROUP BY GROUPING SETS/);
-  assert.doesNotMatch(usageStatsQuery, /UNION ALL/);
+  assert.doesNotMatch(usageStatsQuery.slice(usageStatsQuery.indexOf("usage_events_with_dimensions AS")), /UNION ALL/);
+  const outputCharStatsQuery = mock.requests.find((request) => (
+    request.query.includes("visibleOutputTextChars")
+  ))?.query;
+  assert.ok(outputCharStatsQuery);
+  assert.match(outputCharStatsQuery, /GROUP BY GROUPING SETS/);
+  assert.match(outputCharStatsQuery, /'projectDaily'/);
+  assert.match(outputCharStatsQuery, /'modelEfforts'/);
+  assert.match(outputCharStatsQuery, /\(project, date_key\)/);
+  assert.match(outputCharStatsQuery, /\(model, effort\)/);
+  assert.equal((outputCharStatsQuery.match(/FROM output_char_metrics AS raw/g) || []).length, 1);
+  assert.doesNotMatch(outputCharStatsQuery.slice(outputCharStatsQuery.lastIndexOf("SELECT")), /UNION ALL/);
   const rateLimitQueries = mock.requests.filter((request) => request.query.includes("repriced_samples AS"));
   assert.equal(rateLimitQueries.length, 1, "rate-limit windows and attribution should share one window pass");
   const rateLimitQuery = rateLimitQueries[0]?.query;
@@ -1084,6 +1956,112 @@ test("ClickHouse report pins one committed generation across every query", async
   assert.doesNotMatch(planHistoryQuery, /any\((agent|limit_id)\)/);
   assert.match(usageStatsQuery, /toStartOfInterval\(parseDateTimeBestEffortOrNull\(timestamp\), INTERVAL 15 MINUTE\)/);
   assert.match(usageStatsQuery, /projectQuarterHourlyProviderModels/);
+});
+
+test("ClickHouse manifest query is accepted by the installed clickhouse-local analyzer", async (t) => {
+  const mock = createClickHouseServer();
+  const home = fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-manifest-analyzer-test-"));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  mock.activeRows.import_generations = [{ generation_id: "analyzer-generation", committed_at_ms: 7 }];
+  mock.activeRows.import_generation_checkpoints = [{
+    generation_id: "analyzer-generation",
+    committed_at_ms: 7,
+    base_generation_id: "analyzer-generation",
+    base_committed_at_ms: 7,
+  }];
+  mock.activeRows.import_generation_sources = [{
+    generation_id: "analyzer-generation",
+    source_path: "/tmp/analyzer-session.jsonl",
+    import_id: "analyzer-import",
+    committed_segment_end: 10,
+    deleted: 0,
+  }];
+  mock.activeRows.sources = [{
+    source_path: "/tmp/analyzer-session.jsonl",
+    import_id: "analyzer-import",
+    segment_end: 10,
+  }];
+
+  await withServer(mock, async (url) => {
+    await syncDatabase(defaultOptions({
+      dbEngine: "clickhouse",
+      home,
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_manifest_analyzer_test",
+    }));
+  });
+
+  const query = mock.requests.find((request) => request.query.includes("uniqExact(source.import_id) AS active_import_count"))?.query;
+  assert.ok(query, "generation source query must be captured");
+  assert.match(query, /history\.source_path AS source_path/);
+  assert.match(query, /history\.import_id AS import_id/);
+  assert.match(query, /watermarks\.committed_segment_end AS committed_segment_end/);
+
+  const version = spawnSync("clickhouse", ["local", "--version"], {
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  if (version.error?.code === "ENOENT") {
+    t.diagnostic("clickhouse-local is not installed; SQL shape contract was still checked");
+    return;
+  }
+  assert.ifError(version.error);
+  assert.equal(version.status, 0, version.stderr);
+
+  const statements = [
+    "CREATE TEMPORARY TABLE import_generations (generation_id String, committed_at_ms UInt64)",
+    `CREATE TEMPORARY TABLE import_generation_checkpoints (
+      committed_at_ms UInt64,
+      generation_id String,
+      base_committed_at_ms UInt64,
+      base_generation_id String
+    )`,
+    `CREATE TEMPORARY TABLE import_generation_sources (
+      generation_id String,
+      source_path String,
+      import_id String,
+      committed_segment_end Nullable(UInt64),
+      deleted UInt8
+    )`,
+    `CREATE TEMPORARY TABLE import_generation_source_deltas (
+      committed_at_ms UInt64,
+      generation_id String,
+      source_path String,
+      import_id String,
+      committed_segment_end Nullable(UInt64),
+      deleted UInt8
+    )`,
+    `CREATE TEMPORARY TABLE sources (
+      source_path String,
+      import_id String,
+      fingerprint String,
+      imported_at String,
+      cursor_version UInt64,
+      segment_start UInt64,
+      segment_end UInt64,
+      cursor_line UInt64,
+      cursor_guard String,
+      cursor_prefix_guard String,
+      parser_checkpoint String,
+      file_device String,
+      file_inode String
+    )`,
+    "INSERT INTO import_generations VALUES ('analyzer-generation', 7)",
+    "INSERT INTO import_generation_checkpoints VALUES (7, 'analyzer-generation', 7, 'analyzer-generation')",
+    "INSERT INTO import_generation_sources VALUES ('analyzer-generation', '/tmp/analyzer-session.jsonl', 'analyzer-import', 10, 0)",
+    "INSERT INTO sources VALUES ('/tmp/analyzer-session.jsonl', 'analyzer-import', 'fingerprint', '2026-09-03T00:00:00.000Z', 1, 0, 10, 1, '', '', '', '', '')",
+    query,
+  ];
+  const execution = spawnSync("clickhouse", [
+    "local",
+    "--param_generation=analyzer-generation",
+    ...statements.flatMap((statement) => ["--query", statement]),
+  ], {
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  assert.equal(execution.status, 0, execution.stderr);
+  assert.equal(JSON.parse(execution.stdout.trim()).source_path, "/tmp/analyzer-session.jsonl");
 });
 
 test("ClickHouse legacy header union uses explicit migration-safe column order", async () => {

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -23,13 +23,14 @@ test("default configuration exposes a validated editable pricing catalog", () =>
   assert.equal(configuration.settings.pricingBasis, "standard");
   assert.equal(configuration.settings.regionalMultiplier, 1);
   assert.equal(configuration.settings.monthlyCostLimitUsd, null);
-  assert.equal(configuration.settings.pricingRevision, "packaged-4");
+  assert.equal(configuration.settings.pricingRevision, "packaged-5");
   assert.deepEqual(configuration.settings.usageProfile, {
     id: "default",
     name: "Work API",
     mode: "api",
   });
   assert.ok(configuration.prices.some((row) => row.provider === "openai" && row.model === "gpt-5.6-luna" && row.variant === "short"));
+  assert.ok(configuration.prices.some((row) => row.provider === "openai" && row.model === "gpt-6-astra" && row.variant === "short"));
   assert.ok(configuration.prices.some((row) => row.provider === "openai" && row.model === "codex-auto-review" && row.variant === "short"));
   const opus5 = configuration.prices.find((row) => row.provider === "anthropic" && row.model === "claude-opus-5");
   const opus48 = configuration.prices.find((row) => row.provider === "anthropic" && row.model === "claude-opus-4-8");
@@ -39,6 +40,58 @@ test("default configuration exposes a validated editable pricing catalog", () =>
     assert.equal(opus5[field], opus48[field], `${field} pricing must match Opus 4.8`);
   }
   assert.deepEqual(normalizeConfiguration(configuration), configuration);
+});
+
+test("default GPT-6 Astra and current GPT-5.6 Sol rows match the official rates", () => {
+  const configuration = defaultConfiguration();
+  const expected = {
+    "gpt-6-astra": {
+      sourceUrl: "https://developers.openai.com/api/docs/models/gpt-6-astra",
+      effectiveFrom: null,
+      short: { input: 10, cacheRead: 1, cacheCreate30m: 12.5, output: 50 },
+      long: { input: 20, cacheRead: 2, cacheCreate30m: 25, output: 75 },
+    },
+    "gpt-5.6-sol": {
+      sourceUrl: "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
+      effectiveFrom: "2026-08-21T00:00:00.000Z",
+      short: { input: 4, cacheRead: 0.4, cacheCreate30m: 5, output: 20 },
+      long: { input: 8, cacheRead: 0.8, cacheCreate30m: 10, output: 30 },
+    },
+  };
+
+  for (const [model, modelExpected] of Object.entries(expected)) {
+    for (const variant of ["short", "long"]) {
+      const row = configuration.prices.find((candidate) => (
+        candidate.provider === "openai" && candidate.model === model && candidate.variant === variant &&
+        candidate.effectiveFrom === modelExpected.effectiveFrom
+      ));
+      assert.ok(row, `${model}/${variant} packaged row is present`);
+      for (const [field, value] of Object.entries(modelExpected[variant])) {
+        assert.equal(row[field], value, `${model}/${variant} ${field} rate`);
+      }
+      assert.equal(row.sourceUrl, modelExpected.sourceUrl);
+    }
+  }
+});
+
+test("default GPT-5.6 Sol rows preserve the August 21 price-cut boundary", () => {
+  const configuration = defaultConfiguration();
+  const historicalUntil = "2026-08-20T23:59:59.999Z";
+  const expected = {
+    short: { input: 5, cacheRead: 0.5, cacheCreate30m: 6.25, output: 30 },
+    long: { input: 10, cacheRead: 1, cacheCreate30m: 12.5, output: 45 },
+  };
+
+  for (const variant of ["short", "long"]) {
+    const row = configuration.prices.find((candidate) => (
+      candidate.provider === "openai" && candidate.model === "gpt-5.6-sol" &&
+      candidate.variant === variant && candidate.effectiveUntil === historicalUntil
+    ));
+    assert.ok(row, `gpt-5.6-sol/${variant} historical packaged row is present`);
+    for (const [field, value] of Object.entries(expected[variant])) {
+      assert.equal(row[field], value, `gpt-5.6-sol/${variant} historical ${field} rate`);
+    }
+  }
 });
 
 test("default GPT-5.6 Luna and Terra rows match the current official standard rates", () => {
@@ -112,11 +165,19 @@ test("default GPT-5.6 Luna and Terra rows preserve the historical pricing bounda
 });
 
 test("legacy packaged catalog recognition rejects even tiny tariff edits", () => {
-  const temporalModels = new Set(["gpt-5.6-luna", "gpt-5.6-terra"]);
+  const temporalModels = new Set(["gpt-5.6-sol", "gpt-5.6-luna", "gpt-5.6-terra"]);
   const legacy = defaultConfiguration().prices.flatMap((row) => {
+    if (row.model === "gpt-6-astra") return [];
     if (!temporalModels.has(row.model)) return [row];
     if (!row.effectiveUntil) return [];
-    return [{ ...row, effectiveFrom: null, effectiveUntil: null }];
+    return [{
+      ...row,
+      effectiveFrom: null,
+      effectiveUntil: null,
+      sourceUrl: row.model === "gpt-5.6-sol"
+        ? "https://developers.openai.com/api/docs/pricing"
+        : row.sourceUrl,
+    }];
   });
 
   assert.equal(isLegacyPackagedPricingCatalog(legacy), true);
@@ -126,11 +187,41 @@ test("legacy packaged catalog recognition rejects even tiny tariff edits", () =>
   assert.equal(packagedPricingCatalogRevision(legacy), "");
 });
 
+test("packaged-4 catalog remains recognizable for an in-place packaged-5 upgrade", () => {
+  const packaged4 = defaultConfiguration().prices.flatMap((row) => {
+    if (row.model === "gpt-6-astra") return [];
+    if (row.model !== "gpt-5.6-sol") return [row];
+    if (!row.effectiveUntil) return [];
+    return [{
+      ...row,
+      effectiveFrom: null,
+      effectiveUntil: null,
+      sourceUrl: "https://developers.openai.com/api/docs/pricing",
+    }];
+  });
+
+  assert.equal(packagedPricingCatalogRevision(packaged4), "packaged-4");
+  const normalized = normalizeConfiguration({
+    revision: "legacy-packaged-4",
+    settings: { ...defaultConfiguration().settings, pricingRevision: "packaged-4" },
+    prices: packaged4,
+  });
+  assert.equal(normalized.settings.pricingRevision, "packaged-5");
+  assert.ok(normalized.prices.some((row) => row.model === "gpt-6-astra"));
+  assert.equal(normalized.prices.filter((row) => row.model === "gpt-5.6-sol").length, 4);
+  assert.equal(normalized.prices.filter((row) => (
+    row.model === "gpt-5.6-sol" && row.effectiveUntil === "2026-08-20T23:59:59.999Z"
+  )).length, 2);
+  assert.equal(normalized.prices.filter((row) => (
+    row.model === "gpt-5.6-sol" && row.effectiveFrom === "2026-08-21T00:00:00.000Z"
+  )).length, 2);
+});
+
 test("current packaged catalog recognition rejects even tiny tariff edits", () => {
   const current = defaultConfiguration().prices;
 
   assert.equal(isCurrentPackagedPricingCatalog(current), true);
-  assert.equal(packagedPricingCatalogRevision(current), "packaged-4");
+  assert.equal(packagedPricingCatalogRevision(current), "packaged-5");
   current.find((row) => row.model === "gpt-5.6-luna" && row.variant === "short" && row.effectiveFrom).input += Number.EPSILON;
   assert.equal(isCurrentPackagedPricingCatalog(current), false);
   assert.equal(packagedPricingCatalogRevision(current), "");
@@ -148,7 +239,7 @@ test("packaged-2 pricing is upgraded with Opus 5 without replacing persisted row
 
   const normalized = normalizeConfiguration(configuration);
 
-  assert.equal(normalized.settings.pricingRevision, "packaged-4");
+  assert.equal(normalized.settings.pricingRevision, "packaged-5");
   assert.equal(normalized.prices.find((row) => row.id === luna.id).input, 2);
   assert.ok(normalized.prices.some((row) => row.provider === "anthropic" && row.model === "claude-opus-5"));
 });
@@ -165,7 +256,7 @@ test("packaged-1 pricing is upgraded with codex-auto-review without replacing pe
 
   const normalized = normalizeConfiguration(configuration);
 
-  assert.equal(normalized.settings.pricingRevision, "packaged-4");
+  assert.equal(normalized.settings.pricingRevision, "packaged-5");
   assert.equal(normalized.prices.find((row) => row.id === luna.id).input, 2);
   assert.ok(normalized.prices.some((row) => row.provider === "openai" && row.model === "codex-auto-review"));
 });
@@ -177,7 +268,7 @@ test("standard edited catalogs get a stable pricing-engine revision and auto-rev
 
   const normalized = normalizeConfiguration(configuration);
 
-  assert.match(normalized.settings.pricingRevision, /^packaged-4:[0-9a-f]{32}$/);
+  assert.match(normalized.settings.pricingRevision, /^packaged-5:[0-9a-f]{32}$/);
   assert.equal(normalizeConfiguration(normalized).settings.pricingRevision, normalized.settings.pricingRevision);
   assert.ok(normalized.prices.some((row) => row.provider === "openai" && row.model === "codex-auto-review"));
 
@@ -189,15 +280,15 @@ test("standard edited catalogs get a stable pricing-engine revision and auto-rev
 
 test("managed packaged overlay revisions remain distinct from edited standard catalogs", () => {
   const configuration = defaultConfiguration();
-  const currentManagedRevision = `packaged-4:managed:${"a".repeat(32)}`;
+  const currentManagedRevision = `packaged-5:managed:${"a".repeat(32)}`;
   configuration.settings.pricingRevision = currentManagedRevision;
 
   assert.equal(normalizeConfiguration(configuration).settings.pricingRevision, currentManagedRevision);
 
-  configuration.settings.pricingRevision = `packaged-3:managed:${"b".repeat(32)}`;
+  configuration.settings.pricingRevision = `packaged-4:managed:${"b".repeat(32)}`;
   assert.match(
     normalizeConfiguration(configuration).settings.pricingRevision,
-    /^packaged-4:managed:[0-9a-f]{32}$/,
+    /^packaged-5:managed:[0-9a-f]{32}$/,
   );
 });
 

--- a/test/launcher.test.js
+++ b/test/launcher.test.js
@@ -7,6 +7,7 @@ const Path = require("node:path");
 const test = require("node:test");
 const {
   browserCommand,
+  dashboardReady,
   downloadClickHouseInstaller,
   ensureClickHouse,
   findExecutable,
@@ -16,6 +17,32 @@ const {
   runLauncher,
   waitForDashboardProcess,
 } = require("../lib/launcher");
+
+async function withStatusServer(payload, callback) {
+  const http = require("node:http");
+  const server = http.createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify(payload));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    await callback(`http://127.0.0.1:${server.address().port}`);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+test("dashboard readiness requires a loopback sync-capable endpoint and the selected engine", async () => {
+  await withStatusServer({ sync: { available: false, engine: "clickhouse", state: "running" } }, async (url) => {
+    assert.equal(await dashboardReady(url, "clickhouse"), false);
+  });
+  await withStatusServer({ sync: { available: true, engine: "sqlite", state: "running" } }, async (url) => {
+    assert.equal(await dashboardReady(url, "clickhouse"), false);
+  });
+  await withStatusServer({ sync: { available: true, engine: "clickhouse", state: "running" } }, async (url) => {
+    assert.equal(await dashboardReady(url, "clickhouse"), true);
+  });
+});
 
 test("ClickHouse installer requests the shell payload and rejects HTML", async () => {
   let requestOptions = null;

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -8,6 +8,7 @@ const zlib = require("node:zlib");
 const { execFileSync } = require("node:child_process");
 const test = require("node:test");
 const { buildReport, createLineProcessor, newReport } = require("../app");
+const { CLAUDE_REQUEST_CHECKPOINT_LIMIT } = require("../lib/ingest/parser");
 const { defaultOptions } = require("./support/fixtures");
 
 test("buildReport scans explicit JSONL path and zip archives", async () => {
@@ -361,6 +362,289 @@ test("Claude speed and service_tier metadata stay separate per request", () => {
     report._usageEvents[1].cost.amount,
     "Anthropic priority service_tier must not imply fast pricing",
   );
+});
+
+test("Claude parser checkpoint keeps bounded recent request deduplication across an append boundary", () => {
+  const sourceLabel = "claude-checkpoint-fixture";
+  const line = (requestId) => JSON.stringify({
+    type: "assistant",
+    timestamp: "2026-08-15T00:00:00.000Z",
+    requestId,
+    cwd: "/tmp/claude-checkpoint",
+    message: {
+      model: "claude-opus-4-8",
+      usage: { input_tokens: 10, output_tokens: 2 },
+    },
+  });
+  const prefix = createLineProcessor(newReport(), defaultOptions(), sourceLabel);
+  prefix(line("req-a"), 1);
+  const checkpoint = JSON.parse(JSON.stringify(prefix.checkpoint()));
+  assert.equal(checkpoint.kind, "claude");
+  assert.equal(checkpoint.deduplication, "clickhouse-event-key");
+  assert.deepEqual(checkpoint.recentRequestIds, ["req-a"]);
+
+  const report = newReport();
+  const resumed = createLineProcessor(report, defaultOptions({ parserCheckpoint: checkpoint }), sourceLabel);
+  resumed(line("req-a"), 2);
+  resumed(line("req-b"), 3);
+
+  assert.equal(report.total.requests, 1);
+  assert.equal(report._usageEvents.length, 1);
+  assert.equal(resumed.checkpoint().recentRequestIds.length, 2);
+
+  const unkeyed = createLineProcessor(newReport(), defaultOptions(), "claude-unkeyed-checkpoint-fixture");
+  unkeyed(line(undefined), 1);
+  assert.deepEqual(unkeyed.checkpoint(), {
+    version: checkpoint.version,
+    kind: "claude",
+    sourceLabel: "claude-unkeyed-checkpoint-fixture",
+    deduplication: "clickhouse-event-key",
+    recentRequestIds: [],
+  });
+  assert.throws(
+    () => createLineProcessor(newReport(), defaultOptions({
+      parserCheckpoint: {
+        ...checkpoint,
+        recentRequestIds: Array.from({ length: CLAUDE_REQUEST_CHECKPOINT_LIMIT + 1 }, (_, index) => `req-${index}`),
+      },
+    }), sourceLabel),
+    /Claude parser checkpoint is not safe to resume/,
+  );
+
+  const long = createLineProcessor(newReport(), defaultOptions(), "claude-long-checkpoint-fixture");
+  for (let index = 0; index < CLAUDE_REQUEST_CHECKPOINT_LIMIT + 10; index += 1) {
+    long(line(`req-${index}`), index + 1);
+  }
+  const bounded = long.checkpoint();
+  assert.equal(bounded.kind, "claude");
+  assert.equal(bounded.recentRequestIds.length, CLAUDE_REQUEST_CHECKPOINT_LIMIT);
+  assert.equal(bounded.recentRequestIds.at(-1), `req-${CLAUDE_REQUEST_CHECKPOINT_LIMIT + 9}`);
+});
+
+test("serialized Codex parser checkpoint resumes cumulative usage and open-turn state", () => {
+  const sourceLabel = "codex-checkpoint-fixture";
+  const options = defaultOptions({ openaiContext: "short" });
+  const prefix = [
+    {
+      type: "session_meta",
+      timestamp: "2026-08-15T00:00:00.000Z",
+      payload: {
+        id: "01a00536-203c-7d72-84fd-e189308e89ce",
+        cwd: "/tmp/checkpoint-project",
+        model_provider: "openai",
+        model: "gpt-5.6-sol",
+      },
+    },
+    {
+      type: "event_msg",
+      timestamp: "2026-08-15T00:00:01.000Z",
+      payload: {
+        type: "thread_settings_applied",
+        thread_settings: { model: "gpt-5.6-sol", service_tier: "priority" },
+      },
+    },
+    {
+      type: "turn_context",
+      timestamp: "2026-08-15T00:00:02.000Z",
+      payload: {
+        turn_id: "01a00536-3000-7000-8000-000000000001",
+        cwd: "/tmp/checkpoint-project",
+        model: "gpt-5.6-sol",
+        effort: "high",
+      },
+    },
+    {
+      type: "event_msg",
+      timestamp: "2026-08-15T00:00:03.000Z",
+      payload: {
+        type: "token_count",
+        info: {
+          last_token_usage: {
+            input_tokens: 1_000,
+            cached_input_tokens: 400,
+            output_tokens: 100,
+            reasoning_output_tokens: 20,
+          },
+          total_token_usage: {
+            input_tokens: 1_000,
+            cached_input_tokens: 400,
+            output_tokens: 100,
+            reasoning_output_tokens: 20,
+          },
+          model_context_window: 128_000,
+        },
+        rate_limits: {
+          limit_id: "codex",
+          primary: { used_percent: 10, window_minutes: 300, resets_at: 1_800_000_000 },
+        },
+      },
+    },
+    {
+      type: "response_item",
+      timestamp: "2026-08-15T00:00:04.000Z",
+      payload: {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "abcdefghij" }],
+      },
+    },
+  ];
+  const tail = [{
+    type: "event_msg",
+    timestamp: "2026-08-15T00:00:05.000Z",
+    payload: {
+      type: "token_count",
+      info: {
+        last_token_usage: {
+          input_tokens: 500,
+          cached_input_tokens: 200,
+          output_tokens: 50,
+          reasoning_output_tokens: 10,
+        },
+        total_token_usage: {
+          input_tokens: 1_500,
+          cached_input_tokens: 600,
+          output_tokens: 150,
+          reasoning_output_tokens: 30,
+        },
+        model_context_window: 128_000,
+      },
+      rate_limits: {
+        limit_id: "codex",
+        primary: { used_percent: 15, window_minutes: 300, resets_at: 1_800_000_000 },
+      },
+    },
+  }];
+
+  const uninterruptedReport = newReport();
+  const uninterrupted = createLineProcessor(uninterruptedReport, options, sourceLabel);
+  prefix.forEach((record, index) => uninterrupted(JSON.stringify(record), index + 1));
+  const usageOffset = uninterruptedReport._usageEvents.length;
+  const metricOffset = uninterruptedReport._outputCharMetrics.length;
+  const rateLimitOffset = uninterruptedReport._rateLimitSamples.length;
+  const checkpoint = JSON.parse(JSON.stringify(uninterrupted.checkpoint()));
+  tail.forEach((record, index) => uninterrupted(JSON.stringify(record), prefix.length + index + 1));
+  uninterrupted.finalize();
+
+  const resumedReport = newReport();
+  const resumed = createLineProcessor(
+    resumedReport,
+    defaultOptions({ openaiContext: "short", codexParserCheckpoint: checkpoint }),
+    sourceLabel,
+  );
+  tail.forEach((record, index) => resumed(JSON.stringify(record), prefix.length + index + 1));
+  resumed.finalize();
+
+  assert.deepEqual(resumedReport._usageEvents, uninterruptedReport._usageEvents.slice(usageOffset));
+  assert.deepEqual(resumedReport._outputCharMetrics, uninterruptedReport._outputCharMetrics.slice(metricOffset));
+  assert.deepEqual(resumedReport._rateLimitSamples, uninterruptedReport._rateLimitSamples.slice(rateLimitOffset));
+  assert.equal(resumedReport.total.requests, 1);
+  assert.equal(resumedReport.total.input, 300);
+  assert.equal(resumedReport.total.cacheRead, 200);
+  assert.equal(resumedReport.total.output, 50);
+  assert.equal(resumedReport.total.reasoningOutput, 10);
+  assert.equal(resumedReport._usageEvents[0].serviceTier, "priority");
+  assert.equal(resumedReport._usageEvents[0].effort, "high");
+  assert.equal(resumedReport._outputCharMetrics[0].visibleOutputChars, 10);
+  assert.equal(resumedReport._outputCharMetrics[0].visibleOutputTokens, 40);
+  assert.equal(resumedReport._rateLimitSamples[0].sequence, 1);
+});
+
+test("Codex parser checkpoint preserves duplicate suppression across the byte boundary", () => {
+  const sourceLabel = "codex-checkpoint-duplicate-fixture";
+  const report = newReport();
+  const processLine = createLineProcessor(report, defaultOptions(), sourceLabel);
+  processLine(JSON.stringify({
+    type: "session_meta",
+    timestamp: "2026-08-15T00:00:00.000Z",
+    payload: {
+      id: "01a00536-203c-7d72-84fd-e189308e89ce",
+      cwd: "/tmp/checkpoint-project",
+    },
+  }), 1);
+  processLine(JSON.stringify({
+    type: "turn_context",
+    timestamp: "2026-08-15T00:00:01.000Z",
+    payload: {
+      turn_id: "01a00536-3000-7000-8000-000000000002",
+      cwd: "/tmp/checkpoint-project",
+      model: "gpt-5-codex",
+    },
+  }), 2);
+  const usageSnapshot = {
+    type: "event_msg",
+    timestamp: "2026-08-15T00:00:02.000Z",
+    payload: {
+      type: "token_count",
+      info: {
+        last_token_usage: {
+          input_tokens: 100,
+          cached_input_tokens: 20,
+          output_tokens: 10,
+        },
+      },
+    },
+  };
+  processLine(JSON.stringify(usageSnapshot), 3);
+  const checkpoint = JSON.parse(JSON.stringify(processLine.checkpoint()));
+
+  const resumedReport = newReport();
+  const resumed = createLineProcessor(
+    resumedReport,
+    defaultOptions({ codexParserCheckpoint: checkpoint }),
+    sourceLabel,
+  );
+  resumed(JSON.stringify({ ...usageSnapshot, timestamp: "2026-08-15T00:00:03.000Z" }), 4);
+
+  assert.equal(resumedReport.sources.tokenCountSnapshots, 1);
+  assert.equal(resumedReport.sources.skippedTokenCountSnapshots, 1);
+  assert.equal(resumedReport.total.requests, 0);
+  assert.equal(resumedReport._usageEvents.length, 0);
+});
+
+test("Codex parser checkpoint fails closed for forks and incompatible identities", () => {
+  const sourceLabel = "codex-checkpoint-safety-fixture";
+  const report = newReport();
+  const processLine = createLineProcessor(report, defaultOptions(), sourceLabel);
+  processLine(JSON.stringify({
+    type: "session_meta",
+    timestamp: "2026-08-15T00:00:00.000Z",
+    payload: {
+      id: "01a00536-203c-7d72-84fd-e189308e89ce",
+      cwd: "/tmp/checkpoint-project",
+    },
+  }), 1);
+  const checkpoint = processLine.checkpoint();
+  assert.ok(checkpoint);
+
+  assert.throws(
+    () => createLineProcessor(
+      newReport(),
+      defaultOptions({ codexParserCheckpoint: { ...checkpoint, version: checkpoint.version + 1 } }),
+      sourceLabel,
+    ),
+    /Unsupported Codex parser checkpoint version/,
+  );
+  assert.throws(
+    () => createLineProcessor(
+      newReport(),
+      defaultOptions({ codexParserCheckpoint: checkpoint }),
+      `${sourceLabel}-other`,
+    ),
+    /Codex parser checkpoint source mismatch/,
+  );
+
+  const forked = createLineProcessor(newReport(), defaultOptions(), "codex-checkpoint-fork-fixture");
+  forked(JSON.stringify({
+    type: "session_meta",
+    timestamp: "2026-08-15T00:00:00.000Z",
+    payload: {
+      id: "01a00536-203c-7d72-84fd-e189308e89cf",
+      forked_from_id: "01a00536-203c-7d72-84fd-e189308e89ce",
+      cwd: "/tmp/checkpoint-project",
+    },
+  }), 1);
+  assert.equal(forked.checkpoint(), null);
 });
 
 test("omp malformed JSON is counted in lenient mode and rejected in strict mode", async () => {

--- a/test/pricing-usage.test.js
+++ b/test/pricing-usage.test.js
@@ -987,6 +987,62 @@ test("GPT-5.6 Luna and Terra packaged rates switch at the 2026-07-30 boundary", 
   }
 });
 
+test("GPT-5.6 Sol packaged rates switch at the 2026-08-21 boundary", () => {
+  const { defaultConfiguration } = require("../lib/core/configuration");
+  const pricingCatalog = defaultConfiguration().prices;
+  const usageValue = {
+    input: 1_000_000,
+    cacheCreate30m: 1_000_000,
+    cacheRead: 1_000_000,
+    output: 1_000_000,
+    inputIncludesCacheRead: false,
+  };
+  const before = new Date("2026-08-20T23:59:59.999Z");
+  const exact = new Date("2026-08-21T00:00:00.000Z");
+
+  for (const [variant, historical, current] of [
+    ["short", { input: 5, cachedInput: 0.5, cacheCreate30m: 6.25, output: 30 }, { input: 4, cachedInput: 0.4, cacheCreate30m: 5, output: 20 }],
+    ["long", { input: 10, cachedInput: 1, cacheCreate30m: 12.5, output: 45 }, { input: 8, cachedInput: 0.8, cacheCreate30m: 10, output: 30 }],
+  ]) {
+    assert.deepEqual(pricing.lookupOpenAIPrices("gpt-5.6-sol", usageValue, { openaiContext: variant }, before), historical);
+    assert.deepEqual(pricing.lookupOpenAIPrices("gpt-5.6-sol", usageValue, { openaiContext: variant }, exact), current);
+    const historicalCost = pricing.calculateCost("openai", "gpt-5.6-sol", usageValue, before, {
+      openaiContext: variant,
+      pricingCatalog,
+    });
+    const currentCost = pricing.calculateCost("openai", "gpt-5.6-sol", usageValue, exact, {
+      openaiContext: variant,
+      pricingCatalog,
+    });
+    assert.equal(historicalCost.amount, Object.values(historical).reduce((sum, value) => sum + value, 0));
+    assert.equal(currentCost.amount, Object.values(current).reduce((sum, value) => sum + value, 0));
+  }
+});
+
+test("GPT-6 Astra uses the official short and long-context rates", () => {
+  const usageValue = {
+    input: 1_000_000,
+    cacheCreate30m: 1_000_000,
+    cacheRead: 1_000_000,
+    output: 1_000_000,
+    inputIncludesCacheRead: false,
+  };
+  const date = new Date("2026-09-05T00:00:00.000Z");
+
+  assert.deepEqual(pricing.lookupOpenAIPrices("gpt-6-astra", usageValue, { openaiContext: "short" }, date), {
+    input: 10,
+    cachedInput: 1,
+    cacheCreate30m: 12.5,
+    output: 50,
+  });
+  assert.deepEqual(pricing.lookupOpenAIPrices("gpt-6-astra", usageValue, { openaiContext: "long" }, date), {
+    input: 20,
+    cachedInput: 2,
+    cacheCreate30m: 25,
+    output: 75,
+  });
+});
+
 test("unknown providers and models remain unpriced", () => {
   const usageValue = simpleUsage(1_000_000);
 
@@ -997,10 +1053,12 @@ test("unknown providers and models remain unpriced", () => {
 
 test("OpenAI priority service tier applies the model-specific fast multiplier", () => {
   const usageValue = simpleUsage(100_000, 100_000);
-  const date = new Date("2026-07-10T00:00:00.000Z");
+  const date = new Date("2026-09-05T00:00:00.000Z");
   const expectedMultipliers = {
+    "gpt-6-astra": 2.5,
     "gpt-5.5": 2.5,
     "gpt-5.6-sol": 2.5,
+    "gpt-5.6-terra": 2.5,
     "gpt-5.6-luna": 2.5,
     "gpt-5.4": 2,
   };

--- a/test/sqlite.test.js
+++ b/test/sqlite.test.js
@@ -255,7 +255,7 @@ test("SQLite upgrades legacy managed packaged pricing with temporal GPT-5.6 rows
   storedBefore.prepare("UPDATE analytics_settings SET revision = 'packaged-3', value_json = ? WHERE revision = ? AND key = 'pricingRevision'").run(JSON.stringify("packaged-3"), currentRevision);
   storedBefore.prepare("UPDATE analytics_settings SET revision = 'packaged-3' WHERE revision = ?").run(currentRevision);
   storedBefore.prepare("UPDATE pricing_catalog SET revision = 'packaged-3' WHERE revision = ?").run(currentRevision);
-  storedBefore.prepare("DELETE FROM pricing_catalog WHERE revision = 'packaged-3' AND model IN ('gpt-5.6-terra', 'gpt-5.6-luna')").run();
+  storedBefore.prepare("DELETE FROM pricing_catalog WHERE revision = 'packaged-3' AND model IN ('gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna')").run();
   const insertLegacy = storedBefore.prepare(`
     INSERT INTO pricing_catalog(
       revision, row_id, provider, model, match_mode, variant,
@@ -264,6 +264,7 @@ test("SQLite upgrades legacy managed packaged pricing with temporal GPT-5.6 rows
     ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
   for (const [model, rates] of Object.entries({
+    "gpt-5.6-sol": { input: 5, cacheCreate30m: 6.25, cacheRead: 0.5, output: 30 },
     "gpt-5.6-terra": { input: 2, cacheCreate30m: 2.5, cacheRead: 0.2, output: 12 },
     "gpt-5.6-luna": { input: 0.2, cacheCreate30m: 0.25, cacheRead: 0.02, output: 1.2 },
   })) {
@@ -293,7 +294,12 @@ test("SQLite upgrades legacy managed packaged pricing with temporal GPT-5.6 rows
 
   const migrated = await loadConfiguration(options);
   assert.notEqual(migrated.revision, "packaged-3");
-  assert.equal(migrated.settings.pricingRevision, "packaged-4");
+  assert.equal(migrated.settings.pricingRevision, "packaged-5");
+  assert.ok(migrated.prices.some((row) => row.provider === "openai" && row.model === "gpt-6-astra"));
+  const solRows = migrated.prices.filter((row) => row.provider === "openai" && row.model === "gpt-5.6-sol");
+  assert.equal(solRows.length, 4);
+  assert.equal(solRows.filter((row) => row.effectiveUntil === "2026-08-20T23:59:59.999Z").length, 2);
+  assert.equal(solRows.filter((row) => row.effectiveFrom === "2026-08-21T00:00:00.000Z").length, 2);
   const targetRows = migrated.prices.filter((row) => row.provider === "openai" && ["gpt-5.6-terra", "gpt-5.6-luna"].includes(row.model));
   assert.equal(targetRows.length, 8);
   assert.equal(targetRows.filter((row) => row.effectiveUntil === "2026-07-29T23:59:59.999Z").length, 4);
@@ -313,6 +319,16 @@ test("SQLite upgrades legacy managed packaged pricing with temporal GPT-5.6 rows
   assert.deepEqual(
     { input: historicalTerra.input, cacheCreate30m: historicalTerra.cacheCreate30m, cacheRead: historicalTerra.cacheRead, output: historicalTerra.output },
     { input: 2.5, cacheCreate30m: 3.125, cacheRead: 0.25, output: 15 },
+  );
+  const historicalSol = solRows.find((row) => row.variant === "short" && row.effectiveUntil);
+  const currentSol = solRows.find((row) => row.variant === "short" && row.effectiveFrom);
+  assert.deepEqual(
+    { input: historicalSol.input, cacheCreate30m: historicalSol.cacheCreate30m, cacheRead: historicalSol.cacheRead, output: historicalSol.output },
+    { input: 5, cacheCreate30m: 6.25, cacheRead: 0.5, output: 30 },
+  );
+  assert.deepEqual(
+    { input: currentSol.input, cacheCreate30m: currentSol.cacheCreate30m, cacheRead: currentSol.cacheRead, output: currentSol.output },
+    { input: 4, cacheCreate30m: 5, cacheRead: 0.4, output: 20 },
   );
 
   const storedAfter = new DatabaseSync(db);

--- a/test/web.test.js
+++ b/test/web.test.js
@@ -140,6 +140,77 @@ test("web server reuses preloaded report without rebuilding the database", async
   }
 });
 
+test("webserver mode listens before its automatic sync completes", async () => {
+  let syncCalls = 0;
+  let reportBuilds = 0;
+  let releaseSync;
+  const syncGate = new Promise((resolve) => { releaseSync = resolve; });
+  const web = createWebServer({
+    buildReportFromSelectedDatabase: async () => {
+      reportBuilds += 1;
+      return { ...newReport(), marker: "database" };
+    },
+    resolveDbPath: () => Path.join(os.tmpdir(), "tokenomics-startup-sync.sqlite"),
+    syncDatabase: async () => {
+      syncCalls += 1;
+      await syncGate;
+      return { ...newReport(), marker: "current" };
+    },
+  });
+  const server = await web.startWebServer(defaultOptions({
+    webserver: true,
+    webserverSync: true,
+    host: "127.0.0.1",
+    port: 0,
+  }));
+  try {
+    const base = `http://127.0.0.1:${server.address().port}`;
+    const status = await fetch(`${base}/api/sync`).then((response) => response.json());
+    const summaryResponse = await fetch(`${base}/api/summary`);
+    const summary = await summaryResponse.json();
+    assert.equal(syncCalls, 1);
+    assert.equal(status.sync.state, "running");
+    assert.equal(summaryResponse.status, 200);
+    assert.equal(summary.contractVersion, 1);
+    assert.equal(reportBuilds, 0);
+
+    releaseSync();
+    await server.syncController.waitForIdle();
+    assert.equal((await fetch(`${base}/api/sync`).then((response) => response.json())).sync.state, "succeeded");
+    assert.equal((await fetch(`${base}/api/report`).then((response) => response.json())).marker, "current");
+  } finally {
+    releaseSync();
+    await server.syncController.waitForIdle();
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+});
+
+test("webserver mode respects disabled automatic sync", async () => {
+  let syncCalls = 0;
+  const web = createWebServer({
+    buildReportFromSelectedDatabase: async () => newReport(),
+    resolveDbPath: () => Path.join(os.tmpdir(), "tokenomics-no-startup-sync.sqlite"),
+    syncDatabase: async () => {
+      syncCalls += 1;
+      return newReport();
+    },
+  });
+  const server = await web.startWebServer(defaultOptions({
+    webserver: true,
+    webserverSync: false,
+    host: "127.0.0.1",
+    port: 0,
+  }));
+  try {
+    const base = `http://127.0.0.1:${server.address().port}`;
+    const status = await fetch(`${base}/api/sync`).then((response) => response.json());
+    assert.equal(syncCalls, 0);
+    assert.equal(status.sync.state, "idle");
+  } finally {
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+});
+
 test("web server returns 404 for unknown routes and 405 for non-GET requests", async () => {
   const server = await startWebServer(defaultOptions({
     preloadedReport: newReport(),


### PR DESCRIPTION
## Summary

- start the dashboard before the initial synchronization completes and expose the running state through `/api/sync`
- resume append-only Codex and Claude Code JSONL files from the last committed complete record instead of rereading the whole session
- persist guarded byte cursors and parser checkpoints in ClickHouse, while falling back to a full source epoch for truncation, rotation, unsafe checkpoints, or failed guards
- replace full manifest rewrites with per-generation deltas and periodic metadata checkpoints, while preserving marker-last atomic visibility
- add GPT-6 Astra pricing and the August 21 GPT-5.6 Sol price reduction through the `packaged-5` catalog migration

## Motivation

Previously, every changed session was parsed and inserted from byte zero, and webserver startup waited for that synchronization to finish. Work therefore grew with the lifetime of large session files, making startup and later refreshes progressively slower.

## Correctness and compatibility

- only plain append-only Codex and Claude Code JSONL sources take the byte-range fast path; compressed and other formats keep full replacement semantics
- committed byte watermarks hide partial or failed staging rows, and a generation marker is still published last
- logical event keys make append retries idempotent and replace provisional open-turn output metrics
- stale concurrent checkpoints, source rewrites, archived-session moves, legacy multi-import manifests, and forked Codex sessions are covered by fallback or regression tests
- inserts remain awaited and bounded before commit publication; this change does not enable server-side asynchronous inserts
- packaged pricing upgrades reprice stored usage without reopening source sessions and preserve custom catalogs

## Pricing sources

- GPT-6 Astra: https://developers.openai.com/api/docs/models/gpt-6-astra
- GPT-5.6 Sol: https://developers.openai.com/api/docs/models/gpt-5.6-sol
- Codex Fast mode: https://learn.chatgpt.com/docs/agent-configuration/speed

## Verification

- `node --test --test-concurrency=1` — 293/293 passed
- `npm --cache /private/tmp/tokenomics-npm-cache pack --dry-run --json` — passed
- `git diff --check` — passed
- the Node suite includes a `clickhouse-local` analyzer check for the manifest query and focused append, retry, failure, concurrency, migration, pricing-boundary, and startup tests

## Residual risk

The append detector intentionally uses bounded prefix samples plus a tail guard rather than hashing the entire historical file on every sync. It relies on the append-only producer contract; an in-place rewrite outside all sampled windows may require a manual reset. No live user database or menu-bar process was mutated during verification.
