### PR TITLE
Prevent replayed Codex usage from inflating costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ without launching the application:
 TOKENOMICS_NO_LAUNCH=1 /bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/skuznetsov/tokenomics-viewer/main/install.sh)"
 ```
 
+Updates replace the previously installed local runtime before synchronization.
+Ordinary incremental synchronization keeps the last committed report visible;
+when an analytics-format migration requires a one-time replay, Tokenomics hides
+the affected totals until the corrected generation is published atomically.
+
 If `~/.local/bin` is not on `PATH`, the installer prints the exact `export`
 command to use. It does not edit shell startup files.
 

--- a/install.sh
+++ b/install.sh
@@ -133,18 +133,25 @@ copy_application() {
 write_wrapper() {
   wrapper=$1
   entrypoint=$2
+  wrapper_releases_root=${3:-}
   node_q=$(shell_quote "$NODE_BIN")
   entry_q=$(shell_quote "$INSTALL_ROOT/current/$entrypoint")
   temporary="$wrapper.$$"
   {
     printf '%s\n' '#!/bin/sh'
-    printf 'exec %s %s "$@"\n' "$node_q" "$entry_q"
+    if [ "$entrypoint" = "launcher.js" ] && [ -n "$wrapper_releases_root" ]; then
+      releases_q=$(shell_quote "$wrapper_releases_root")
+      printf 'exec %s %s --legacy-releases-root %s "$@"\n' "$node_q" "$entry_q" "$releases_q"
+    else
+      printf 'exec %s %s "$@"\n' "$node_q" "$entry_q"
+    fi
   } > "$temporary"
   chmod 755 "$temporary"
   mv -f "$temporary" "$wrapper"
 }
 
 write_macos_launcher_configuration() {
+  runtime_id=$1
   configuration_path=${TOKENOMICS_MACOS_LAUNCHER_CONFIG:-}
   if [ -z "$configuration_path" ]; then
     [ "$(uname -s)" = "Darwin" ] || return 0
@@ -154,16 +161,16 @@ write_macos_launcher_configuration() {
   "$NODE_BIN" -e '
     const fs = require("node:fs");
     const path = require("node:path");
-    const [configurationPath, command] = process.argv.slice(1);
+    const [configurationPath, command, runtimeId] = process.argv.slice(1);
     const temporary = `${configurationPath}.${process.pid}.tmp`;
     fs.mkdirSync(path.dirname(configurationPath), { recursive: true });
     try {
-      fs.writeFileSync(temporary, `${JSON.stringify({ schema: 1, command, args: [] }, null, 2)}\n`, { mode: 0o600 });
+      fs.writeFileSync(temporary, `${JSON.stringify({ schema: 1, command, args: [], runtimeId }, null, 2)}\n`, { mode: 0o600 });
       fs.renameSync(temporary, configurationPath);
     } finally {
       fs.rmSync(temporary, { force: true });
     }
-  ' "$configuration_path" "$BIN_DIR/tokenomics-launch"
+  ' "$configuration_path" "$BIN_DIR/tokenomics-launch" "$runtime_id"
 }
 
 require_command curl
@@ -213,6 +220,8 @@ else
 fi
 
 "$NODE_BIN" "$staged_release/launcher.js" --help >/dev/null
+runtime_id=$("$NODE_BIN" -e 'process.stdout.write(require(process.argv[1]).RUNTIME_ID)' \
+  "$staged_release/lib/core/runtime-identity.js")
 mv "$staged_release" "$release_dir"
 next_link="$INSTALL_ROOT/.current.$$"
 ln -s "$release_dir" "$next_link"
@@ -221,8 +230,8 @@ ln -s "$release_dir" "$next_link"
 
 write_wrapper "$BIN_DIR/tokenomics" app.js
 write_wrapper "$BIN_DIR/tokenomics-viewer" app.js
-write_wrapper "$BIN_DIR/tokenomics-launch" launcher.js
-write_macos_launcher_configuration
+write_wrapper "$BIN_DIR/tokenomics-launch" launcher.js "$RELEASES_DIR"
+write_macos_launcher_configuration "$runtime_id"
 
 say "Tokenomics Viewer installed in $INSTALL_ROOT"
 say "Commands installed in $BIN_DIR"

--- a/lib/core/derivation.js
+++ b/lib/core/derivation.js
@@ -2,9 +2,14 @@
 
 // Bump these independently when their derived values can change for the same source bytes.
 const ANALYTICS_DERIVATION_VERSION = 8;
+// Keep parser-owned revisions separate from the shared analytics counter. Two
+// parallel changes can otherwise choose the same next integer and accidentally
+// make an old source look current after both branches merge.
+const CODEX_USAGE_DERIVATION_VERSION = 2;
 
 function sourceFingerprint(parts, {
   analyticsDerivationVersion = ANALYTICS_DERIVATION_VERSION,
+  codexUsageDerivationVersion = CODEX_USAGE_DERIVATION_VERSION,
 } = {}) {
   const {
     pricingCatalogVersion: _legacyPricingCatalogVersion,
@@ -14,6 +19,7 @@ function sourceFingerprint(parts, {
   return Object.entries({
     ...sourceParts,
     analyticsDerivationVersion,
+    codexUsageDerivationVersion,
   })
     .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
     .map(([key, value]) => String(key) + "=" + (value ?? ""))
@@ -33,7 +39,15 @@ function sameSourceFingerprint(left, right) {
 }
 
 function analyticsDerivationVersionFromFingerprint(fingerprint) {
-  const prefix = "analyticsDerivationVersion=";
+  return derivationVersionFromFingerprint(fingerprint, "analyticsDerivationVersion");
+}
+
+function codexUsageDerivationVersionFromFingerprint(fingerprint) {
+  return derivationVersionFromFingerprint(fingerprint, "codexUsageDerivationVersion");
+}
+
+function derivationVersionFromFingerprint(fingerprint, key) {
+  const prefix = key + "=";
   const part = String(fingerprint || "")
     .split("|")
     .find((candidate) => candidate.startsWith(prefix));
@@ -43,15 +57,22 @@ function analyticsDerivationVersionFromFingerprint(fingerprint) {
 }
 
 function sameAnalyticsDerivation(left, right) {
-  const leftVersion = analyticsDerivationVersionFromFingerprint(left);
-  const rightVersion = analyticsDerivationVersionFromFingerprint(right);
-  return leftVersion !== null && leftVersion === rightVersion;
+  const leftAnalytics = analyticsDerivationVersionFromFingerprint(left);
+  const rightAnalytics = analyticsDerivationVersionFromFingerprint(right);
+  const leftCodexUsage = codexUsageDerivationVersionFromFingerprint(left);
+  const rightCodexUsage = codexUsageDerivationVersionFromFingerprint(right);
+  return leftAnalytics !== null
+    && leftAnalytics === rightAnalytics
+    && leftCodexUsage !== null
+    && leftCodexUsage === rightCodexUsage;
 }
 
 module.exports = {
   ANALYTICS_DERIVATION_VERSION,
+  CODEX_USAGE_DERIVATION_VERSION,
   analyticsDerivationVersionFromFingerprint,
   canonicalSourceFingerprint,
+  codexUsageDerivationVersionFromFingerprint,
   sameAnalyticsDerivation,
   sameSourceFingerprint,
   sourceFingerprint,

--- a/lib/core/derivation.js
+++ b/lib/core/derivation.js
@@ -32,9 +32,27 @@ function sameSourceFingerprint(left, right) {
   return canonicalSourceFingerprint(left) === canonicalSourceFingerprint(right);
 }
 
+function analyticsDerivationVersionFromFingerprint(fingerprint) {
+  const prefix = "analyticsDerivationVersion=";
+  const part = String(fingerprint || "")
+    .split("|")
+    .find((candidate) => candidate.startsWith(prefix));
+  if (!part) return null;
+  const value = Number(part.slice(prefix.length));
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+function sameAnalyticsDerivation(left, right) {
+  const leftVersion = analyticsDerivationVersionFromFingerprint(left);
+  const rightVersion = analyticsDerivationVersionFromFingerprint(right);
+  return leftVersion !== null && leftVersion === rightVersion;
+}
+
 module.exports = {
   ANALYTICS_DERIVATION_VERSION,
+  analyticsDerivationVersionFromFingerprint,
   canonicalSourceFingerprint,
+  sameAnalyticsDerivation,
   sameSourceFingerprint,
   sourceFingerprint,
 };

--- a/lib/core/runtime-identity.js
+++ b/lib/core/runtime-identity.js
@@ -1,0 +1,37 @@
+"use strict";
+
+const Crypto = require("node:crypto");
+const Fs = require("node:fs");
+const Path = require("node:path");
+
+const RUNTIME_IDENTITY_PATHS = ["app.js", "launcher.js", "package.json", "lib", "public"];
+
+function addPathToHash(hash, root, relativePath) {
+  const absolutePath = Path.join(root, relativePath);
+  const stat = Fs.lstatSync(absolutePath);
+  if (stat.isDirectory()) {
+    for (const entry of Fs.readdirSync(absolutePath).sort()) {
+      addPathToHash(hash, root, Path.join(relativePath, entry));
+    }
+    return;
+  }
+  if (!stat.isFile()) return;
+  hash.update(relativePath.split(Path.sep).join("/"));
+  hash.update("\0");
+  hash.update(Fs.readFileSync(absolutePath));
+  hash.update("\0");
+}
+
+function runtimeIdentity(root = Path.resolve(__dirname, "../..")) {
+  const hash = Crypto.createHash("sha256");
+  for (const relativePath of RUNTIME_IDENTITY_PATHS) addPathToHash(hash, root, relativePath);
+  return `sha256:${hash.digest("hex")}`;
+}
+
+const RUNTIME_ID = runtimeIdentity();
+
+module.exports = {
+  RUNTIME_ID,
+  RUNTIME_IDENTITY_PATHS,
+  runtimeIdentity,
+};

--- a/lib/core/usage.js
+++ b/lib/core/usage.js
@@ -125,8 +125,8 @@ function usageFromCodexInfo(info, previousTotalUsage = null, preferLastTokenUsag
     const lastUsage = source.last_token_usage
       ? usageFromCodexTokenUsage(source.last_token_usage, contextWindow)
       : null;
-    const usage = preferLastTokenUsage && lastUsage
-      ? lastUsage
+    const usage = preferLastTokenUsage
+      ? (lastUsage || usageFromCodexTokenUsage({}, contextWindow))
       : previousTotalUsage ? subtractUsage(totalUsage, previousTotalUsage) : totalUsage;
     return {
       usage,

--- a/lib/ingest/parser.js
+++ b/lib/ingest/parser.js
@@ -26,6 +26,7 @@ const {
   usageFromClaudeUsage,
   usageFromOmpUsage,
   usageFromCodexInfo,
+  usageFromCodexTokenUsage,
 } = require("../core/usage");
 const { addUsage } = require("../core/aggregate");
 const {
@@ -43,7 +44,10 @@ const {
 const { addRateLimitSnapshot } = require("../core/rate-limits");
 const { addTelemetrySnapshot } = require("../core/telemetry");
 
-const CODEX_PARSER_CHECKPOINT_VERSION = 1;
+const CODEX_PARSER_CHECKPOINT_VERSION = 2;
+const SUPPORTED_PARSER_CHECKPOINT_VERSIONS = new Set([1, CODEX_PARSER_CHECKPOINT_VERSION]);
+const CODEX_USAGE_FORMAT_LEGACY = "legacy-token-count";
+const CODEX_USAGE_FORMAT_RECORD = "token-usage-record";
 // The durable ClickHouse event key (request ID or global source line) performs
 // exact cross-range and retry deduplication.
 // Keep only a bounded recent window here to suppress adjacent duplicates while
@@ -54,10 +58,29 @@ function cloneCheckpointValue(value) {
   return value == null ? value : JSON.parse(JSON.stringify(value));
 }
 
+function isSupportedCodexTokenUsage(usage) {
+  if (!usage || typeof usage !== "object" || Array.isArray(usage)) return false;
+  const hasOwn = (field) => Object.prototype.hasOwnProperty.call(usage, field);
+  const isTokenCount = (value) => Number.isSafeInteger(value) && value >= 0;
+  const requiredFields = ["input_tokens", "output_tokens", "total_tokens"];
+  if (!requiredFields.every((field) => hasOwn(field) && isTokenCount(usage[field]))) return false;
+  const optionalFields = ["cached_input_tokens", "cache_write_input_tokens", "reasoning_output_tokens"];
+  if (!optionalFields.every((field) => !hasOwn(field) || isTokenCount(usage[field]))) return false;
+
+  const input = usage.input_tokens;
+  const output = usage.output_tokens;
+  const cacheRead = usage.cached_input_tokens || 0;
+  const cacheWrite = usage.cache_write_input_tokens || 0;
+  const reasoningOutput = usage.reasoning_output_tokens || 0;
+  return usage.total_tokens === input + output
+    && cacheRead + cacheWrite <= input
+    && reasoningOutput <= output;
+}
+
 function restoreParserCheckpoint(checkpoint, sourceLabel) {
   if (!checkpoint) return null;
   const kind = checkpoint.kind || "codex";
-  if (checkpoint.version !== CODEX_PARSER_CHECKPOINT_VERSION) {
+  if (!SUPPORTED_PARSER_CHECKPOINT_VERSIONS.has(checkpoint.version)) {
     throw new Error(`Unsupported ${kind === "claude" ? "Claude" : "Codex"} parser checkpoint version: ${checkpoint.version}`);
   }
   if (checkpoint.sourceLabel !== sourceLabel) {
@@ -78,8 +101,24 @@ function restoreParserCheckpoint(checkpoint, sourceLabel) {
     };
   }
   if (kind !== "codex") throw new Error(`Unsupported parser checkpoint kind: ${kind}`);
+  if (checkpoint.version < CODEX_PARSER_CHECKPOINT_VERSION) {
+    throw new Error("Stale Codex parser checkpoint requires a full source replay");
+  }
   if (!checkpoint.sessionId || checkpoint.forkedFromId || checkpoint.skippingForkReplay) {
     throw new Error("Codex parser checkpoint is not safe to resume");
+  }
+  const usageFormat = checkpoint.usageFormat || CODEX_USAGE_FORMAT_LEGACY;
+  if (![CODEX_USAGE_FORMAT_LEGACY, CODEX_USAGE_FORMAT_RECORD].includes(usageFormat)) {
+    throw new Error(`Unsupported Codex usage format in parser checkpoint: ${usageFormat}`);
+  }
+  const recentUsageResponseIds = checkpoint.recentUsageResponseIds ?? [];
+  if (
+    !Array.isArray(recentUsageResponseIds) ||
+    recentUsageResponseIds.length > CLAUDE_REQUEST_CHECKPOINT_LIMIT ||
+    recentUsageResponseIds.some((id) => typeof id !== "string" || !id) ||
+    (usageFormat === CODEX_USAGE_FORMAT_RECORD && checkpoint.version >= 2 && !checkpoint.recentUsageResponseIds)
+  ) {
+    throw new Error("Codex token usage record checkpoint is not safe to resume");
   }
 
   const turn = checkpoint.turn ? cloneCheckpointValue(checkpoint.turn) : null;
@@ -97,6 +136,8 @@ function restoreParserCheckpoint(checkpoint, sourceLabel) {
     skippingForkReplay: false,
     preScannedForkReplay: false,
     preferLastTokenUsageAfterForkReplay: false,
+    usageFormat,
+    recentUsageResponseIds: [...new Set(recentUsageResponseIds)],
     project: checkpoint.project,
     model: checkpoint.model,
     provider: checkpoint.provider,
@@ -149,6 +190,8 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
     skippingForkReplay: false,
     preScannedForkReplay: false,
     preferLastTokenUsageAfterForkReplay: false,
+    usageFormat: CODEX_USAGE_FORMAT_LEGACY,
+    recentUsageResponseIds: [],
     project: UNKNOWN_PROJECT,
     model: UNKNOWN_MODEL,
     provider: "openai",
@@ -169,6 +212,7 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
   };
 
   const seenClaudeRequests = new Set(restoredCheckpoint?.kind === "claude" ? restoredCheckpoint.seenRequestIds : []);
+  const seenCodexUsageResponses = new Set(codexState.recentUsageResponseIds);
   let hasClaudeUsage = restoredCheckpoint?.kind === "claude";
   if (restoredCodexState) {
     report._rateLimitSequence = Number(parserCheckpoint.rateLimitSequence) || 0;
@@ -251,6 +295,61 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
     updateTurnMeta();
   };
 
+  const addCodexUsage = (usage, timestamp, lineNo, requestId = null) => {
+    ensureTurn(null, timestamp, lineNo);
+    const provider = codexState.provider || "openai";
+    const model = codexState.model;
+    const effort = codexState.effort;
+    codexState.turn.output += usage.output;
+    codexState.turn.reasoningOutput += usage.reasoningOutput;
+    if (!hasUsageTokens(usage)) return null;
+
+    const added = addUsage(report, {
+      provider,
+      model,
+      project: codexState.project,
+      effort,
+      serviceTier: codexState.turn?.serviceTier || codexState.serviceTier,
+      serviceMode: codexState.turn?.serviceMode || codexState.serviceMode,
+      agent: CODEX_SERVICE_AGENT,
+      timestamp,
+      usage,
+      visibleChars: codexState.visibleChars,
+      sourcePath: session?.path || sourceLabel,
+      lineNo,
+      requestId,
+    }, options);
+    const visibleOutputTokens = outputTextTokens(added.usage);
+    const visibleOutputChars = preferredAssistantOutputChars(codexState.assistantOutputChars);
+    if (visibleOutputChars > 0 && visibleOutputTokens > 0) {
+      const charsPerToken = visibleOutputChars / visibleOutputTokens;
+      const outputMetricKey = codexState.turn.hasOutputCharMetric
+        ? `${codexState.turn.turnKey}:request:${requestId || lineNo}`
+        : codexState.turn.turnKey;
+      codexState.turn.hasOutputCharMetric = true;
+      if (charsPerToken <= MAX_VALID_OUTPUT_CHARS_PER_TOKEN) {
+        const outputCharMetric = addOutputCharTokenMetric(report, {
+          sourcePath: session?.path || sourceLabel,
+          turnId: codexState.turn?.turnId || null,
+          turnKey: outputMetricKey || null,
+          lineNo,
+          timestamp,
+          provider,
+          model,
+          project: codexState.project,
+          effort,
+          visibleOutputChars,
+          visibleOutputTokens,
+        });
+        if (session) addOutputCharTokenStats(session.stats, outputCharMetric);
+      }
+    }
+    codexState.visibleChars = newVisibleChars();
+    codexState.assistantOutputChars = newAssistantOutputChars();
+    if (session) addToStats(session.stats, added.usage, added.cost, added.visibleChars);
+    return added;
+  };
+
   const addOmpUsage = (json, lineNo) => {
     // Model id: prefer the model nested in the assistant message; fall back to
     // the model_change combined form (segment after the last '/'), else UNKNOWN.
@@ -327,6 +426,17 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
       if (!codexState.sessionId) {
         codexState.sessionId = normalizeCodexUuid(json.payload.id) || json.payload.id || null;
         codexState.forkedFromId = normalizeCodexUuid(json.payload.forked_from_id);
+        const sourceParentThreadId = normalizeCodexUuid(
+          json.payload.parent_thread_id || json.payload.source?.subagent?.thread_spawn?.parent_thread_id,
+        );
+        // A new ownership domain may inherit a cumulative legacy counter. The
+        // first snapshot establishes its baseline; only its last request is
+        // attributable to this thread. This is structural, not date/version
+        // based, and also covers modern subagents without forked_from_id.
+        codexState.preferLastTokenUsageAfterForkReplay = Boolean(
+          (codexState.forkedFromId && !sameCodexUuid(codexState.forkedFromId, codexState.sessionId)) ||
+          (sourceParentThreadId && !sameCodexUuid(sourceParentThreadId, codexState.sessionId)),
+        );
         codexState.forkParentTraces = codexState.forkedFromId
           ? options.codexForkRegistry?.tracesBySession?.get(codexState.forkedFromId) || null
           : null;
@@ -391,6 +501,38 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
       if (codexState.skippingForkReplay) return;
     }
 
+    if (json.type === "token_usage_record" && json.payload) {
+      const recordThreadId = normalizeCodexUuid(json.payload.thread_id);
+      // New records are authoritative only when Codex explicitly attributes
+      // them to this rollout. Copied parent records must not switch formats.
+      if (!recordThreadId || !codexState.sessionId || !sameCodexUuid(recordThreadId, codexState.sessionId)) {
+        return;
+      }
+      const requestId = typeof json.payload.response_id === "string" && json.payload.response_id
+        ? json.payload.response_id
+        : null;
+      codexState.usageFormat = CODEX_USAGE_FORMAT_RECORD;
+      codexState.totalUsage = null;
+      codexState.preferLastTokenUsageAfterForkReplay = false;
+      if (!requestId || !isSupportedCodexTokenUsage(json.payload.usage)) {
+        report.sources.parseErrors += 1;
+        if (session) session.parseErrors += 1;
+        if (options.strictJson) {
+          throw new Error(`Unsupported Codex token_usage_record in ${sourceLabel}:${lineNo}`);
+        }
+        return;
+      }
+      if (seenCodexUsageResponses.has(requestId)) return;
+      seenCodexUsageResponses.add(requestId);
+      if (seenCodexUsageResponses.size > CLAUDE_REQUEST_CHECKPOINT_LIMIT) {
+        seenCodexUsageResponses.delete(seenCodexUsageResponses.values().next().value);
+      }
+      const timestamp = new Date(json.timestamp);
+      ensureTurn(json.payload.turn_id || null, timestamp, lineNo);
+      addCodexUsage(usageFromCodexTokenUsage(json.payload.usage), timestamp, lineNo, requestId);
+      return;
+    }
+
     if (json.type === "event_msg" && json.payload?.type === "thread_settings_applied") {
       const serviceTier = normalizeServiceTier(json.payload.thread_settings?.service_tier);
       if (serviceTier !== UNKNOWN_SERVICE_TIER) {
@@ -433,6 +575,22 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
       const provider = codexState.provider || "openai";
       const model = codexState.model;
       const effort = codexState.effort;
+      if (codexState.usageFormat === CODEX_USAGE_FORMAT_RECORD) {
+        addRateLimitSnapshot(report, json.payload.rate_limits, {
+          agent: AGENT_CODEX,
+          provider,
+          model,
+          effort,
+          timestamp,
+          sourcePath: session?.path || sourceLabel,
+          lineNo,
+          usage: normalizeUsage({}),
+          cost: { known: true, amount: 0, reasoningAmount: 0 },
+        });
+        report.sources.skippedTokenCountSnapshots += 1;
+        if (session) session.skippedTokenCountSnapshots += 1;
+        return;
+      }
       const lastTokenUsage = json.payload.info.last_token_usage;
       if (!json.payload.info.total_token_usage && lastTokenUsage) {
         const lastTokenUsageKey = JSON.stringify(lastTokenUsage);
@@ -465,10 +623,9 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
       );
       codexState.totalUsage = codexUsage.totalUsage || null;
       codexState.preferLastTokenUsageAfterForkReplay = false;
-      codexState.turn.output += codexUsage.usage.output;
-      codexState.turn.reasoningOutput += codexUsage.usage.reasoningOutput;
 
-      if (!hasUsageTokens(codexUsage.usage)) {
+      const added = addCodexUsage(codexUsage.usage, timestamp, lineNo);
+      if (!added) {
         addRateLimitSnapshot(report, json.payload.rate_limits, {
           agent: AGENT_CODEX,
           provider,
@@ -484,48 +641,6 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
         if (session) session.skippedTokenCountSnapshots += 1;
         return;
       }
-
-      const added = addUsage(report, {
-        provider,
-        model,
-        project: codexState.project,
-        effort,
-        serviceTier: codexState.turn?.serviceTier || codexState.serviceTier,
-        serviceMode: codexState.turn?.serviceMode || codexState.serviceMode,
-        agent: CODEX_SERVICE_AGENT,
-        timestamp,
-        usage: codexUsage.usage,
-        visibleChars: codexState.visibleChars,
-        sourcePath: session?.path || sourceLabel,
-        lineNo,
-      }, options);
-      const visibleOutputTokens = outputTextTokens(added.usage);
-      const visibleOutputChars = preferredAssistantOutputChars(codexState.assistantOutputChars);
-      if (visibleOutputChars > 0 && visibleOutputTokens > 0) {
-        const charsPerToken = visibleOutputChars / visibleOutputTokens;
-        const outputMetricKey = codexState.turn.hasOutputCharMetric
-          ? `${codexState.turn.turnKey}:request:${lineNo}`
-          : codexState.turn.turnKey;
-        codexState.turn.hasOutputCharMetric = true;
-        if (charsPerToken <= MAX_VALID_OUTPUT_CHARS_PER_TOKEN) {
-          const outputCharMetric = addOutputCharTokenMetric(report, {
-            sourcePath: session?.path || sourceLabel,
-            turnId: codexState.turn?.turnId || null,
-            turnKey: outputMetricKey || null,
-            lineNo,
-            timestamp,
-            provider,
-            model,
-            project: codexState.project,
-            effort,
-            visibleOutputChars,
-            visibleOutputTokens,
-          });
-          if (session) addOutputCharTokenStats(session.stats, outputCharMetric);
-        }
-      }
-      codexState.visibleChars = newVisibleChars();
-      codexState.assistantOutputChars = newAssistantOutputChars();
       addRateLimitSnapshot(report, json.payload.rate_limits, {
         agent: AGENT_CODEX,
         provider,
@@ -537,7 +652,6 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
         usage: added.usage,
         cost: added.cost,
       });
-      if (session) addToStats(session.stats, added.usage, added.cost, added.visibleChars);
       return;
     }
 
@@ -641,6 +755,8 @@ function createLineProcessor(report, options, sourceLabel, session = null) {
       effort: codexState.effort,
       serviceTier: codexState.serviceTier,
       serviceMode: codexState.serviceMode,
+      usageFormat: codexState.usageFormat,
+      recentUsageResponseIds: [...seenCodexUsageResponses],
       totalUsage: cloneCheckpointValue(codexState.totalUsage),
       visibleChars: cloneCheckpointValue(codexState.visibleChars),
       assistantOutputChars: cloneCheckpointValue(codexState.assistantOutputChars),

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -5,7 +5,10 @@ const Fs = require("node:fs");
 const Net = require("node:net");
 const Os = require("node:os");
 const Path = require("node:path");
+const Util = require("node:util");
+const { RUNTIME_ID } = require("./core/runtime-identity");
 const fsp = Fs.promises;
+const execFile = Util.promisify(ChildProcess.execFile);
 
 const CLICKHOUSE_URL = "http://127.0.0.1:8123";
 const INSTALLER_URL = "https://clickhouse.com/cli";
@@ -16,6 +19,7 @@ function parseLauncherArgs(argv) {
     forceEngine: null,
     noOpen: false,
     port: DEFAULT_PORT,
+    legacyReleasesRoot: null,
     appArgs: [],
   };
   for (let index = 0; index < argv.length; index += 1) {
@@ -36,6 +40,10 @@ function parseLauncherArgs(argv) {
       options.port = Number(argv[++index]);
     } else if (arg.startsWith("--port=")) {
       options.port = Number(arg.slice("--port=".length));
+    } else if (arg === "--legacy-releases-root") {
+      options.legacyReleasesRoot = argv[++index] || null;
+    } else if (arg.startsWith("--legacy-releases-root=")) {
+      options.legacyReleasesRoot = arg.slice("--legacy-releases-root=".length) || null;
     } else if (arg === "--help" || arg === "-h") {
       options.help = true;
     } else {
@@ -44,6 +52,9 @@ function parseLauncherArgs(argv) {
   }
   if (!Number.isInteger(options.port) || options.port < 1 || options.port > 65535) {
     throw new Error("Launcher port must be an integer from 1 to 65535");
+  }
+  if (options.legacyReleasesRoot && !Path.isAbsolute(options.legacyReleasesRoot)) {
+    throw new Error("Legacy releases root must be absolute");
   }
   return options;
 }
@@ -207,21 +218,143 @@ async function httpOk(url) {
   }
 }
 
-async function dashboardReady(baseUrl, expectedEngine = null) {
+async function dashboardStatus(baseUrl, expectedEngine = null, expectedRuntimeId = RUNTIME_ID) {
   try {
     const response = await fetch(`${baseUrl}/api/sync`, {
       signal: AbortSignal.timeout(1_500),
       cache: "no-store",
     });
-    if (!response.ok) return false;
+    if (!response.ok) return { kind: "unavailable", sync: null };
     const body = await response.json();
-    if (!body?.sync || body.sync.available !== true) return false;
-    if (!expectedEngine) return true;
+    if (!body?.sync || body.sync.available !== true) {
+      return { kind: "unavailable", sync: body?.sync || null };
+    }
     const engine = body.sync.engine || body.sync.result?.engine;
-    return engine === expectedEngine;
+    const engineMatches = !expectedEngine || engine === expectedEngine;
+    const runtimeMatches = !expectedRuntimeId || body.sync.runtimeId === expectedRuntimeId;
+    return {
+      kind: engineMatches && runtimeMatches ? "compatible" : "stale",
+      sync: body.sync,
+    };
+  } catch {
+    return { kind: "unavailable", sync: null };
+  }
+}
+
+async function dashboardReady(baseUrl, expectedEngine = null, expectedRuntimeId = RUNTIME_ID) {
+  return (await dashboardStatus(baseUrl, expectedEngine, expectedRuntimeId)).kind === "compatible";
+}
+
+async function requestRuntimeStop(baseUrl) {
+  let response;
+  try {
+    response = await fetch(`${baseUrl}/api/runtime/stop`, {
+      method: "POST",
+      headers: { "x-tokenomics-action": "replace-runtime" },
+      signal: AbortSignal.timeout(5_000),
+    });
+  } catch {
+    return "unavailable";
+  }
+  if (response.status === 202) return "stopping";
+  if ([404, 405, 501].includes(response.status)) return "unsupported";
+  if (response.status === 409) return "busy";
+  throw new Error(`Existing dashboard rejected runtime replacement: HTTP ${response.status}`);
+}
+
+async function listeningProcessIds(port) {
+  try {
+    const { stdout } = await execFile("lsof", ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-t"]);
+    return [...new Set(stdout.split(/\s+/).filter((value) => /^\d+$/.test(value)).map(Number))];
+  } catch (error) {
+    if (error.code === 1) return [];
+    throw error;
+  }
+}
+
+async function processWorkingDirectory(pid) {
+  try {
+    const { stdout } = await execFile("lsof", ["-a", "-p", String(pid), "-d", "cwd", "-Fn"]);
+    const pathLine = stdout.split(/\r?\n/).find((line) => line.startsWith("n"));
+    return pathLine ? pathLine.slice(1) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function processCommandLine(pid) {
+  try {
+    const { stdout } = await execFile("ps", ["-ww", "-p", String(pid), "-o", "command="]);
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function commandRunsEntrypoint(commandLine, entrypoint) {
+  if (!commandLine) return false;
+  const escaped = entrypoint.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(?:^|[\\s"'])${escaped}(?=$|[\\s"'])`).test(commandLine);
+}
+
+async function stopLegacyDashboard(port, releasesRoot, dependencies = {}) {
+  if (!releasesRoot) return false;
+  const listPids = dependencies.listeningProcessIds || listeningProcessIds;
+  const workingDirectory = dependencies.processWorkingDirectory || processWorkingDirectory;
+  const commandLine = dependencies.processCommandLine || processCommandLine;
+  const realpath = dependencies.realpath || ((path) => fsp.realpath(path));
+  const kill = dependencies.kill || ((pid, signal) => process.kill(pid, signal));
+  let expectedRoot;
+  try {
+    expectedRoot = await realpath(releasesRoot);
   } catch {
     return false;
   }
+  const matching = [];
+  for (const pid of await listPids(port)) {
+    const directory = await workingDirectory(pid);
+    const actualDirectory = directory ? await realpath(directory).catch(() => null) : null;
+    const command = await commandLine(pid);
+    const isInstalledRelease = actualDirectory && Path.dirname(actualDirectory) === expectedRoot;
+    const expectedEntrypoint = actualDirectory && Path.join(actualDirectory, "app.js");
+    if (isInstalledRelease && commandRunsEntrypoint(command, expectedEntrypoint)) {
+      matching.push(pid);
+    }
+  }
+  if (matching.length !== 1) return false;
+  kill(matching[0], "SIGTERM");
+  return true;
+}
+
+async function replaceStaleDashboard(runtime, baseUrl, port, initialStatus, legacyReleasesRoot) {
+  let status = initialStatus;
+  await waitUntil(async () => {
+    if (status.sync?.state !== "running") return true;
+    status = await runtime.dashboardStatus(baseUrl, null, null);
+    return status.kind === "unavailable" || status.sync?.state !== "running";
+  }, { timeoutMs: 30 * 60_000, intervalMs: 500, label: "existing Tokenomics synchronization" });
+
+  let stopResult = await runtime.requestRuntimeStop(baseUrl);
+  if (stopResult === "busy") {
+    await waitUntil(async () => {
+      const current = await runtime.dashboardStatus(baseUrl, null, null);
+      return current.kind === "unavailable" || current.sync?.state !== "running";
+    }, { timeoutMs: 30 * 60_000, intervalMs: 500, label: "existing Tokenomics synchronization" });
+    stopResult = await runtime.requestRuntimeStop(baseUrl);
+  }
+  if (stopResult === "unsupported") {
+    const stopped = await runtime.stopLegacyDashboard(port, legacyReleasesRoot);
+    if (!stopped) {
+      throw new Error("An older Tokenomics runtime owns the dashboard port and could not be replaced safely");
+    }
+  } else if (!["stopping", "unavailable"].includes(stopResult)) {
+    throw new Error("The existing Tokenomics runtime could not be replaced safely");
+  }
+  await waitUntil(() => runtime.portAvailable(port), {
+    timeoutMs: 30_000,
+    intervalMs: 100,
+    label: `dashboard port ${port}`,
+  });
 }
 
 async function triggerSync(baseUrl) {
@@ -322,7 +455,10 @@ function defaultRuntime() {
   return {
     sqliteDb: Path.join(dataDirectory, "tokenomics.sqlite"),
     log: console.log,
+    dashboardStatus,
     dashboardReady,
+    requestRuntimeStop,
+    stopLegacyDashboard,
     triggerSync,
     ensureClickHouse: () => ensureClickHouse({
       healthCheck: clickhouseHealth,
@@ -333,6 +469,7 @@ function defaultRuntime() {
       waitForHealth: () => waitUntil(clickhouseHealth, { timeoutMs: 120_000, label: "ClickHouse" }),
     }),
     findAvailablePort,
+    portAvailable,
     spawnTokenomics,
     waitForDashboard: (url, child) => waitForDashboardProcess(url, child),
     openBrowser,
@@ -350,11 +487,21 @@ async function runLauncher(argv, dependencies = {}) {
   const engine = options.forceEngine || "clickhouse";
 
   const preferredUrl = `http://127.0.0.1:${options.port}`;
-  if (await runtime.dashboardReady(preferredUrl, engine)) {
+  const status = dependencies.dashboardStatus
+    ? await dependencies.dashboardStatus(preferredUrl, engine, RUNTIME_ID)
+    : dependencies.dashboardReady
+      ? { kind: await dependencies.dashboardReady(preferredUrl, engine, RUNTIME_ID) ? "compatible" : "unavailable", sync: null }
+      : await runtime.dashboardStatus(preferredUrl, engine, RUNTIME_ID);
+  if (status.kind === "compatible") {
     runtime.log(`Reusing dashboard at ${preferredUrl}`);
     await runtime.triggerSync(preferredUrl);
     await openBrowserSafely(runtime, preferredUrl, options.noOpen);
     return 0;
+  }
+
+  if (status.kind === "stale") {
+    runtime.log(`Replacing an older Tokenomics runtime at ${preferredUrl}`);
+    await replaceStaleDashboard(runtime, preferredUrl, options.port, status, options.legacyReleasesRoot);
   }
 
   if (engine === "clickhouse") await runtime.ensureClickHouse();
@@ -383,6 +530,7 @@ async function runLauncher(argv, dependencies = {}) {
 module.exports = {
   CLICKHOUSE_URL,
   browserCommand,
+  dashboardStatus,
   dashboardReady,
   downloadClickHouseInstaller,
   ensureClickHouse,
@@ -393,5 +541,6 @@ module.exports = {
   launcherHelpText,
   parseLauncherArgs,
   runLauncher,
+  stopLegacyDashboard,
   waitForDashboardProcess,
 };

--- a/lib/storage/clickhouse.js
+++ b/lib/storage/clickhouse.js
@@ -25,7 +25,11 @@ const {
   weekKey,
   yearKey,
 } = require("../core/report-model");
-const { sameSourceFingerprint, sourceFingerprint } = require("../core/derivation");
+const {
+  sameAnalyticsDerivation,
+  sameSourceFingerprint,
+  sourceFingerprint,
+} = require("../core/derivation");
 const {
   defaultConfiguration,
   LEGACY_PACKAGED_CONFIGURATION_REVISION,
@@ -38,6 +42,7 @@ const {
   pricingOptionsFromConfiguration,
 } = require("../core/configuration");
 const { normalizeCodexUuid } = require("../core/usage");
+const { CODEX_PARSER_CHECKPOINT_VERSION } = require("../ingest/parser");
 const { normalizeServiceTier } = require("../core/pricing");
 const { normalizeAgent, normalizeServiceMode } = require("../core/service-mode");
 const { emitSyncProgress } = require("../core/sync-progress");
@@ -1562,7 +1567,9 @@ function createClickHouseBackend(dependencies = {}) {
     const current = preflight?.current || await inspectAppendFile(input.path, stat);
     if (!sourceState && current.completeOffset === 0) return false;
     let plan = { mode: "full", reason: "new-source", start: 0, end: current.completeOffset };
-    if (sourceState && number(sourceState.active_import_count) > 1) {
+    if (sourceState && !sameAnalyticsDerivation(sourceState.fingerprint, fingerprint)) {
+      plan = { mode: "full", reason: "stale-analytics-derivation" };
+    } else if (sourceState && number(sourceState.active_import_count) > 1) {
       plan = { mode: "full", reason: "legacy-multi-import-manifest" };
     } else if (sourceState) {
       plan = preflight?.plan || await validateAppendCursor(input.path, sourceState, current);
@@ -1578,6 +1585,14 @@ function createClickHouseBackend(dependencies = {}) {
     if (plan.mode === "append") {
       try {
         parserCheckpoint = JSON.parse(sourceState.parser_checkpoint);
+        const checkpointKind = parserCheckpoint.kind || "codex";
+        if (
+          checkpointKind === "codex" &&
+          Number(parserCheckpoint.version) !== CODEX_PARSER_CHECKPOINT_VERSION
+        ) {
+          plan = { mode: "full", reason: "incompatible-parser-checkpoint", start: 0, end: current.completeOffset };
+          parserCheckpoint = null;
+        }
       } catch {
         plan = { mode: "full", reason: "invalid-checkpoint", start: 0, end: current.completeOffset };
       }

--- a/lib/storage/clickhouse.js
+++ b/lib/storage/clickhouse.js
@@ -1515,14 +1515,40 @@ function createClickHouseBackend(dependencies = {}) {
     );
   }
 
+  function clickHouseParserReplayReason(sourceState) {
+    if (!sourceState?.parser_checkpoint) return null;
+    let checkpoint;
+    try {
+      checkpoint = JSON.parse(sourceState.parser_checkpoint);
+    } catch {
+      return "invalid-checkpoint";
+    }
+    const kind = checkpoint.kind || "codex";
+    if (kind !== "codex") return null;
+    const version = Number(checkpoint.version);
+    if (!Number.isSafeInteger(version) || version < 0) return "invalid-checkpoint";
+    if (version > CODEX_PARSER_CHECKPOINT_VERSION) {
+      throw new Error(
+        `Codex parser checkpoint version ${version} is newer than supported version ${CODEX_PARSER_CHECKPOINT_VERSION}`,
+      );
+    }
+    return version < CODEX_PARSER_CHECKPOINT_VERSION ? "incompatible-parser-checkpoint" : null;
+  }
+
   async function preflightClickHouseAppendSources(preparedInputs, changedSourcePaths, sourceStates) {
     for (const input of preparedInputs) {
       if (
         input.kind !== "jsonl"
-        || changedSourcePaths.has(input.path)
         || !clickHouseAppendableJsonlInput(input)
       ) continue;
       const sourceState = sourceStates.get(input.path);
+      const parserReplayReason = clickHouseParserReplayReason(sourceState);
+      if (parserReplayReason) {
+        input.clickHouseParserReplayReason = parserReplayReason;
+        changedSourcePaths.add(input.path);
+        continue;
+      }
+      if (changedSourcePaths.has(input.path)) continue;
       if (!hasClickHouseResumableCursor(sourceState)) continue;
       const current = await inspectAppendFile(input.path, input.stat);
       const plan = await validateAppendCursor(input.path, sourceState, current);
@@ -1556,9 +1582,12 @@ function createClickHouseBackend(dependencies = {}) {
 
     // Legacy and deliberately non-resumable parser states still use the source
     // fingerprint. They have no cursor contract that a bounded guard can prove.
+    const parserReplayReason = input.clickHouseParserReplayReason
+      || clickHouseParserReplayReason(sourceState);
     if (
       sameSourceFingerprint(sourceState?.fingerprint, fingerprint)
       && !hasClickHouseResumableCursor(sourceState)
+      && !parserReplayReason
     ) return false;
 
     // Append-only sources always validate the bounded cursor guards, even if a
@@ -1567,7 +1596,9 @@ function createClickHouseBackend(dependencies = {}) {
     const current = preflight?.current || await inspectAppendFile(input.path, stat);
     if (!sourceState && current.completeOffset === 0) return false;
     let plan = { mode: "full", reason: "new-source", start: 0, end: current.completeOffset };
-    if (sourceState && !sameAnalyticsDerivation(sourceState.fingerprint, fingerprint)) {
+    if (sourceState && parserReplayReason) {
+      plan = { mode: "full", reason: parserReplayReason };
+    } else if (sourceState && !sameAnalyticsDerivation(sourceState.fingerprint, fingerprint)) {
       plan = { mode: "full", reason: "stale-analytics-derivation" };
     } else if (sourceState && number(sourceState.active_import_count) > 1) {
       plan = { mode: "full", reason: "legacy-multi-import-manifest" };
@@ -1585,14 +1616,6 @@ function createClickHouseBackend(dependencies = {}) {
     if (plan.mode === "append") {
       try {
         parserCheckpoint = JSON.parse(sourceState.parser_checkpoint);
-        const checkpointKind = parserCheckpoint.kind || "codex";
-        if (
-          checkpointKind === "codex" &&
-          Number(parserCheckpoint.version) !== CODEX_PARSER_CHECKPOINT_VERSION
-        ) {
-          plan = { mode: "full", reason: "incompatible-parser-checkpoint", start: 0, end: current.completeOffset };
-          parserCheckpoint = null;
-        }
       } catch {
         plan = { mode: "full", reason: "invalid-checkpoint", start: 0, end: current.completeOffset };
       }

--- a/lib/storage/clickhouse.js
+++ b/lib/storage/clickhouse.js
@@ -1536,6 +1536,7 @@ function createClickHouseBackend(dependencies = {}) {
   }
 
   async function preflightClickHouseAppendSources(preparedInputs, changedSourcePaths, sourceStates) {
+    let reportInvalidated = false;
     for (const input of preparedInputs) {
       if (
         input.kind !== "jsonl"
@@ -1546,6 +1547,7 @@ function createClickHouseBackend(dependencies = {}) {
       if (parserReplayReason) {
         input.clickHouseParserReplayReason = parserReplayReason;
         changedSourcePaths.add(input.path);
+        reportInvalidated = true;
         continue;
       }
       if (changedSourcePaths.has(input.path)) continue;
@@ -1555,6 +1557,7 @@ function createClickHouseBackend(dependencies = {}) {
       input.clickHouseAppendPreflight = { current, plan };
       if (plan.mode !== "unchanged") changedSourcePaths.add(input.path);
     }
+    return reportInvalidated;
   }
 
   async function syncClickHouseJsonlSource(client, input, sourceStates, options) {
@@ -2703,16 +2706,17 @@ function createClickHouseBackend(dependencies = {}) {
     const sourceStates = await loadClickHouseGenerationSources(client, committed?.generation_id);
     const inputs = await discoverInputs(configuredOptions);
     const fingerprintForConfiguration = (parts) => sourceFingerprint(parts);
-    const { preparedInputs, changedSourcePaths, totalSources } = await prepareStorageInputs(inputs, {
+    const { preparedInputs, changedSourcePaths, totalSources, reportInvalidated: derivationInvalidated } = await prepareStorageInputs(inputs, {
       existingFingerprint: (sourcePath) => sourceStates.get(sourcePath)?.fingerprint || null,
       sourceFingerprint: fingerprintForConfiguration,
     });
-    await preflightClickHouseAppendSources(preparedInputs, changedSourcePaths, sourceStates);
+    const checkpointInvalidated = await preflightClickHouseAppendSources(preparedInputs, changedSourcePaths, sourceStates);
     emitSyncProgress(options, {
       phase: "processing",
       totalSources,
       candidateSources: changedSourcePaths.size,
       completedSources: 0,
+      reportInvalidated: derivationInvalidated || checkpointInvalidated,
     });
     logProgress(options, `[clickhouse] changed source candidates=${formatInt(changedSourcePaths.size)}`);
     const persistedCodexSessionHeaders = [

--- a/lib/storage/source-preflight.js
+++ b/lib/storage/source-preflight.js
@@ -2,18 +2,21 @@
 
 const fsp = require("node:fs/promises");
 const { listZipEntries } = require("../ingest/archive");
-const { sameSourceFingerprint } = require("../core/derivation");
+const { sameAnalyticsDerivation, sameSourceFingerprint } = require("../core/derivation");
 
 async function prepareStorageInputs(inputs, { existingFingerprint, sourceFingerprint }) {
   const preparedInputs = [];
   const changedSourcePaths = new Set();
   let totalSources = 0;
+  let reportInvalidated = false;
   for (const input of inputs) {
     const stat = await fsp.stat(input.path);
     if (input.kind === "jsonl") {
       totalSources += 1;
       const fingerprint = sourceFingerprint({ kind: "jsonl", size: stat.size, mtimeMs: stat.mtimeMs });
-      if (!sameSourceFingerprint(await existingFingerprint(input.path), fingerprint)) changedSourcePaths.add(input.path);
+      const previousFingerprint = await existingFingerprint(input.path);
+      if (previousFingerprint && !sameAnalyticsDerivation(previousFingerprint, fingerprint)) reportInvalidated = true;
+      if (!sameSourceFingerprint(previousFingerprint, fingerprint)) changedSourcePaths.add(input.path);
       preparedInputs.push({ ...input, stat });
       continue;
     }
@@ -37,11 +40,13 @@ async function prepareStorageInputs(inputs, { existingFingerprint, sourceFingerp
         uncompressedSize: entry.uncompressedSize,
         localHeaderOffset: entry.localHeaderOffset,
       });
-      if (!sameSourceFingerprint(await existingFingerprint(sourcePath), fingerprint)) changedSourcePaths.add(sourcePath);
+      const previousFingerprint = await existingFingerprint(sourcePath);
+      if (previousFingerprint && !sameAnalyticsDerivation(previousFingerprint, fingerprint)) reportInvalidated = true;
+      if (!sameSourceFingerprint(previousFingerprint, fingerprint)) changedSourcePaths.add(sourcePath);
     }
     preparedInputs.push({ ...input, stat, entries });
   }
-  return { preparedInputs, changedSourcePaths, totalSources };
+  return { preparedInputs, changedSourcePaths, totalSources, reportInvalidated };
 }
 
 module.exports = { prepareStorageInputs };

--- a/lib/storage/sqlite.js
+++ b/lib/storage/sqlite.js
@@ -842,7 +842,7 @@ function createSqliteBackend(dependencies = {}) {
       const configuredOptions = pricingOptionsFromConfiguration(options, configuration);
       const fingerprintForConfiguration = (parts) => sourceFingerprint(parts);
       const inputs = await discoverInputs(configuredOptions);
-      const { preparedInputs, changedSourcePaths, totalSources } = await prepareStorageInputs(inputs, {
+      const { preparedInputs, changedSourcePaths, totalSources, reportInvalidated } = await prepareStorageInputs(inputs, {
         existingFingerprint: (sourcePath) => existingSourceFingerprint(db, sourcePath),
         sourceFingerprint: fingerprintForConfiguration,
       });
@@ -851,6 +851,7 @@ function createSqliteBackend(dependencies = {}) {
         totalSources,
         candidateSources: changedSourcePaths.size,
         completedSources: 0,
+        reportInvalidated,
       });
       progress(options, "[db] changed source candidates=" + formatNumber(changedSourcePaths.size));
       const persistedCodexSessionHeaders = [

--- a/lib/web-server.js
+++ b/lib/web-server.js
@@ -3,7 +3,7 @@
 const http = require("node:http");
 const { URL } = require("node:url");
 const dashboard = require("./dashboard");
-const { newReport } = require("./core/report-model");
+const { RUNTIME_ID } = require("./core/runtime-identity");
 
 const MAX_SYNC_EVENT_CLIENTS = 16;
 const MAX_CONFIGURATION_BODY_BYTES = 1024 * 1024;
@@ -128,7 +128,13 @@ function readJsonBody(request, maxBytes = MAX_CONFIGURATION_BODY_BYTES) {
   });
 }
 
-function createSyncController({ syncDatabase, reportCache, options, now = () => new Date() }) {
+function createSyncController({
+  syncDatabase,
+  reportCache,
+  options,
+  now = () => new Date(),
+  initialReportReady = true,
+}) {
   if (typeof syncDatabase !== "function") throw new TypeError("createSyncController requires a sync function");
   if (!reportCache || typeof reportCache.set !== "function") {
     throw new TypeError("createSyncController requires a replaceable report cache");
@@ -145,6 +151,7 @@ function createSyncController({ syncDatabase, reportCache, options, now = () => 
     error: null,
     progress: null,
     result: null,
+    reportReady: initialReportReady,
   };
 
   function getStatus() {
@@ -181,7 +188,13 @@ function createSyncController({ syncDatabase, reportCache, options, now = () => 
       progress.bytesProcessed = Math.max(0, Number(progress.bytesProcessed) || 0)
         + Math.max(0, Number(event.bytesProcessed) || 0);
     }
-    status = { ...status, progress };
+    status = {
+      ...status,
+      progress,
+      reportReady: typeof event.reportInvalidated === "boolean"
+        ? !event.reportInvalidated
+        : status.reportReady,
+    };
     notify();
   }
 
@@ -196,7 +209,7 @@ function createSyncController({ syncDatabase, reportCache, options, now = () => 
     return () => listeners.delete(listener);
   }
 
-  function start() {
+  function start({ invalidateReport = false } = {}) {
     if (pending) return { started: false, sync: getStatus() };
 
     runId += 1;
@@ -209,6 +222,7 @@ function createSyncController({ syncDatabase, reportCache, options, now = () => 
       error: null,
       progress: null,
       result: null,
+      reportReady: invalidateReport ? false : status.reportReady,
     };
     const startedAtMs = started.getTime();
     notify();
@@ -246,6 +260,7 @@ function createSyncController({ syncDatabase, reportCache, options, now = () => 
             skippedSources: Math.max(0, totalSources - changedSources),
             sessions: Array.isArray(report?.sessions) ? report.sessions.length : 0,
           },
+          reportReady: true,
         };
         notify();
       })
@@ -286,6 +301,7 @@ function syncStatusPayload(options) {
     // The launcher uses this stable field before deciding whether an existing
     // dashboard can be reused, including while its first sync is still running.
     engine: options.dbEngine || "sqlite",
+    runtimeId: options.runtimeId || RUNTIME_ID,
     available,
     unavailableReason: available ? null : "Sync is only available when the webserver is bound to a loopback host.",
   };
@@ -394,6 +410,30 @@ function createWebServer({
         return;
       }
 
+      if (url.pathname === "/api/runtime/stop") {
+        if (request.method !== "POST") {
+          sendJson(response, { error: "method not allowed" }, 405);
+          return;
+        }
+        if (!options.syncAllowed || typeof options.requestShutdown !== "function") {
+          sendJson(response, { error: "runtime replacement is unavailable" }, 403);
+          return;
+        }
+        const action = request.headers["x-tokenomics-action"];
+        const fetchSite = request.headers["sec-fetch-site"];
+        if (action !== "replace-runtime" || fetchSite === "cross-site") {
+          sendJson(response, { error: "runtime replacement request rejected" }, 403);
+          return;
+        }
+        if (options.configurationWritePending || options.syncController?.getStatus().state === "running") {
+          sendJson(response, { error: "runtime cannot stop while work is in progress" }, 409);
+          return;
+        }
+        sendJson(response, { stopping: true, runtimeId: options.runtimeId || RUNTIME_ID }, 202);
+        setImmediate(options.requestShutdown);
+        return;
+      }
+
       if (url.pathname === "/api/configuration") {
         if (typeof loadConfiguration !== "function") {
           sendJson(response, { error: "configuration unavailable" }, 501);
@@ -471,6 +511,11 @@ function createWebServer({
         return;
       }
 
+      if (options.syncController?.getStatus().reportReady === false) {
+        sendJson(response, { error: "usage report is being refreshed" }, 503);
+        return;
+      }
+
       const report = await options.reportCache.get();
       if (url.pathname === "/api/report") {
         sendJson(response, report);
@@ -534,10 +579,10 @@ function createWebServer({
     const db = resolveDbPath(options);
     const reportOptions = { ...options, db };
     const autoStartSync = Boolean(options.webserverSync && typeof syncDatabase === "function");
-    const initialReport = options.preloadedReport
-      || (autoStartSync ? newReport() : null);
+    const initialReport = options.preloadedReport || null;
     const serverOptions = {
       ...reportOptions,
+      runtimeId: options.runtimeId || RUNTIME_ID,
       syncAllowed: isLoopbackHost(options.host),
       syncEventResponses: new Set(),
       reportCache: options.reportCache || createReportCache(
@@ -550,6 +595,7 @@ function createWebServer({
         syncDatabase,
         reportCache: serverOptions.reportCache,
         options: reportOptions,
+        initialReportReady: !autoStartSync,
       });
     }
     const server = http.createServer((request, response) => {
@@ -562,6 +608,12 @@ function createWebServer({
       for (const response of serverOptions.syncEventResponses) response.end();
       return closeServer(callback);
     };
+    let shutdownRequested = false;
+    serverOptions.requestShutdown = () => {
+      if (shutdownRequested) return;
+      shutdownRequested = true;
+      server.close();
+    };
     server.syncController = serverOptions.syncController || null;
     await new Promise((resolve, reject) => {
       server.once("error", reject);
@@ -572,7 +624,7 @@ function createWebServer({
     });
     // Make readiness independent from ingestion latency. Clients can observe
     // the initial run through /api/sync while report routes remain responsive.
-    if (autoStartSync) server.syncController.start();
+    if (autoStartSync) server.syncController.start({ invalidateReport: true });
     return server;
   }
 

--- a/mac/Sources/TokenomicsMenubar/ConnectionCoordinator.swift
+++ b/mac/Sources/TokenomicsMenubar/ConnectionCoordinator.swift
@@ -196,7 +196,13 @@ public final class ConnectionCoordinator: ObservableObject {
 
             var syncSnapshot: SyncProbe?
             var syncFailureMessage: String?
-            if triggerSync && !discovery.launched {
+            let initialSync = try await client.probeSync(at: selected)
+            if !initialSync.reportReady {
+                payload = nil
+                lastGoodPayload = nil
+                state = .syncing(lastGood: false)
+                syncSnapshot = try await waitForReport(at: selected, generation: generation)
+            } else if triggerSync && !discovery.launched {
                 state = .syncing(lastGood: lastGoodPayload != nil)
                 do {
                     syncSnapshot = try await syncAndWait(at: selected, generation: generation)
@@ -245,11 +251,18 @@ public final class ConnectionCoordinator: ObservableObject {
         guard let candidate = ordered.first else {
             throw EndpointError.network("The configured Tokenomics port is invalid.")
         }
+        let launchConfiguration = launcherConfiguration()
 
         guard isCurrent(generation) else { throw CancellationError() }
         do {
-            _ = try await client.probeSync(at: candidate)
-            return (candidate, false)
+            let probe = try await client.probeSync(at: candidate)
+            if launchConfiguration?.runtimeId == nil || probe.runtimeId == launchConfiguration?.runtimeId {
+                return (candidate, false)
+            }
+            // The endpoint belongs to Tokenomics, but not to the installed
+            // release. Never carry its report across the replacement boundary.
+            payload = nil
+            lastGoodPayload = nil
         } catch EndpointError.notTokenomics {
             throw EndpointError.notTokenomics
         } catch EndpointError.httpStatus {
@@ -270,7 +283,7 @@ public final class ConnectionCoordinator: ObservableObject {
             self.launcherProcess = nil
         }
 
-        guard let launchConfiguration = launcherConfiguration() else {
+        guard let launchConfiguration else {
             throw EndpointError.network("Tokenomics is unavailable on port \(candidate.port).")
         }
 
@@ -307,9 +320,11 @@ public final class ConnectionCoordinator: ObservableObject {
                     throw LauncherError.exitedBeforeService(1, process.output)
                 }
                 do {
-                    _ = try await client.probeSync(at: candidate)
-                    launcherOutput = process.output
-                    return (candidate, true)
+                    let probe = try await client.probeSync(at: candidate)
+                    if launchConfiguration.runtimeId == nil || probe.runtimeId == launchConfiguration.runtimeId {
+                        launcherOutput = process.output
+                        return (candidate, true)
+                    }
                 } catch EndpointError.notTokenomics, EndpointError.decoding, EndpointError.httpStatus {
                     // Keep waiting while the configured process binds its port.
                 } catch is CancellationError {
@@ -364,6 +379,20 @@ public final class ConnectionCoordinator: ObservableObject {
             case .running:
                 try await Task.sleep(for: .milliseconds(500))
             }
+        }
+        throw EndpointError.timeout
+    }
+
+    private func waitForReport(at endpoint: Endpoint, generation: Int) async throws -> SyncProbe {
+        let deadline = Date().addingTimeInterval(30 * 60)
+        while Date() < deadline {
+            guard isCurrent(generation) else { throw CancellationError() }
+            let status = try await client.probeSync(at: endpoint)
+            if status.reportReady { return status }
+            if status.state == .failed {
+                throw EndpointError.network(status.error ?? "The backend refresh failed")
+            }
+            try await Task.sleep(for: .milliseconds(500))
         }
         throw EndpointError.timeout
     }

--- a/mac/Sources/TokenomicsMenubar/HTTPClient.swift
+++ b/mac/Sources/TokenomicsMenubar/HTTPClient.swift
@@ -4,11 +4,21 @@ public struct SyncProbe: Equatable, Sendable {
     public var state: SyncState
     public var available: Bool
     public var error: String?
+    public var runtimeId: String?
+    public var reportReady: Bool
 
-    public init(state: SyncState, available: Bool = true, error: String? = nil) {
+    public init(
+        state: SyncState,
+        available: Bool = true,
+        error: String? = nil,
+        runtimeId: String? = nil,
+        reportReady: Bool = true
+    ) {
         self.state = state
         self.available = available
         self.error = error
+        self.runtimeId = runtimeId
+        self.reportReady = reportReady
     }
 }
 
@@ -37,7 +47,13 @@ public final class URLSessionTokenomicsClient: TokenomicsHTTPClient, @unchecked 
             let envelope = try JSONDecoder().decode(SyncEnvelope.self, from: data)
             guard let state = envelope.sync.state else { throw EndpointError.notTokenomics }
             guard let decoded = SyncState.parse(state) else { throw EndpointError.notTokenomics }
-            return SyncProbe(state: decoded, available: envelope.sync.available ?? true, error: envelope.sync.error)
+            return SyncProbe(
+                state: decoded,
+                available: envelope.sync.available ?? true,
+                error: envelope.sync.error,
+                runtimeId: envelope.sync.runtimeId,
+                reportReady: envelope.sync.reportReady ?? true
+            )
         } catch let error as EndpointError {
             throw error
         } catch {
@@ -108,4 +124,6 @@ private struct SyncBody: Decodable {
     let state: String?
     var available: Bool?
     var error: String?
+    var runtimeId: String?
+    var reportReady: Bool?
 }

--- a/mac/Sources/TokenomicsMenubar/Launcher.swift
+++ b/mac/Sources/TokenomicsMenubar/Launcher.swift
@@ -231,11 +231,18 @@ public struct PersistedLauncherConfiguration: Codable, Equatable, Sendable {
     public var schema: Int
     public var command: String
     public var args: [String]
+    public var runtimeId: String?
 
-    public init(schema: Int = LauncherConfigurationSchema.current, command: String, args: [String] = []) {
+    public init(
+        schema: Int = LauncherConfigurationSchema.current,
+        command: String,
+        args: [String] = [],
+        runtimeId: String? = nil
+    ) {
         self.schema = schema
         self.command = command
         self.args = args
+        self.runtimeId = runtimeId
     }
 }
 

--- a/mac/Tests/TokenomicsMenubarTests/TokenomicsMenubarTests.swift
+++ b/mac/Tests/TokenomicsMenubarTests/TokenomicsMenubarTests.swift
@@ -785,6 +785,57 @@ final class CoordinatorSyncTests: XCTestCase {
         coordinator.stop()
     }
 
+    func testInstalledRuntimeMismatchStartsLauncherAndDoesNotReuseOldSummary() async throws {
+        let suiteName = "TokenomicsMenubarTests.runtime-transition"
+        let suite = UserDefaults(suiteName: suiteName)!
+        suite.removePersistentDomain(forName: suiteName)
+        let preferences = PreferencesStore(defaults: suite)
+        let client = RuntimeTransitionClient()
+        let launcher = RuntimeTransitionLauncher(client: client)
+        let coordinator = ConnectionCoordinator(
+            preferences: preferences,
+            client: client,
+            launcher: launcher,
+            launcherConfigurationResolver: { _ in
+                PersistedLauncherConfiguration(command: "/bin/sh", runtimeId: "new-runtime")
+            }
+        )
+        defer { coordinator.stop() }
+
+        coordinator.start()
+        await coordinator.waitForCurrentOperation()
+
+        XCTAssertEqual(launcher.startCount, 1)
+        XCTAssertEqual(client.summaryFetchCount, 1)
+        XCTAssertEqual(coordinator.payload?.currentMonth?.amountUSD, 1)
+        XCTAssertEqual(coordinator.state, .connected)
+    }
+
+    func testInitialInvalidatedReportWaitsForPublicationWithoutStartingAnotherSync() async throws {
+        let suiteName = "TokenomicsMenubarTests.report-publication"
+        let suite = UserDefaults(suiteName: suiteName)!
+        suite.removePersistentDomain(forName: suiteName)
+        let preferences = PreferencesStore(defaults: suite)
+        let client = PublishingClient()
+        let coordinator = ConnectionCoordinator(
+            preferences: preferences,
+            client: client,
+            launcher: FailingLauncher(),
+            launcherConfigurationResolver: { _ in
+                PersistedLauncherConfiguration(command: "/bin/sh", runtimeId: "current-runtime")
+            }
+        )
+        defer { coordinator.stop() }
+
+        coordinator.start()
+        await coordinator.waitForCurrentOperation()
+
+        XCTAssertEqual(client.syncRequestCount, 0)
+        XCTAssertEqual(client.summaryFetchCount, 1)
+        XCTAssertEqual(coordinator.payload?.currentMonth?.amountUSD, 2)
+        XCTAssertEqual(coordinator.state, .connected)
+    }
+
     func testWrongServiceIsNotReplacedByTheLauncher() async throws {
         let suiteName = "TokenomicsMenubarTests.wrong-service"
         let suite = UserDefaults(suiteName: suiteName)!
@@ -1077,6 +1128,61 @@ private final class StartableClient: TokenomicsHTTPClient, @unchecked Sendable {
     }
 
     func triggerSync(at endpoint: Endpoint) async throws {}
+}
+
+private final class RuntimeTransitionClient: TokenomicsHTTPClient, @unchecked Sendable {
+    var runtimeId = "old-runtime"
+    private(set) var summaryFetchCount = 0
+
+    func probeSync(at endpoint: Endpoint) async throws -> SyncProbe {
+        SyncProbe(state: .succeeded, runtimeId: runtimeId)
+    }
+
+    func fetchSummary(at endpoint: Endpoint) async throws -> SummaryResponse {
+        summaryFetchCount += 1
+        return SummaryResponse(
+            currentMonth: UsagePeriod(amountUSD: runtimeId == "new-runtime" ? 1 : 999),
+            daily: []
+        )
+    }
+
+    func triggerSync(at endpoint: Endpoint) async throws {}
+}
+
+@MainActor
+private final class RuntimeTransitionLauncher: TokenomicsLauncher {
+    private let client: RuntimeTransitionClient
+    private(set) var startCount = 0
+
+    init(client: RuntimeTransitionClient) { self.client = client }
+
+    func start(executablePath: String, port: Int, timeout: Duration) async throws -> any TokenomicsProcessHandle {
+        startCount += 1
+        client.runtimeId = "new-runtime"
+        return RecordingProcess()
+    }
+}
+
+private final class PublishingClient: TokenomicsHTTPClient, @unchecked Sendable {
+    private var probeCount = 0
+    private(set) var syncRequestCount = 0
+    private(set) var summaryFetchCount = 0
+
+    func probeSync(at endpoint: Endpoint) async throws -> SyncProbe {
+        probeCount += 1
+        return SyncProbe(
+            state: probeCount >= 3 ? .succeeded : .running,
+            runtimeId: "current-runtime",
+            reportReady: probeCount >= 3
+        )
+    }
+
+    func fetchSummary(at endpoint: Endpoint) async throws -> SummaryResponse {
+        summaryFetchCount += 1
+        return SummaryResponse(currentMonth: UsagePeriod(amountUSD: 2), daily: [])
+    }
+
+    func triggerSync(at endpoint: Endpoint) async throws { syncRequestCount += 1 }
 }
 
 private final class UnavailableClient: TokenomicsHTTPClient, @unchecked Sendable {

--- a/public/index.html
+++ b/public/index.html
@@ -164,12 +164,18 @@
     body[data-dashboard-mode="settings"] main > :not(#pricing-settings) { display:none !important; }
     body[data-dashboard-mode="settings"] #pricing-settings { display:block; }
     body[data-dashboard-mode="settings"] .section-nav { display:none; }
+    #report-pending { display:grid; min-height:240px; place-content:center; text-align:center; }
+    #report-pending h2 { margin-bottom:6px; }
+    body[data-report-ready="true"] #report-pending { display:none; }
+    body[data-report-ready="false"] main > :not(#report-pending) { display:none !important; }
+    body[data-report-ready="false"] .section-nav,
+    body[data-report-ready="false"] #dashboard-mode-controls { display:none; }
     @media (max-width: 1180px) { .cards { grid-template-columns:repeat(3, minmax(0, 1fr)); } .card:nth-child(3) { border-right:0; } .card:nth-child(n+4) { border-top:1px solid var(--line); } }
     @media (max-width: 760px) { .cards { grid-template-columns:repeat(2, minmax(0, 1fr)); } .card, .card:nth-child(3) { border-right:1px solid var(--line); border-top:1px solid var(--line); } .card:nth-child(-n+2) { border-top:0; } .card:nth-child(2n) { border-right:0; } .card:last-child { grid-column:1 / -1; border-right:0; } .service-mode-grid { grid-template-columns:1fr; } .panel-head { display:grid; } .chart-head-meta { justify-items:start; } .hover-legend { justify-items:start; } .legend-line { justify-content:flex-start; } .date-controls { justify-content:flex-start; } .recommendation-list { grid-template-columns:1fr; } .recommendation-item:nth-child(odd) { border-right:0; } .settings-grid { grid-template-columns:1fr; } .settings-actions { justify-content:flex-start; } .pricing-table th:nth-child(2), .pricing-table td:nth-child(2) { position:static; box-shadow:none; } }
     @media (max-width: 560px) { .brand-row { align-items:flex-start; flex-wrap:wrap; } .brand-group { align-items:flex-start; flex-direction:column; gap:3px; } .header-actions { width:100%; justify-content:space-between; } .sync-state { max-width:240px; } .section-nav { gap:18px; } main { padding:12px; } section { scroll-margin-top:170px; } .cards { grid-template-columns:1fr; } .card, .card:nth-child(3), .card:nth-child(2n) { border-right:0; border-top:1px solid var(--line); } .card:first-child { border-top:0; } .card:last-child { grid-column:auto; } .observed-harness-grid { grid-template-columns:1fr; } .token-card .value { white-space:normal; } .chart-wrap, .project-chart-wrap { min-height:330px; } .mix-canvas { height:330px; } .date-control-group { flex-wrap:wrap; } .chart-help::after { position:fixed; inset:auto 12px 12px 12px; width:auto; transform:translateY(3px); } }
   </style>
 </head>
-<body data-dashboard-mode="overview">
+<body data-dashboard-mode="overview" data-report-ready="false">
   <header class="app-header" id="app-header">
     <div class="brand-row">
       <div class="brand-group">
@@ -195,6 +201,9 @@
     </nav>
   </header>
   <main>
+    <section id="report-pending" role="status" aria-live="polite">
+      <div><h2 id="report-pending-title">Updating usage data…</h2><div class="muted" id="report-pending-detail">Tokenomics is applying a one-time data refresh.</div></div>
+    </section>
     <section class="kpi-band" id="overview-section"><div class="cards" id="cards"></div></section>
     <section id="service-mode-section" class="service-mode-panel">
       <div class="panel-head"><div class="panel-title-stack"><h2>Service Mode</h2><div class="muted">Explicit per-request mode telemetry; unknown is not guessed from the model name.</div></div></div>
@@ -1859,6 +1868,7 @@
     let syncPollGeneration = 0;
     let syncEventSource = null;
     let syncAvailable = false;
+    let reportRevealPromise = null;
 
     async function fetchTimeline({ project, days, from, to, fromAt, toAt } = {}) {
       const params = new URLSearchParams();
@@ -1935,6 +1945,16 @@
       const response = await fetch('/api/summary', { cache: 'no-store' });
       if (!response.ok) throw new Error('Summary request failed: HTTP ' + response.status);
       render(await response.json());
+      document.body.dataset.reportReady = 'true';
+    }
+
+    async function revealReadyReport(sync) {
+      if (sync?.reportReady !== true || document.body.dataset.reportReady === 'true') return false;
+      if (!reportRevealPromise) {
+        reportRevealPromise = loadSummary().finally(() => { reportRevealPromise = null; });
+      }
+      await reportRevealPromise;
+      return true;
     }
 
     function renderSyncStatus(sync) {
@@ -1944,6 +1964,11 @@
       const state = sync?.state || 'idle';
       if (typeof sync?.available === 'boolean') syncAvailable = sync.available;
       const running = state === 'running';
+      if (sync?.reportReady === false) document.body.dataset.reportReady = 'false';
+      if (running && sync?.reportReady === false) {
+        document.getElementById('report-pending-title').textContent = 'Updating usage data…';
+        document.getElementById('report-pending-detail').textContent = 'Tokenomics is applying a one-time data refresh.';
+      }
       button.disabled = running || !syncAvailable;
       button.textContent = running ? 'Syncing...' : 'Sync';
       dot.classList.toggle('running', running);
@@ -1966,6 +1991,10 @@
       } else if (state === 'failed') {
         updated.textContent = 'Sync failed';
         updated.title = sync.error || 'Unknown sync error';
+        if (sync?.reportReady === false) {
+          document.getElementById('report-pending-title').textContent = 'Usage data could not be updated';
+          document.getElementById('report-pending-detail').textContent = sync.error || 'Retry the update to continue.';
+        }
       } else if (state === 'succeeded') {
         const result = sync.result || {};
         updated.textContent = 'Synced ' + (result.changedSources || 0) + ' changed · ' +
@@ -2142,8 +2171,9 @@
           const sync = await fetchSyncStatus();
           failures = 0;
           renderSyncStatus(sync);
+          const revealed = await revealReadyReport(sync);
           if (sync.state !== 'running') {
-            if (sync.state === 'succeeded') {
+            if (sync.state === 'succeeded' && !revealed) {
               await loadSummary();
               renderSyncStatus(sync);
             }
@@ -2185,9 +2215,10 @@
         try {
           const sync = JSON.parse(event.data).sync;
           renderSyncStatus(sync);
+          const revealed = await revealReadyReport(sync);
           if (sync.state !== 'running') {
             closeSyncEventSource();
-            if (sync.state === 'succeeded') {
+            if (sync.state === 'succeeded' && !revealed) {
               await loadSummary();
               renderSyncStatus(sync);
             }
@@ -2227,8 +2258,13 @@
     }
 
     async function initializeDashboard() {
-      const [, sync] = await Promise.all([loadSummary(), fetchSyncStatus(), loadConfigurationEditor()]);
+      const [sync] = await Promise.all([fetchSyncStatus(), loadConfigurationEditor()]);
       renderSyncStatus(sync);
+      if (sync.reportReady === false) {
+        if (sync.state === 'running') watchSyncStatus();
+        return;
+      }
+      await loadSummary();
       if (sync.state === 'running') watchSyncStatus();
     }
 

--- a/test/clickhouse.test.js
+++ b/test/clickhouse.test.js
@@ -1170,6 +1170,7 @@ test("ClickHouse publishes only complete appended JSONL records in one stable so
 test("ClickHouse fully replays a Codex source once when its parser checkpoint predates format detection", async () => {
   const jsonl = createSessionFile({ rows: 2 });
   const mock = createClickHouseServer();
+  const progressEvents = [];
 
   await withServer(mock, async (url) => {
     const options = defaultOptions({
@@ -1178,6 +1179,7 @@ test("ClickHouse fully replays a Codex source once when its parser checkpoint pr
       clickhouseDatabase: "tokenomics_stale_checkpoint_test",
       paths: [jsonl],
       progress: false,
+      onSyncProgress: (event) => progressEvents.push(event),
     });
     await syncDatabase(options);
 
@@ -1190,6 +1192,7 @@ test("ClickHouse fully replays a Codex source once when its parser checkpoint pr
     delete staleCheckpoint.recentUsageResponseIds;
     initialSource.parser_checkpoint = JSON.stringify(staleCheckpoint);
 
+    progressEvents.length = 0;
     const report = await syncDatabase(options);
 
     const currentSource = mock.visibleRows("sources")[0];
@@ -1202,8 +1205,10 @@ test("ClickHouse fully replays a Codex source once when its parser checkpoint pr
       4,
       "the one-time replay must replace the unchanged old source epoch",
     );
+    assert.equal(progressEvents.find((event) => event.phase === "processing").reportInvalidated, true);
 
     const generationCount = mock.activeRows.import_generations.length;
+    progressEvents.length = 0;
     await syncDatabase(options);
     assert.equal(mock.activeRows.import_generations.length, generationCount);
     assert.equal(
@@ -1211,6 +1216,7 @@ test("ClickHouse fully replays a Codex source once when its parser checkpoint pr
       4,
       "the upgraded checkpoint must not replay the source a second time",
     );
+    assert.equal(progressEvents.find((event) => event.phase === "processing").reportInvalidated, false);
   });
 });
 

--- a/test/clickhouse.test.js
+++ b/test/clickhouse.test.js
@@ -10,7 +10,9 @@ const test = require("node:test");
 const { buildReportFromClickHouse, loadConfiguration, saveConfiguration, syncDatabase } = require("../app");
 const {
   ANALYTICS_DERIVATION_VERSION,
+  CODEX_USAGE_DERIVATION_VERSION,
   analyticsDerivationVersionFromFingerprint,
+  codexUsageDerivationVersionFromFingerprint,
 } = require("../lib/core/derivation");
 const {
   CLAUDE_REQUEST_CHECKPOINT_LIMIT,
@@ -1188,33 +1190,65 @@ test("ClickHouse fully replays a Codex source once when its parser checkpoint pr
     delete staleCheckpoint.recentUsageResponseIds;
     initialSource.parser_checkpoint = JSON.stringify(staleCheckpoint);
 
-    fs.appendFileSync(jsonl, `${JSON.stringify({
-      type: "event_msg",
-      timestamp: "2026-07-05T00:00:02.000Z",
-      payload: {
-        type: "token_count",
-        info: {
-          last_token_usage: { input_tokens: 2, cached_input_tokens: 0, output_tokens: 1 },
-          model_context_window: 128_000,
-        },
-      },
-    })}\n`);
     const report = await syncDatabase(options);
 
     const currentSource = mock.visibleRows("sources")[0];
-    assert.equal(report.total.requests, 3);
+    assert.equal(report.total.requests, 2);
     assert.notEqual(currentSource.import_id, initialImportId);
     assert.equal(JSON.parse(currentSource.parser_checkpoint).version, CODEX_PARSER_CHECKPOINT_VERSION);
-    assert.equal(mock.visibleRows("usage_events").length, 3);
+    assert.equal(mock.visibleRows("usage_events").length, 2);
     assert.equal(
       mock.inserts.usage_events.reduce((sum, insert) => sum + insert.rows, 0),
-      5,
-      "the one-time replay must replace the old source epoch with all three rows",
+      4,
+      "the one-time replay must replace the unchanged old source epoch",
+    );
+
+    const generationCount = mock.activeRows.import_generations.length;
+    await syncDatabase(options);
+    assert.equal(mock.activeRows.import_generations.length, generationCount);
+    assert.equal(
+      mock.inserts.usage_events.reduce((sum, insert) => sum + insert.rows, 0),
+      4,
+      "the upgraded checkpoint must not replay the source a second time",
     );
   });
 });
 
-test("ClickHouse fully replays an unchanged append source after an analytics derivation upgrade", async () => {
+test("ClickHouse refuses a future Codex parser checkpoint without replacing committed data", async () => {
+  const jsonl = createSessionFile({ rows: 2 });
+  const mock = createClickHouseServer();
+
+  await withServer(mock, async (url) => {
+    const options = defaultOptions({
+      dbEngine: "clickhouse",
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_future_checkpoint_test",
+      paths: [jsonl],
+      progress: false,
+    });
+    await syncDatabase(options);
+
+    const initialSource = mock.visibleRows("sources")[0];
+    const initialImportId = initialSource.import_id;
+    const futureCheckpoint = JSON.parse(initialSource.parser_checkpoint);
+    futureCheckpoint.version = CODEX_PARSER_CHECKPOINT_VERSION + 1;
+    initialSource.parser_checkpoint = JSON.stringify(futureCheckpoint);
+
+    await assert.rejects(
+      syncDatabase(options),
+      /checkpoint version 3 is newer than supported version 2/,
+    );
+    assert.equal(mock.visibleRows("sources")[0].import_id, initialImportId);
+    assert.equal(mock.visibleRows("usage_events").length, 2);
+    assert.equal(
+      mock.inserts.usage_events.reduce((sum, insert) => sum + insert.rows, 0),
+      2,
+      "a downgraded reader must not stage replacement usage",
+    );
+  });
+});
+
+test("ClickHouse fully replays an unchanged source once when a named derivation is missing", async () => {
   const jsonl = createSessionFile({ rows: 2 });
   const mock = createClickHouseServer();
 
@@ -1234,10 +1268,16 @@ test("ClickHouse fully replays an unchanged append source after an analytics der
       analyticsDerivationVersionFromFingerprint(initialSource.fingerprint),
       ANALYTICS_DERIVATION_VERSION,
     );
-    initialSource.fingerprint = initialSource.fingerprint.replace(
-      /analyticsDerivationVersion=\d+/,
-      "analyticsDerivationVersion=" + (ANALYTICS_DERIVATION_VERSION - 1),
+    initialSource.fingerprint = initialSource.fingerprint
+      .split("|")
+      .filter((part) => !part.startsWith("codexUsageDerivationVersion="))
+      .join("|");
+    assert.equal(
+      analyticsDerivationVersionFromFingerprint(initialSource.fingerprint),
+      ANALYTICS_DERIVATION_VERSION,
+      "the global version deliberately collides with the current version",
     );
+    assert.equal(codexUsageDerivationVersionFromFingerprint(initialSource.fingerprint), null);
 
     const report = await syncDatabase(options);
 
@@ -1248,11 +1288,24 @@ test("ClickHouse fully replays an unchanged append source after an analytics der
       analyticsDerivationVersionFromFingerprint(currentSource.fingerprint),
       ANALYTICS_DERIVATION_VERSION,
     );
+    assert.equal(
+      codexUsageDerivationVersionFromFingerprint(currentSource.fingerprint),
+      CODEX_USAGE_DERIVATION_VERSION,
+    );
     assert.equal(mock.visibleRows("usage_events").length, 2);
     assert.equal(
       mock.inserts.usage_events.reduce((sum, insert) => sum + insert.rows, 0),
       4,
       "the derivation upgrade must replace rather than append to the old source epoch",
+    );
+
+    const generationCount = mock.activeRows.import_generations.length;
+    await syncDatabase(options);
+    assert.equal(mock.activeRows.import_generations.length, generationCount);
+    assert.equal(
+      mock.inserts.usage_events.reduce((sum, insert) => sum + insert.rows, 0),
+      4,
+      "the named derivation marker must prevent a second replay",
     );
   });
 });

--- a/test/clickhouse.test.js
+++ b/test/clickhouse.test.js
@@ -10,8 +10,12 @@ const test = require("node:test");
 const { buildReportFromClickHouse, loadConfiguration, saveConfiguration, syncDatabase } = require("../app");
 const {
   ANALYTICS_DERIVATION_VERSION,
+  analyticsDerivationVersionFromFingerprint,
 } = require("../lib/core/derivation");
-const { CLAUDE_REQUEST_CHECKPOINT_LIMIT } = require("../lib/ingest/parser");
+const {
+  CLAUDE_REQUEST_CHECKPOINT_LIMIT,
+  CODEX_PARSER_CHECKPOINT_VERSION,
+} = require("../lib/ingest/parser");
 const { createClickHouseBackend } = require("../lib/storage/clickhouse");
 const { defaultOptions } = require("./support/fixtures");
 
@@ -1157,6 +1161,98 @@ test("ClickHouse publishes only complete appended JSONL records in one stable so
       mock.inserts.usage_events.reduce((sum, insert) => sum + insert.rows, 0),
       3,
       "the append must insert only the new usage row",
+    );
+  });
+});
+
+test("ClickHouse fully replays a Codex source once when its parser checkpoint predates format detection", async () => {
+  const jsonl = createSessionFile({ rows: 2 });
+  const mock = createClickHouseServer();
+
+  await withServer(mock, async (url) => {
+    const options = defaultOptions({
+      dbEngine: "clickhouse",
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_stale_checkpoint_test",
+      paths: [jsonl],
+      progress: false,
+    });
+    await syncDatabase(options);
+
+    const initialSource = mock.visibleRows("sources")[0];
+    const initialImportId = initialSource.import_id;
+    const staleCheckpoint = JSON.parse(initialSource.parser_checkpoint);
+    assert.equal(staleCheckpoint.version, CODEX_PARSER_CHECKPOINT_VERSION);
+    staleCheckpoint.version = CODEX_PARSER_CHECKPOINT_VERSION - 1;
+    delete staleCheckpoint.usageFormat;
+    delete staleCheckpoint.recentUsageResponseIds;
+    initialSource.parser_checkpoint = JSON.stringify(staleCheckpoint);
+
+    fs.appendFileSync(jsonl, `${JSON.stringify({
+      type: "event_msg",
+      timestamp: "2026-07-05T00:00:02.000Z",
+      payload: {
+        type: "token_count",
+        info: {
+          last_token_usage: { input_tokens: 2, cached_input_tokens: 0, output_tokens: 1 },
+          model_context_window: 128_000,
+        },
+      },
+    })}\n`);
+    const report = await syncDatabase(options);
+
+    const currentSource = mock.visibleRows("sources")[0];
+    assert.equal(report.total.requests, 3);
+    assert.notEqual(currentSource.import_id, initialImportId);
+    assert.equal(JSON.parse(currentSource.parser_checkpoint).version, CODEX_PARSER_CHECKPOINT_VERSION);
+    assert.equal(mock.visibleRows("usage_events").length, 3);
+    assert.equal(
+      mock.inserts.usage_events.reduce((sum, insert) => sum + insert.rows, 0),
+      5,
+      "the one-time replay must replace the old source epoch with all three rows",
+    );
+  });
+});
+
+test("ClickHouse fully replays an unchanged append source after an analytics derivation upgrade", async () => {
+  const jsonl = createSessionFile({ rows: 2 });
+  const mock = createClickHouseServer();
+
+  await withServer(mock, async (url) => {
+    const options = defaultOptions({
+      dbEngine: "clickhouse",
+      clickhouseUrl: url,
+      clickhouseDatabase: "tokenomics_derivation_replay_test",
+      paths: [jsonl],
+      progress: false,
+    });
+    await syncDatabase(options);
+
+    const initialSource = mock.visibleRows("sources")[0];
+    const initialImportId = initialSource.import_id;
+    assert.equal(
+      analyticsDerivationVersionFromFingerprint(initialSource.fingerprint),
+      ANALYTICS_DERIVATION_VERSION,
+    );
+    initialSource.fingerprint = initialSource.fingerprint.replace(
+      /analyticsDerivationVersion=\d+/,
+      "analyticsDerivationVersion=" + (ANALYTICS_DERIVATION_VERSION - 1),
+    );
+
+    const report = await syncDatabase(options);
+
+    const currentSource = mock.visibleRows("sources")[0];
+    assert.equal(report.total.requests, 2);
+    assert.notEqual(currentSource.import_id, initialImportId);
+    assert.equal(
+      analyticsDerivationVersionFromFingerprint(currentSource.fingerprint),
+      ANALYTICS_DERIVATION_VERSION,
+    );
+    assert.equal(mock.visibleRows("usage_events").length, 2);
+    assert.equal(
+      mock.inserts.usage_events.reduce((sum, insert) => sum + insert.rows, 0),
+      4,
+      "the derivation upgrade must replace rather than append to the old source epoch",
     );
   });
 });

--- a/test/dashboard-report.test.js
+++ b/test/dashboard-report.test.js
@@ -32,6 +32,15 @@ test("dashboard summary exposes service modes as distinct analytics buckets", ()
   assert.match(html, /Unknown/);
 });
 
+test("dashboard withholds report sections until the backend publishes a valid generation", () => {
+  const html = dashboardHtml();
+  assert.match(html, /data-report-ready="false"/);
+  assert.match(html, /id="report-pending"/);
+  assert.match(html, /if \(sync\.reportReady === false\)/);
+  assert.match(html, /revealReadyReport\(sync\)/);
+  assert.match(html, /document\.body\.dataset\.reportReady = 'true'/);
+});
+
 test("dashboard summary exposes the current UTC calendar month", () => {
   const report = newReport();
   report.monthlyCostLimitUsd = 100;

--- a/test/derivation.test.js
+++ b/test/derivation.test.js
@@ -4,6 +4,8 @@ const assert = require("node:assert/strict");
 const test = require("node:test");
 const {
   ANALYTICS_DERIVATION_VERSION,
+  CODEX_USAGE_DERIVATION_VERSION,
+  sameAnalyticsDerivation,
   sameSourceFingerprint,
   sourceFingerprint,
 } = require("../lib/core/derivation");
@@ -25,10 +27,27 @@ test("source fingerprints use deterministic key ordering", () => {
   assert.equal(first, second);
   assert.equal(first, [
     `analyticsDerivationVersion=${ANALYTICS_DERIVATION_VERSION}`,
+    `codexUsageDerivationVersion=${CODEX_USAGE_DERIVATION_VERSION}`,
     "kind=jsonl",
     "mtimeMs=42",
     "size=128",
   ].join("|"));
+});
+
+test("Codex usage derivation invalidates a colliding global analytics version", () => {
+  const current = sourceFingerprint(sourceParts);
+  const previous = current
+    .split("|")
+    .filter((part) => !part.startsWith("codexUsageDerivationVersion="))
+    .join("|");
+
+  assert.equal(
+    previous.includes(`analyticsDerivationVersion=${ANALYTICS_DERIVATION_VERSION}`),
+    true,
+  );
+  assert.equal(sameAnalyticsDerivation(previous, current), false);
+  assert.equal(sameSourceFingerprint(previous, current), false);
+  assert.equal(sameAnalyticsDerivation(current, current), true);
 });
 
 test("source fingerprints invalidate when the analytics derivation changes", () => {

--- a/test/fork-replay.test.js
+++ b/test/fork-replay.test.js
@@ -498,3 +498,173 @@ test("skips replayed parent traces in archived Codex ZIP sessions", async () => 
   assert.equal(report.projects["/tmp/parent-project"].requests, 1);
   assert.equal(report.projects["/tmp/child-project"].requests, 1);
 });
+
+test("uses last usage as the first baseline for an August 8 paginated subagent", () => {
+  const report = newReport();
+  const childSessionId = "019fe2c8-0226-7d51-ab63-ebaf20a840c8";
+  const parentSessionId = "019fb815-3dfa-7693-bd58-8d61c9d0784f";
+  const processLine = createLineProcessor(report, defaultOptions(), "codex-migrated-fork-fixture");
+
+  const tokenCount = (timestamp, total, last) => JSON.stringify({
+    type: "event_msg",
+    timestamp,
+    payload: {
+      type: "token_count",
+      info: {
+        total_token_usage: total,
+        last_token_usage: last,
+      },
+    },
+  });
+
+  processLine(JSON.stringify({
+    type: "session_meta",
+    timestamp: "2026-08-08T19:09:46.579Z",
+    payload: {
+      id: childSessionId,
+      parent_thread_id: parentSessionId,
+      cwd: "/tmp/migrated-fork",
+      source: {
+        subagent: {
+          thread_spawn: {
+            parent_thread_id: parentSessionId,
+          },
+        },
+      },
+      history_mode: "paginated",
+      subagent_history_start_ordinal: 202,
+    },
+  }), 1);
+  processLine(JSON.stringify({
+    type: "turn_context",
+    timestamp: "2026-08-08T19:09:46.579Z",
+    payload: {
+      turn_id: "01a05a1f-c000-7000-8000-000000000001",
+      cwd: "/tmp/migrated-fork",
+      model: "gpt-5-codex",
+    },
+  }), 2);
+  processLine(tokenCount(
+    "2026-08-08T19:09:46.579Z",
+    { input_tokens: 59_108_282, cached_input_tokens: 57_617_152, output_tokens: 143_257, reasoning_output_tokens: 69_382 },
+    { input_tokens: 198_685, cached_input_tokens: 11_008, output_tokens: 347, reasoning_output_tokens: 121 },
+  ), 3);
+  processLine(tokenCount(
+    "2026-08-08T19:09:46.579Z",
+    { input_tokens: 59_108_282, cached_input_tokens: 57_617_152, output_tokens: 143_257, reasoning_output_tokens: 69_382 },
+    { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0, reasoning_output_tokens: 0 },
+  ), 4);
+  processLine(tokenCount(
+    "2026-08-08T19:09:46.579Z",
+    { input_tokens: 59_144_504, cached_input_tokens: 57_623_040, output_tokens: 143_752, reasoning_output_tokens: 69_597 },
+    { input_tokens: 36_222, cached_input_tokens: 5_888, output_tokens: 495, reasoning_output_tokens: 215 },
+  ), 5);
+
+  assert.equal(report.total.requests, 2);
+  assert.equal(report.total.input, 218_011);
+  assert.equal(report.total.cacheRead, 16_896);
+  assert.equal(report.total.output, 842);
+  assert.equal(report.total.reasoningOutput, 336);
+  assert.equal(report.sources.skippedTokenCountSnapshots, 1);
+});
+
+test("uses owned token usage records and ignores paired aggregate token counts", () => {
+  const report = newReport();
+  const childSessionId = "01a07682-5e9a-72d0-b128-35db975c5156";
+  const parentSessionId = "01a07680-0000-7000-8000-000000000001";
+  const processLine = createLineProcessor(report, defaultOptions(), "codex-token-record-fixture");
+
+  processLine(JSON.stringify({
+    type: "session_meta",
+    timestamp: "2026-09-06T12:00:00.000Z",
+    payload: {
+      id: childSessionId,
+      forked_from_id: null,
+      cwd: "/tmp/token-record-child",
+      source: {
+        subagent: {
+          thread_spawn: {
+            parent_thread_id: parentSessionId,
+          },
+        },
+      },
+      history_mode: "paginated",
+      subagent_history_start_ordinal: 121,
+    },
+  }), 1);
+  processLine(JSON.stringify({
+    type: "turn_context",
+    timestamp: "2026-09-06T12:00:01.000Z",
+    payload: {
+      turn_id: "01a07682-6000-7000-8000-000000000002",
+      cwd: "/tmp/token-record-child",
+      model: "gpt-5-codex",
+    },
+  }), 2);
+
+  // A copied record from another ownership domain is not evidence of child usage.
+  processLine(JSON.stringify({
+    type: "token_usage_record",
+    timestamp: "2026-09-06T12:00:02.000Z",
+    payload: {
+      thread_id: parentSessionId,
+      response_id: "resp-parent",
+      usage: { input_tokens: 9_000_000, cached_input_tokens: 8_000_000, output_tokens: 900_000, total_tokens: 9_900_000 },
+    },
+  }), 3);
+
+  const usageRecord = (timestamp, responseId, usage) => JSON.stringify({
+    type: "token_usage_record",
+    timestamp,
+    payload: {
+      thread_id: childSessionId,
+      response_id: responseId,
+      usage,
+    },
+  });
+  const pairedTokenCount = (timestamp, total, last) => JSON.stringify({
+    type: "event_msg",
+    timestamp,
+    payload: {
+      type: "token_count",
+      info: { total_token_usage: total, last_token_usage: last },
+    },
+  });
+
+  processLine(usageRecord("2026-09-06T12:00:03.000Z", "resp-child-1", {
+    input_tokens: 100,
+    cached_input_tokens: 90,
+    output_tokens: 10,
+    total_tokens: 110,
+  }), 4);
+  processLine(usageRecord("2026-09-06T12:00:03.050Z", "resp-child-1", {
+    input_tokens: 100,
+    cached_input_tokens: 90,
+    output_tokens: 10,
+    total_tokens: 110,
+  }), 5);
+  processLine(pairedTokenCount(
+    "2026-09-06T12:00:03.100Z",
+    { input_tokens: 10_000_100, cached_input_tokens: 9_000_090, output_tokens: 1_000_010 },
+    { input_tokens: 100, cached_input_tokens: 90, output_tokens: 10 },
+  ), 6);
+  processLine(usageRecord("2026-09-06T12:00:04.000Z", "resp-child-2", {
+    input_tokens: 50,
+    cached_input_tokens: 45,
+    output_tokens: 5,
+    total_tokens: 55,
+  }), 7);
+  processLine(pairedTokenCount(
+    "2026-09-06T12:00:04.100Z",
+    { input_tokens: 10_000_150, cached_input_tokens: 9_000_135, output_tokens: 1_000_015 },
+    { input_tokens: 50, cached_input_tokens: 45, output_tokens: 5 },
+  ), 8);
+
+  assert.equal(report.total.requests, 2);
+  assert.equal(report.total.input, 15);
+  assert.equal(report.total.cacheRead, 135);
+  assert.equal(report.total.output, 15);
+  assert.equal(report.sources.tokenCountSnapshots, 2);
+  assert.equal(report.sources.skippedTokenCountSnapshots, 2);
+  assert.deepEqual(report._usageEvents.map((event) => event.requestId), ["resp-child-1", "resp-child-2"]);
+});

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -10,6 +10,7 @@ const Util = require("node:util");
 
 const execFile = Util.promisify(ChildProcess.execFile);
 const root = Path.resolve(__dirname, "..");
+const { RUNTIME_ID } = require("../lib/core/runtime-identity");
 
 test("one-line installer is offline-testable, repeatable, and preserves data", async () => {
   const temporary = await fs.mkdtemp(Path.join(Os.tmpdir(), "tokenomics-installer-"));
@@ -39,6 +40,7 @@ test("one-line installer is offline-testable, repeatable, and preserves data", a
     schema: 1,
     command: Path.join(binDir, "tokenomics-launch"),
     args: [],
+    runtimeId: RUNTIME_ID,
   });
 
   const help = await execFile(Path.join(binDir, "tokenomics-launch"), ["--help"], { env });
@@ -56,6 +58,9 @@ test("one-line installer is offline-testable, repeatable, and preserves data", a
   const nextRelease = await fs.realpath(Path.join(installRoot, "current"));
 
   assert.notEqual(nextRelease, previousRelease);
+  const launcherWrapper = await fs.readFile(Path.join(binDir, "tokenomics-launch"), "utf8");
+  assert.match(launcherWrapper, /--legacy-releases-root/);
+  assert.match(launcherWrapper, new RegExp(`${Path.basename(installRoot)}/releases`));
   assert.equal(await fs.readFile(dataMarker, "utf8"), "keep me\n");
   assert.equal(await fs.readFile(Path.join(nextRelease, "package.json"), "utf8"), await fs.readFile(Path.join(root, "package.json"), "utf8"));
 

--- a/test/launcher.test.js
+++ b/test/launcher.test.js
@@ -7,6 +7,7 @@ const Path = require("node:path");
 const test = require("node:test");
 const {
   browserCommand,
+  dashboardStatus,
   dashboardReady,
   downloadClickHouseInstaller,
   ensureClickHouse,
@@ -18,6 +19,7 @@ const {
   runLauncher,
   waitForDashboardProcess,
 } = require("../lib/launcher");
+const { RUNTIME_ID } = require("../lib/core/runtime-identity");
 
 async function withStatusServer(payload, callback) {
   const http = require("node:http");
@@ -40,8 +42,12 @@ test("dashboard readiness requires a loopback sync-capable endpoint and the sele
   await withStatusServer({ sync: { available: true, engine: "sqlite", state: "running" } }, async (url) => {
     assert.equal(await dashboardReady(url, "clickhouse"), false);
   });
-  await withStatusServer({ sync: { available: true, engine: "clickhouse", state: "running" } }, async (url) => {
+  await withStatusServer({ sync: { available: true, engine: "clickhouse", runtimeId: RUNTIME_ID, state: "running" } }, async (url) => {
     assert.equal(await dashboardReady(url, "clickhouse"), true);
+  });
+  await withStatusServer({ sync: { available: true, engine: "clickhouse", state: "succeeded" } }, async (url) => {
+    assert.equal(await dashboardReady(url, "clickhouse"), false);
+    assert.equal((await dashboardStatus(url, "clickhouse")).kind, "stale");
   });
 });
 
@@ -103,8 +109,11 @@ test("launcher arguments keep orchestration flags separate from app arguments", 
     forceEngine: "clickhouse",
     noOpen: true,
     port: 9001,
+    legacyReleasesRoot: null,
     appArgs: ["--source", "codex"],
   });
+  assert.equal(parseLauncherArgs(["--legacy-releases-root", "/installed/releases"]).legacyReleasesRoot, "/installed/releases");
+  assert.throws(() => parseLauncherArgs(["--legacy-releases-root", "relative"]), /absolute/);
   assert.equal(parseLauncherArgs(["--no-clickhouse"]).forceEngine, "sqlite");
   assert.throws(() => parseLauncherArgs(["--sqlite", "--clickhouse"]), /only one/);
   assert.throws(() => parseLauncherArgs(["--port", "nope"]), /port/);
@@ -263,6 +272,74 @@ test("launcher reuses an existing dashboard and starts a protected sync", async 
   assert.deepEqual(calls[0], ["probe", "clickhouse"]);
   assert.ok(calls.includes("sync"));
   assert.ok(calls.includes("open"));
+});
+
+test("launcher replaces a stale runtime on the exact configured port", async () => {
+  const calls = [];
+  const exitCode = await runLauncher(["--no-open", "--legacy-releases-root", "/installed/releases"], {
+    dashboardStatus: async (_url, engine, runtimeId) => {
+      calls.push(["probe", engine, runtimeId]);
+      return { kind: "stale", sync: { state: "succeeded" } };
+    },
+    requestRuntimeStop: async () => { calls.push("stop-runtime"); return "unsupported"; },
+    stopLegacyDashboard: async (port, root) => { calls.push(["stop-legacy", port, root]); return true; },
+    portAvailable: async (port) => { calls.push(["available", port]); return true; },
+    ensureClickHouse: async () => calls.push("clickhouse"),
+    findAvailablePort: async (port) => { calls.push(["find-port", port]); return port; },
+    spawnTokenomics: async (args) => {
+      calls.push(["spawn", ...args]);
+      return { exit: Promise.resolve(0), stop: () => calls.push("stop-child") };
+    },
+    waitForDashboard: async () => calls.push("ready"),
+    log: () => {},
+  });
+  assert.equal(exitCode, 0);
+  assert.deepEqual(calls.slice(0, 6), [
+    ["probe", "clickhouse", RUNTIME_ID],
+    "stop-runtime",
+    ["stop-legacy", 8787, "/installed/releases"],
+    ["available", 8787],
+    "clickhouse",
+    ["find-port", 8787],
+  ]);
+  assert.ok(calls.some((entry) => Array.isArray(entry) && entry[0] === "spawn" && entry.includes("8787")));
+});
+
+test("legacy replacement kills only the sole listener rooted in an installed release", async () => {
+  const killed = [];
+  const stopped = await require("../lib/launcher").stopLegacyDashboard(8787, "/installed/releases", {
+    listeningProcessIds: async () => [101, 202],
+    processWorkingDirectory: async (pid) => pid === 202 ? "/installed/releases/v1" : "/other/service",
+    processCommandLine: async (pid) => pid === 202 ? "node /installed/releases/v1/app.js --webserver" : "node /other/service/app.js",
+    realpath: async (path) => path,
+    kill: (pid, signal) => killed.push([pid, signal]),
+  });
+  assert.equal(stopped, true);
+  assert.deepEqual(killed, [[202, "SIGTERM"]]);
+
+  assert.equal(await require("../lib/launcher").stopLegacyDashboard(8787, "/installed/releases", {
+    listeningProcessIds: async () => [202, 303],
+    processWorkingDirectory: async () => "/installed/releases/v1",
+    processCommandLine: async () => "node /installed/releases/v1/app.js --webserver",
+    realpath: async (path) => path,
+    kill: () => { throw new Error("must not kill ambiguous listeners"); },
+  }), false);
+
+  assert.equal(await require("../lib/launcher").stopLegacyDashboard(8787, "/installed/releases", {
+    listeningProcessIds: async () => [202],
+    processWorkingDirectory: async () => "/installed/releases/v1",
+    processCommandLine: async () => "node /installed/releases/v1/not-tokenomics.js --webserver",
+    realpath: async (path) => path,
+    kill: () => { throw new Error("must not kill a different entrypoint"); },
+  }), false);
+
+  assert.equal(await require("../lib/launcher").stopLegacyDashboard(8787, "/installed/releases", {
+    listeningProcessIds: async () => [202],
+    processWorkingDirectory: async () => "/installed/not-a-release",
+    processCommandLine: async () => "node /installed/not-a-release/app.js --webserver",
+    realpath: async (path) => path,
+    kill: () => { throw new Error("must not kill a process outside the releases root"); },
+  }), false);
 });
 
 test("browser opener failure does not fail an otherwise ready dashboard", async () => {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -602,6 +602,129 @@ test("Codex parser checkpoint preserves duplicate suppression across the byte bo
   assert.equal(resumedReport._usageEvents.length, 0);
 });
 
+test("Codex parser checkpoint preserves token usage record authority across the byte boundary", () => {
+  const sourceLabel = "codex-checkpoint-token-record-fixture";
+  const sessionId = "01a07682-5e9a-72d0-b128-35db975c5156";
+  const report = newReport();
+  const processLine = createLineProcessor(report, defaultOptions(), sourceLabel);
+  processLine(JSON.stringify({
+    type: "session_meta",
+    timestamp: "2026-09-06T12:00:00.000Z",
+    payload: {
+      id: sessionId,
+      cwd: "/tmp/checkpoint-token-record",
+    },
+  }), 1);
+  processLine(JSON.stringify({
+    type: "turn_context",
+    timestamp: "2026-09-06T12:00:01.000Z",
+    payload: {
+      turn_id: "01a07682-6000-7000-8000-000000000002",
+      cwd: "/tmp/checkpoint-token-record",
+      model: "gpt-5-codex",
+    },
+  }), 2);
+  processLine(JSON.stringify({
+    type: "token_usage_record",
+    timestamp: "2026-09-06T12:00:02.000Z",
+    payload: {
+      thread_id: sessionId,
+      response_id: "resp-checkpoint-child",
+      usage: { input_tokens: 100, cached_input_tokens: 90, output_tokens: 10, total_tokens: 110 },
+    },
+  }), 3);
+  const checkpoint = JSON.parse(JSON.stringify(processLine.checkpoint()));
+
+  const resumedReport = newReport();
+  const resumed = createLineProcessor(
+    resumedReport,
+    defaultOptions({ codexParserCheckpoint: checkpoint }),
+    sourceLabel,
+  );
+  resumed(JSON.stringify({
+    type: "event_msg",
+    timestamp: "2026-09-06T12:00:02.100Z",
+    payload: {
+      type: "token_count",
+      info: {
+        total_token_usage: { input_tokens: 10_000_100, cached_input_tokens: 9_000_090, output_tokens: 1_000_010 },
+        last_token_usage: { input_tokens: 100, cached_input_tokens: 90, output_tokens: 10 },
+      },
+    },
+  }), 4);
+
+  assert.equal(checkpoint.usageFormat, "token-usage-record");
+  assert.equal(resumedReport.sources.tokenCountSnapshots, 1);
+  assert.equal(resumedReport.sources.skippedTokenCountSnapshots, 1);
+  assert.equal(resumedReport.total.requests, 0);
+});
+
+test("owned but unsupported token usage records fail closed without poisoning later valid records", () => {
+  const sourceLabel = "codex-unsupported-token-record-fixture";
+  const sessionId = "01a07682-5e9a-72d0-b128-35db975c5156";
+  const report = newReport();
+  const processLine = createLineProcessor(report, defaultOptions(), sourceLabel);
+  processLine(JSON.stringify({
+    type: "session_meta",
+    timestamp: "2026-09-06T12:00:00.000Z",
+    payload: { id: sessionId, cwd: "/tmp/unsupported-token-record" },
+  }), 1);
+  processLine(JSON.stringify({
+    type: "token_usage_record",
+    timestamp: "2026-09-06T12:00:01.000Z",
+    payload: {
+      thread_id: sessionId,
+      response_id: "resp-unsupported",
+      usage: { future_token_unit: 100 },
+    },
+  }), 2);
+  processLine(JSON.stringify({
+    type: "token_usage_record",
+    timestamp: "2026-09-06T12:00:01.010Z",
+    payload: {
+      thread_id: sessionId,
+      response_id: "resp-recoverable",
+      usage: { input_tokens: 100, cached_input_tokens: 90, output_tokens: 10, total_tokens: 1_000_000 },
+    },
+  }), 3);
+  processLine(JSON.stringify({
+    type: "token_usage_record",
+    timestamp: "2026-09-06T12:00:01.020Z",
+    payload: {
+      thread_id: sessionId,
+      usage: { input_tokens: 100, cached_input_tokens: 90, output_tokens: 10, total_tokens: 110 },
+    },
+  }), 4);
+  processLine(JSON.stringify({
+    type: "token_usage_record",
+    timestamp: "2026-09-06T12:00:01.030Z",
+    payload: {
+      thread_id: sessionId,
+      response_id: "resp-recoverable",
+      usage: { input_tokens: 100, cached_input_tokens: 90, output_tokens: 10, total_tokens: 110 },
+    },
+  }), 5);
+  processLine(JSON.stringify({
+    type: "event_msg",
+    timestamp: "2026-09-06T12:00:01.100Z",
+    payload: {
+      type: "token_count",
+      info: {
+        total_token_usage: { input_tokens: 10_000_000, cached_input_tokens: 9_000_000, output_tokens: 1_000_000 },
+        last_token_usage: { input_tokens: 100, cached_input_tokens: 90, output_tokens: 10 },
+      },
+    },
+  }), 6);
+
+  assert.equal(report.sources.parseErrors, 3);
+  assert.equal(report.sources.skippedTokenCountSnapshots, 1);
+  assert.equal(report.total.requests, 1);
+  assert.equal(report.total.input, 10);
+  assert.equal(report.total.cacheRead, 90);
+  assert.equal(report.total.output, 10);
+  assert.equal(processLine.checkpoint().usageFormat, "token-usage-record");
+});
+
 test("Codex parser checkpoint fails closed for forks and incompatible identities", () => {
   const sourceLabel = "codex-checkpoint-safety-fixture";
   const report = newReport();
@@ -632,6 +755,45 @@ test("Codex parser checkpoint fails closed for forks and incompatible identities
       `${sourceLabel}-other`,
     ),
     /Codex parser checkpoint source mismatch/,
+  );
+  assert.throws(
+    () => createLineProcessor(
+      newReport(),
+      defaultOptions({
+        codexParserCheckpoint: {
+          ...checkpoint,
+          usageFormat: "token-unknown-format",
+        },
+      }),
+      sourceLabel,
+    ),
+    /Unsupported Codex usage format/,
+  );
+  assert.throws(
+    () => createLineProcessor(
+      newReport(),
+      defaultOptions({
+        codexParserCheckpoint: {
+          ...checkpoint,
+          usageFormat: "token-usage-record",
+          recentUsageResponseIds: [""],
+        },
+      }),
+      sourceLabel,
+    ),
+    /token usage record checkpoint is not safe/,
+  );
+
+  const legacyCheckpoint = { ...checkpoint, version: 1 };
+  delete legacyCheckpoint.usageFormat;
+  delete legacyCheckpoint.recentUsageResponseIds;
+  assert.throws(
+    () => createLineProcessor(
+      newReport(),
+      defaultOptions({ codexParserCheckpoint: legacyCheckpoint }),
+      sourceLabel,
+    ),
+    /requires a full source replay/,
   );
 
   const forked = createLineProcessor(newReport(), defaultOptions(), "codex-checkpoint-fork-fixture");

--- a/test/pricing-usage.test.js
+++ b/test/pricing-usage.test.js
@@ -665,6 +665,28 @@ test("normalizes official nested Codex cache details and subtracts cumulative de
   });
 });
 
+test("a legacy ownership boundary establishes a cumulative baseline when last usage is absent", () => {
+  const first = usageFromCodexInfo({
+    total_token_usage: {
+      input_tokens: 1_000_000_000,
+      cached_input_tokens: 900_000_000,
+      output_tokens: 10_000_000,
+    },
+  }, null, true);
+  const second = usageFromCodexInfo({
+    total_token_usage: {
+      input_tokens: 1_000_000_100,
+      cached_input_tokens: 900_000_090,
+      output_tokens: 10_000_010,
+    },
+  }, first.totalUsage);
+
+  assert.equal(usage.hasUsageTokens(first.usage), false);
+  assert.equal(second.usage.input, 10);
+  assert.equal(second.usage.cacheRead, 90);
+  assert.equal(second.usage.output, 10);
+});
+
 test("keeps cumulative deltas stable when Codex adds cache_write_input_tokens", () => {
   const previous = usageFromCodexInfo({
     total_token_usage: {

--- a/test/runtime-identity.test.js
+++ b/test/runtime-identity.test.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs/promises");
+const Os = require("node:os");
+const Path = require("node:path");
+const test = require("node:test");
+const { RUNTIME_ID, runtimeIdentity } = require("../lib/core/runtime-identity");
+
+test("runtime identity is deterministic and changes with shipped backend content", async (t) => {
+  const root = Path.resolve(__dirname, "..");
+  assert.equal(runtimeIdentity(root), RUNTIME_ID);
+
+  const temporary = await fs.mkdtemp(Path.join(Os.tmpdir(), "tokenomics-runtime-id-"));
+  t.after(() => fs.rm(temporary, { recursive: true, force: true }));
+  await Promise.all([
+    fs.mkdir(Path.join(temporary, "lib")),
+    fs.mkdir(Path.join(temporary, "public")),
+  ]);
+  await Promise.all([
+    fs.writeFile(Path.join(temporary, "app.js"), "app\n"),
+    fs.writeFile(Path.join(temporary, "launcher.js"), "launcher\n"),
+    fs.writeFile(Path.join(temporary, "package.json"), "{}\n"),
+    fs.writeFile(Path.join(temporary, "lib", "module.js"), "one\n"),
+    fs.writeFile(Path.join(temporary, "public", "index.html"), "html\n"),
+  ]);
+  const first = runtimeIdentity(temporary);
+  assert.equal(runtimeIdentity(temporary), first);
+  await fs.writeFile(Path.join(temporary, "lib", "module.js"), "two\n");
+  assert.notEqual(runtimeIdentity(temporary), first);
+});

--- a/test/sqlite.test.js
+++ b/test/sqlite.test.js
@@ -411,6 +411,7 @@ test("SQLite reimports a missing named derivation exactly once", async () => {
     onSyncProgress: (event) => progressEvents.push(event),
   }));
   assert.equal(progressEvents.at(-1).changedSources, 1);
+  assert.equal(progressEvents.find((event) => event.phase === "processing").reportInvalidated, true);
 
   const recovered = new DatabaseSync(db);
   try {
@@ -426,6 +427,7 @@ test("SQLite reimports a missing named derivation exactly once", async () => {
     onSyncProgress: (event) => progressEvents.push(event),
   }));
   assert.equal(progressEvents.at(-1).changedSources, 0);
+  assert.equal(progressEvents.find((event) => event.phase === "processing").reportInvalidated, false);
 });
 
 test("SQLite replaces a Codex source when archiving moves the same session", async () => {

--- a/test/sqlite.test.js
+++ b/test/sqlite.test.js
@@ -9,6 +9,7 @@ const test = require("node:test");
 const { buildReport, buildReportFromDatabase, loadConfiguration, saveConfiguration, syncDatabase } = require("../app");
 const {
   ANALYTICS_DERIVATION_VERSION,
+  CODEX_USAGE_DERIVATION_VERSION,
   sourceFingerprint,
 } = require("../lib/core/derivation");
 const { createSqliteBackend } = require("../lib/storage/sqlite");
@@ -373,7 +374,7 @@ test("SQLite leaves custom and derived pricing revisions untouched during packag
   }
 });
 
-test("SQLite persists versioned fingerprints and reimports a stale derivation", async () => {
+test("SQLite reimports a missing named derivation exactly once", async () => {
   const tmp = fs.mkdtempSync(Path.join(os.tmpdir(), "tokenomics-sqlite-derivation-version-test-"));
   const jsonl = Path.join(tmp, "session.jsonl");
   const db = Path.join(tmp, "tokenomics.sqlite");
@@ -390,11 +391,13 @@ test("SQLite persists versioned fingerprints and reimports a stale derivation", 
   try {
     assert.equal(stored.prepare("SELECT fingerprint FROM sources WHERE source_path = ?").get(jsonl).fingerprint, currentFingerprint);
     assert.match(currentFingerprint, new RegExp(`analyticsDerivationVersion=${ANALYTICS_DERIVATION_VERSION}`));
+    assert.match(currentFingerprint, new RegExp(`codexUsageDerivationVersion=${CODEX_USAGE_DERIVATION_VERSION}`));
     assert.equal(stored.prepare("SELECT value FROM meta WHERE key = 'schema_version'").get().value, "1");
     stored.prepare("UPDATE sources SET fingerprint = ? WHERE source_path = ?").run(
-      sourceFingerprint({ kind: "jsonl", size: stat.size, mtimeMs: stat.mtimeMs }, {
-        analyticsDerivationVersion: ANALYTICS_DERIVATION_VERSION + 1,
-      }),
+      currentFingerprint
+        .split("|")
+        .filter((part) => !part.startsWith("codexUsageDerivationVersion="))
+        .join("|"),
       jsonl,
     );
   } finally {
@@ -415,6 +418,14 @@ test("SQLite persists versioned fingerprints and reimports a stale derivation", 
   } finally {
     recovered.close();
   }
+
+  progressEvents.length = 0;
+  await syncDatabase(defaultOptions({
+    db,
+    paths: [jsonl],
+    onSyncProgress: (event) => progressEvents.push(event),
+  }));
+  assert.equal(progressEvents.at(-1).changedSources, 0);
 });
 
 test("SQLite replaces a Codex source when archiving moves the same session", async () => {

--- a/test/web.test.js
+++ b/test/web.test.js
@@ -5,6 +5,8 @@ const fs = require("node:fs");
 const os = require("node:os");
 const Path = require("node:path");
 const test = require("node:test");
+const { once } = require("node:events");
+const { RUNTIME_ID } = require("../lib/core/runtime-identity");
 const { newReport, startWebServer, syncDatabase } = require("../app");
 const {
   MAX_CONFIGURATION_BODY_BYTES,
@@ -151,8 +153,9 @@ test("webserver mode listens before its automatic sync completes", async () => {
       return { ...newReport(), marker: "database" };
     },
     resolveDbPath: () => Path.join(os.tmpdir(), "tokenomics-startup-sync.sqlite"),
-    syncDatabase: async () => {
+    syncDatabase: async (options) => {
       syncCalls += 1;
+      options.onSyncProgress({ phase: "processing", reportInvalidated: true });
       await syncGate;
       return { ...newReport(), marker: "current" };
     },
@@ -170,13 +173,63 @@ test("webserver mode listens before its automatic sync completes", async () => {
     const summary = await summaryResponse.json();
     assert.equal(syncCalls, 1);
     assert.equal(status.sync.state, "running");
-    assert.equal(summaryResponse.status, 200);
-    assert.equal(summary.contractVersion, 1);
+    assert.equal(status.sync.reportReady, false);
+    assert.equal(status.sync.runtimeId, RUNTIME_ID);
+    assert.equal(summaryResponse.status, 503);
+    assert.deepEqual(summary, { error: "usage report is being refreshed" });
     assert.equal(reportBuilds, 0);
+    const stopResponse = await fetch(`${base}/api/runtime/stop`, {
+      method: "POST",
+      headers: { "x-tokenomics-action": "replace-runtime" },
+    });
+    assert.equal(stopResponse.status, 409);
 
     releaseSync();
     await server.syncController.waitForIdle();
-    assert.equal((await fetch(`${base}/api/sync`).then((response) => response.json())).sync.state, "succeeded");
+    const completed = (await fetch(`${base}/api/sync`).then((response) => response.json())).sync;
+    assert.equal(completed.state, "succeeded");
+    assert.equal(completed.reportReady, true);
+    assert.equal((await fetch(`${base}/api/report`).then((response) => response.json())).marker, "current");
+  } finally {
+    releaseSync();
+    await server.syncController.waitForIdle();
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+});
+
+test("webserver keeps the last committed report visible during an ordinary startup sync", async () => {
+  let releaseSync;
+  let announcePlan;
+  const syncGate = new Promise((resolve) => { releaseSync = resolve; });
+  const planReady = new Promise((resolve) => { announcePlan = resolve; });
+  const web = createWebServer({
+    buildReportFromSelectedDatabase: async () => ({ ...newReport(), marker: "last-good" }),
+    resolveDbPath: () => Path.join(os.tmpdir(), "tokenomics-startup-incremental.sqlite"),
+    syncDatabase: async (options) => {
+      options.onSyncProgress({ phase: "processing", reportInvalidated: false });
+      announcePlan();
+      await syncGate;
+      return { ...newReport(), marker: "current" };
+    },
+  });
+  const server = await web.startWebServer(defaultOptions({
+    webserver: true,
+    webserverSync: true,
+    host: "127.0.0.1",
+    port: 0,
+  }));
+  try {
+    await planReady;
+    const base = `http://127.0.0.1:${server.address().port}`;
+    const status = await fetch(`${base}/api/sync`).then((response) => response.json());
+    const reportResponse = await fetch(`${base}/api/report`);
+    assert.equal(status.sync.state, "running");
+    assert.equal(status.sync.reportReady, true);
+    assert.equal(reportResponse.status, 200);
+    assert.equal((await reportResponse.json()).marker, "last-good");
+
+    releaseSync();
+    await server.syncController.waitForIdle();
     assert.equal((await fetch(`${base}/api/report`).then((response) => response.json())).marker, "current");
   } finally {
     releaseSync();
@@ -528,6 +581,31 @@ test("sync endpoint requires a same-origin custom action header", async () => {
   } finally {
     await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
   }
+});
+
+test("runtime replacement is header-protected and closes an idle loopback server", async () => {
+  const server = await startWebServer(defaultOptions({
+    preloadedReport: newReport(),
+    host: "127.0.0.1",
+    port: 0,
+  }));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  const missingHeader = await fetch(`${base}/api/runtime/stop`, { method: "POST" });
+  assert.equal(missingHeader.status, 403);
+  const crossSite = await fetch(`${base}/api/runtime/stop`, {
+    method: "POST",
+    headers: { "x-tokenomics-action": "replace-runtime", "sec-fetch-site": "cross-site" },
+  });
+  assert.equal(crossSite.status, 403);
+
+  const closed = once(server, "close");
+  const accepted = await fetch(`${base}/api/runtime/stop`, {
+    method: "POST",
+    headers: { "x-tokenomics-action": "replace-runtime" },
+  });
+  assert.equal(accepted.status, 202);
+  assert.deepEqual(await accepted.json(), { stopping: true, runtimeId: RUNTIME_ID });
+  await closed;
 });
 
 test("sync endpoint coalesces concurrent runs and atomically publishes the new report", async () => {


### PR DESCRIPTION
## Summary

- distinguish cumulative legacy `token_count` snapshots from exact `token_usage_record` events
- use structural session ownership markers for migrated and forked rollouts instead of date or version heuristics
- automatically replay persisted sources exactly once when the Codex parser or usage derivation is stale
- identify the shipped runtime by content and replace an older installed backend before starting sync
- hide invalidated totals until ClickHouse publishes the corrected generation atomically; keep last-good data visible for ordinary incremental syncs
- make the macOS menu bar and browser wait for `reportReady` without displaying stale totals

## Root cause

Migrated and forked Codex sessions can begin with cumulative token snapshots inherited from their parent history. The old reader treated those totals as usage owned by the child session, inflating token counts and cost. This became visible in sessions created after the early-August rollout format changes.

The first migration fix had three independent gaps:

1. the unchanged-source fast path returned before parser-checkpoint compatibility was evaluated;
2. the intended global analytics version collided with a version already merged by another change;
3. installing a new release atomically updated the `current` symlink but could leave the previous Node backend owning port 8787, so the new replay code never ran.

The third gap explains why the persisted data remained inflated even after the earlier commits reached the installed tree.

## Transparent one-time migration

Every current fingerprint includes `codexUsageDerivationVersion`. A source whose persisted fingerprint lacks that marker, or whose Codex parser checkpoint is older, is fully replayed into a replacement source epoch even when its bytes did not change. The marker and checkpoint are committed with that epoch, so the next sync returns to append-incremental behavior. A failed replay leaves the old committed generation retryable; a future parser checkpoint is rejected without staging replacement usage.

The installer records a content-derived runtime ID. The launcher reuses port 8787 only when both engine and runtime ID match. New runtimes expose a loopback-only, action-header-protected idle shutdown endpoint. For pre-ID installations, the compatibility bridge sends `SIGTERM` only when exactly one listener is present, its real cwd is a direct child of the installer's releases directory, and its command line runs that release's exact `app.js`; ambiguous or unrelated listeners fail closed.

Report endpoints return 503 only while an invalidating replay is in progress. The browser and macOS menu bar render an update state instead of old totals. Ordinary incremental startup syncs keep the previous committed report available and replace it atomically on success.

## Compatibility

- legacy `token_count` sessions retain cumulative-delta accounting
- new `token_usage_record` sessions use exact per-response usage
- Claude checkpoint handling and request-ID deduplication remain unchanged
- SQLite and ClickHouse use the same derivation invalidation signal
- old sync responses remain decodable by the macOS client; missing `reportReady` defaults to ready

## Validation

- `node --test`: 312 passed, 0 failed
- Swift tests: 46 passed, 0 failed
- signed macOS release build completed and passed `codesign` validation
- `npm pack --dry-run --json`: 46 packaged files, including runtime identity
- `git diff --check` and changed JavaScript syntax checks passed
- regression coverage includes exactly-once replay, future-checkpoint refusal, ClickHouse epoch replacement, SQLite replacement, ordinary last-good visibility, invalidating-report suppression, runtime-ID matching, protected shutdown, and fail-closed legacy replacement
- local end-to-end install test replaced an older backend that remained alive after an update
- the invalidating ClickHouse replay kept `/api/summary`, `/api/report`, and `/api/timeline` unavailable until the corrected generation was published
- the corrected report removed the reproduced multi-fold token and cost inflation
- an immediate follow-up sync returned to incremental source processing while `/api/summary` remained HTTP 200

## Operational note

The first launch after this upgrade may perform one full replay and can take several minutes on a large history. It is automatic, preserves the previous committed generation for retry, and does not expose known-invalid totals. Subsequent launches resume incremental tail processing.
